### PR TITLE
fixing indices in invert_cols function for various types of matrices

### DIFF
--- a/fmpq_mat.h
+++ b/fmpq_mat.h
@@ -298,11 +298,11 @@ void fmpq_mat_invert_cols(fmpq_mat_t mat, slong * perm)
 
         if (perm)
         {
-            for (i =0; i < k; i++)
+            for (i = 0; i < k; i++)
             {
                 t = perm[i];
-                perm[i] = perm[c - i];
-                perm[c - i] = t;
+                perm[i] = perm[c - i - 1];
+                perm[c - i - 1] = t;
             }
         }
 

--- a/fmpz_mat.h
+++ b/fmpz_mat.h
@@ -379,11 +379,11 @@ void fmpz_mat_invert_cols(fmpz_mat_t mat, slong * perm)
 
         if (perm)
         {
-            for (i =0; i < k; i++)
+            for (i = 0; i < k; i++)
             {
                 t = perm[i];
-                perm[i] = perm[c - i];
-                perm[c - i] = t;
+                perm[i] = perm[c - i - 1];
+                perm[c - i - 1] = t;
             }
         }
 

--- a/fq_mat_templates.h
+++ b/fq_mat_templates.h
@@ -174,11 +174,11 @@ TEMPLATE(T, mat_invert_cols)(TEMPLATE(T, mat_t) mat, slong * perm, const TEMPLAT
 
         if (perm)
         {
-            for (i =0; i < k; i++)
+            for (i = 0; i < k; i++)
             {
                 t = perm[i];
-                perm[i] = perm[c - i];
-                perm[c - i] = t;
+                perm[i] = perm[c - i - 1];
+                perm[c - i - 1] = t;
             }
         }
 

--- a/nmod_mat.h
+++ b/nmod_mat.h
@@ -330,11 +330,11 @@ void nmod_mat_invert_cols(nmod_mat_t mat, slong * perm)
 
         if (perm)
         {
-            for (i =0; i < k; i++)
+            for (i = 0; i < k; i++)
             {
                 t = perm[i];
-                perm[i] = perm[c - i];
-                perm[c - i] = t;
+                perm[i] = perm[c - i - 1];
+                perm[c - i - 1] = t;
             }
         }
 


### PR DESCRIPTION
The functions `invert_cols` for matrices (`fmpz`, `fmpq`, `nmod`, fq template) have an issue in how they process the permutation given as argument. The length of this permutation is supposedly the same as the number of columns, but these functions consider indices up to `mat->c`. It seems this is simply a minor mistake, solved by replacing `mat->c` by `mat->c - 1`. This is what the commit in this PR does.

This minor bug could not be captured in the test files since there the functions were called with `perm = NULL`.