### PR TITLE
allow lll to work with rank deficient Z basis

### DIFF
--- a/fmpz_lll/is_reduced.c
+++ b/fmpz_lll/is_reduced.c
@@ -2,6 +2,7 @@
     Copyright (C) 2009, 2010 William Hart
     Copyright (C) 2009, 2010 Andy Novocin
     Copyright (C) 2014 Abhinav Baid
+    Copyright (C) 2022 Daniel Schultz
 
     This file is part of FLINT.
 
@@ -16,13 +17,43 @@
 int
 fmpz_lll_is_reduced(const fmpz_mat_t B, const fmpz_lll_t fl, flint_bitcnt_t prec)
 {
-    if (fmpz_lll_is_reduced_d(B, fl))
-        return 1;
+    if (fl->rt == Z_BASIS)
+    {
+        /*
+            The is_reduced checkers below could only return 1 when B has full
+            row rank. Therefore, the definition of fmpz_lll_is_reduced needs to
+            include a stripping out of *initial* zero rows followed by a call
+            to one of these checkers.
+        */
+        int res;
+        fmpz_mat_t BB;
 
-    if (fmpz_lll_is_reduced_mpfr(B, fl, prec))
-        return 1;
+        _fmpz_mat_read_only_window_init_strip_initial_zero_rows(BB, B);
 
-    return (fl->rt == Z_BASIS) ?
-                fmpz_mat_is_reduced(B, fl->delta, fl->eta) :
-                fmpz_mat_is_reduced_gram(B, fl->delta, fl->eta);
+        if (fmpz_lll_is_reduced_d(BB, fl))
+        {
+            res = 1;
+        }
+        else if (fmpz_lll_is_reduced_mpfr(BB, fl, prec))
+        {
+            res = 1;
+        }
+        else
+        {
+            res = fmpz_mat_is_reduced(BB, fl->delta, fl->eta);
+        }
+
+        _fmpz_mat_read_only_window_clear(BB);
+        return res;
+    }
+    else
+    {
+        if (fmpz_lll_is_reduced_d(B, fl))
+            return 1;
+
+        if (fmpz_lll_is_reduced_mpfr(B, fl, prec))
+            return 1;
+
+        return fmpz_mat_is_reduced_gram(B, fl->delta, fl->eta);
+    }
 }

--- a/fmpz_lll/is_reduced_with_removal.c
+++ b/fmpz_lll/is_reduced_with_removal.c
@@ -20,13 +20,37 @@ fmpz_lll_is_reduced_with_removal(const fmpz_mat_t B, const fmpz_lll_t fl,
     if (gs_B == NULL)
         return fmpz_lll_is_reduced(B, fl, prec);
 
-    if (fmpz_lll_is_reduced_d_with_removal(B, fl, gs_B, newd))
-        return 1;
+    if (fl->rt == Z_BASIS)
+    {
+        int res;
+        fmpz_mat_t BB;
 
-    if (fmpz_lll_is_reduced_mpfr_with_removal(B, fl, gs_B, newd, prec))
-        return 1;
+        _fmpz_mat_read_only_window_init_strip_initial_zero_rows(BB, B);
 
-    return (fl->rt == Z_BASIS) ?
-        fmpz_mat_is_reduced_with_removal(B, fl->delta, fl->eta, gs_B, newd) :
-        fmpz_mat_is_reduced_gram_with_removal(B, fl->delta, fl->eta, gs_B, newd);
+        if (fmpz_lll_is_reduced_d_with_removal(BB, fl, gs_B, newd))
+        {
+            res = 1;
+        }
+        else if (fmpz_lll_is_reduced_mpfr_with_removal(BB, fl, gs_B, newd, prec))
+        {
+            res = 1;
+        }
+        else
+        {
+            res = fmpz_mat_is_reduced_with_removal(BB, fl->delta, fl->eta, gs_B, newd);
+        }
+
+        _fmpz_mat_read_only_window_clear(BB);
+        return res;
+    }
+    else
+    {
+        if (fmpz_lll_is_reduced_d_with_removal(B, fl, gs_B, newd))
+            return 1;
+
+        if (fmpz_lll_is_reduced_mpfr_with_removal(B, fl, gs_B, newd, prec))
+            return 1;
+
+        return fmpz_mat_is_reduced_gram_with_removal(B, fl->delta, fl->eta, gs_B, newd);
+    }
 }

--- a/fmpz_lll/test/t-lll.c
+++ b/fmpz_lll/test/t-lll.c
@@ -1,5 +1,6 @@
 /*
     Copyright (C) 2014 Abhinav Baid
+    Copyright (C) 2022 Daniel Schultz
 
     This file is part of FLINT.
 
@@ -29,6 +30,36 @@ main(void)
 
     flint_printf("lll....");
     fflush(stdout);
+
+    /* test rank deficient matrices */
+    {
+        fmpz_mat_init(mat, 3, 3);
+        fmpz_lll_context_init_default(fl);
+
+        fmpz_mat_zero(mat);
+        fmpz_lll(mat, NULL, fl);
+        if (!fmpz_mat_is_zero(mat))
+        {
+            flint_printf("FAIL: check zero matrix\n");
+            fflush(stdout);
+            flint_abort();
+        }
+
+        fmpz_mat_zero(mat);
+        fmpz_set_ui(fmpz_mat_entry(mat, 1, 0), 4);
+        fmpz_set_ui(fmpz_mat_entry(mat, 2, 0), 6);
+        fmpz_lll(mat, NULL, fl);
+        fmpz_abs(fmpz_mat_entry(mat, 2, 0), fmpz_mat_entry(mat, 2, 0));
+        fmpz_sub_ui(fmpz_mat_entry(mat, 2, 0), fmpz_mat_entry(mat, 2, 0), 2);
+        if (!fmpz_mat_is_zero(mat))
+        {
+            flint_printf("FAIL: check gcd(4,6)=2\n");
+            fflush(stdout);
+            flint_abort();
+        }
+
+        fmpz_mat_clear(mat);
+    }
 
     /* test using NTRU like matrices */
     for (i = 0; i < 1 * flint_test_multiplier(); i++)

--- a/fmpz_mat.h
+++ b/fmpz_mat.h
@@ -154,6 +154,13 @@ FLINT_DLL void fmpz_mat_concat_horizontal(fmpz_mat_t res,
 FLINT_DLL void fmpz_mat_concat_vertical(fmpz_mat_t res,
                            const fmpz_mat_t mat1,  const fmpz_mat_t mat2);
 
+FLINT_DLL void _fmpz_mat_read_only_window_init_strip_initial_zero_rows(
+                                             fmpz_mat_t A, const fmpz_mat_t B);
+
+FMPZ_MAT_INLINE void _fmpz_mat_read_only_window_clear(fmpz_mat_t A)
+{
+}
+
 /* Input and output  *********************************************************/
 
 FLINT_DLL int fmpz_mat_fprint(FILE * file, const fmpz_mat_t mat);

--- a/fmpz_mat/is_reduced_with_removal.c
+++ b/fmpz_mat/is_reduced_with_removal.c
@@ -17,6 +17,7 @@ int
 fmpz_mat_is_reduced_with_removal(const fmpz_mat_t A, double delta, double eta,
                                  const fmpz_t gs_B, int newd)
 {
+    int res;
     slong i, j, k, d = A->r, n = A->c;
     fmpq_mat_t Aq, Bq, mu;
     mpq_t deltax, etax;
@@ -56,14 +57,8 @@ fmpz_mat_is_reduced_with_removal(const fmpz_mat_t A, double delta, double eta,
     _fmpq_vec_dot(fmpq_mat_entry(mu, 0, 0), Bq->rows[0], Bq->rows[0], n);
     if (newd == 0 && fmpq_cmp(fmpq_mat_entry(mu, 0, 0), gs_Bq) < 0)
     {
-        fmpq_mat_clear(Aq);
-        fmpq_mat_clear(Bq);
-        fmpq_mat_clear(mu);
-        fmpq_clear(deltaq);
-        fmpq_clear(etaq);
-        fmpq_clear(tmp);
-        fmpq_clear(gs_Bq);
-        return 0;
+        res = 0;
+        goto cleanup;
     }
 
     for (i = 1; i < d; i++)
@@ -77,61 +72,53 @@ fmpz_mat_is_reduced_with_removal(const fmpz_mat_t A, double delta, double eta,
         {
             _fmpq_vec_dot(tmp, Aq->rows[i], Bq->rows[j], n);
 
+            /* avoid division by zero */
+            if (fmpq_is_zero(fmpq_mat_entry(mu, j, j)))
+            {
+                res = 0;
+                goto cleanup;
+            }
+
             fmpq_div(fmpq_mat_entry(mu, i, j), tmp, fmpq_mat_entry(mu, j, j));
 
             for (k = 0; k < n; k++)
             {
                 fmpq_submul(fmpq_mat_entry(Bq, i, k),
-                            fmpq_mat_entry(mu, i, j), fmpq_mat_entry(Bq, j,
-                                                                     k));
+                            fmpq_mat_entry(mu, i, j), fmpq_mat_entry(Bq, j, k));
             }
             if (i < newd)
             {
                 fmpq_abs(tmp, fmpq_mat_entry(mu, i, j));
                 if (fmpq_cmp(tmp, etaq) > 0)    /* check size reduction */
                 {
-                    fmpq_mat_clear(Aq);
-                    fmpq_mat_clear(Bq);
-                    fmpq_mat_clear(mu);
-                    fmpq_clear(deltaq);
-                    fmpq_clear(etaq);
-                    fmpq_clear(tmp);
-                    fmpq_clear(gs_Bq);
-                    return 0;
+                    res = 0;
+                    goto cleanup;
                 }
             }
         }
         _fmpq_vec_dot(fmpq_mat_entry(mu, i, i), Bq->rows[i], Bq->rows[i], n);
         if (i >= newd && fmpq_cmp(fmpq_mat_entry(mu, i, i), gs_Bq) < 0) /* check removals */
         {
-            fmpq_mat_clear(Aq);
-            fmpq_mat_clear(Bq);
-            fmpq_mat_clear(mu);
-            fmpq_clear(deltaq);
-            fmpq_clear(etaq);
-            fmpq_clear(tmp);
-            fmpq_clear(gs_Bq);
-            return 0;
+            res = 0;
+            goto cleanup;
         }
         if (i < newd)
         {
             fmpq_set(tmp, deltaq);
             fmpq_submul(tmp, fmpq_mat_entry(mu, i, i - 1),
-                        fmpq_mat_entry(mu, i, i - 1));
+                             fmpq_mat_entry(mu, i, i - 1));
             fmpq_mul(tmp, tmp, fmpq_mat_entry(mu, i - 1, i - 1));
             if (fmpq_cmp(tmp, fmpq_mat_entry(mu, i, i)) > 0)    /* check Lovasz condition */
             {
-                fmpq_mat_clear(Aq);
-                fmpq_mat_clear(Bq);
-                fmpq_mat_clear(mu);
-                fmpq_clear(deltaq);
-                fmpq_clear(etaq);
-                fmpq_clear(tmp);
-                fmpq_clear(gs_Bq);
-                return 0;
+                res = 0;
+                goto cleanup;
             }
         }
     }
+
+    res = 1;
+
+cleanup:
 
     fmpq_mat_clear(Aq);
     fmpq_mat_clear(Bq);
@@ -140,5 +127,5 @@ fmpz_mat_is_reduced_with_removal(const fmpz_mat_t A, double delta, double eta,
     fmpq_clear(etaq);
     fmpq_clear(tmp);
     fmpq_clear(gs_Bq);
-    return 1;
+    return res;
 }

--- a/fmpz_mat/read_only_window.c
+++ b/fmpz_mat/read_only_window.c
@@ -1,0 +1,32 @@
+/*
+    Copyright (C) 2022 Daniel Schultz
+
+    This file is part of FLINT.
+
+    FLINT is free software: you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License (LGPL) as published
+    by the Free Software Foundation; either version 2.1 of the License, or
+    (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+*/
+
+#include "fmpz_mat.h"
+
+void _fmpz_mat_read_only_window_init_strip_initial_zero_rows(
+    fmpz_mat_t A,
+    const fmpz_mat_t B)
+{
+    slong r = B->r;
+    slong c = B->c;
+    slong i;
+
+    for (i = 0; i < r; i++)
+    {
+        if (!_fmpz_vec_is_zero(B->rows[i], c))
+            break;
+    }
+
+    A->entries = NULL;
+    A->rows = B->rows + i;
+    A->r = r - i;
+    A->c = c;
+}


### PR DESCRIPTION
There is a severe oversight in the design of the lll module. If it was ever working with matrices of non-full row rank, it was only working by accident. Here I tried to salvage it for the Z_BASIS case, and I didn't update the docs for `fmpz_mat_is_reduced` because I do not know what this function is supposed to do (it was dividing by zero before). 