### PR TITLE
missing inlines.c for fmpz_mod_mpoly and BUG fixes

### DIFF
--- a/fmpz_mod_mpoly/equal_fmpz.c
+++ b/fmpz_mod_mpoly/equal_fmpz.c
@@ -60,7 +60,7 @@ int fmpz_mod_mpoly_equal_si(
         ulong uc;
 
         if (c == 0)
-            return 0;
+            return 1;
 
         if (!fmpz_abs_fits_ui(fmpz_mod_mpoly_ctx_modulus(ctx)))
             return 0;

--- a/fmpz_mod_mpoly/inlines.c
+++ b/fmpz_mod_mpoly/inlines.c
@@ -1,0 +1,22 @@
+/*
+    Copyright (C) 2022 Daniel Schultz
+
+    This file is part of FLINT.
+
+    FLINT is free software: you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License (LGPL) as published
+    by the Free Software Foundation; either version 2.1 of the License, or
+    (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+*/
+
+#define FMPZ_MOD_MPOLY_INLINES_C
+
+#define ulong ulongxx /* interferes with system includes */
+#include <stdlib.h>
+#include <stdio.h>
+#undef ulong
+#include <gmp.h>
+#include "flint.h"
+#include "ulong_extras.h"
+#include "fmpz_mod_mpoly.h"
+

--- a/fmpz_mod_mpoly/is_gen.c
+++ b/fmpz_mod_mpoly/is_gen.c
@@ -1,0 +1,24 @@
+/*
+    Copyright (C) 2022 Daniel Schultz
+
+    This file is part of FLINT.
+
+    FLINT is free software: you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License (LGPL) as published
+    by the Free Software Foundation; either version 2.1 of the License, or
+    (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+*/
+
+#include "fmpz_mod_mpoly.h"
+
+int fmpz_mod_mpoly_is_gen(const fmpz_mod_mpoly_t A,
+                                     slong var, const fmpz_mod_mpoly_ctx_t ctx)
+{
+    if (A->length != 1)
+        return fmpz_is_one(fmpz_mod_ctx_modulus(ctx->ffinfo));
+
+    if (!fmpz_is_one(A->coeffs + 0))
+        return 0;
+
+    return mpoly_is_gen(A->exps, var, A->bits, ctx->minfo);
+}

--- a/fmpz_mod_mpoly/test/t-gen.c
+++ b/fmpz_mod_mpoly/test/t-gen.c
@@ -1,0 +1,93 @@
+/*
+    Copyright (C) 2022 Daniel Schultz
+
+    This file is part of FLINT.
+
+    FLINT is free software: you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License (LGPL) as published
+    by the Free Software Foundation; either version 2.1 of the License, or
+    (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+*/
+
+#include <stdio.h>
+#include <stdlib.h>
+#include "fmpz_mod_mpoly.h"
+
+int
+main(void)
+{
+    int i, result;
+    FLINT_TEST_INIT(state);
+
+    flint_printf("gen/is_gen....");
+    fflush(stdout);
+
+    for (i = 0; i < 100 * flint_test_multiplier(); i++)
+    {
+        fmpz_mod_mpoly_ctx_t ctx;
+        fmpz_mod_mpoly_t f1, f2;
+        slong nvars, len, exp_bits, k1, k2;
+
+        fmpz_mod_mpoly_ctx_init_rand_bits(ctx, state, 20, 200);
+        nvars = fmpz_mod_mpoly_ctx_nvars(ctx);
+        if (nvars < 1)
+        {
+            fmpz_mod_mpoly_ctx_clear(ctx);
+            continue;
+        }
+
+        fmpz_mod_mpoly_init(f1, ctx);
+        fmpz_mod_mpoly_init(f2, ctx);
+
+        len = n_randint(state, 100);
+        exp_bits = n_randint(state, 200) + 1;
+
+        fmpz_mod_mpoly_randtest_bits(f1, state, len, exp_bits, ctx);
+        fmpz_mod_mpoly_randtest_bits(f2, state, len, exp_bits, ctx);
+
+        k1 = n_randint(state, nvars);
+        k2 = n_randint(state, nvars);
+        fmpz_mod_mpoly_gen(f1, k1, ctx);
+        fmpz_mod_mpoly_assert_canonical(f1, ctx);
+        fmpz_mod_mpoly_gen(f2, k2, ctx);
+        fmpz_mod_mpoly_assert_canonical(f2, ctx);
+
+        result = 1;
+        result = result && fmpz_mod_mpoly_is_gen(f1, k1, ctx);
+        result = result && fmpz_mod_mpoly_is_gen(f1, -WORD(1), ctx);
+        result = result && fmpz_mod_mpoly_is_gen(f2, k2, ctx);
+        result = result && fmpz_mod_mpoly_is_gen(f2, -WORD(1), ctx);
+
+        if (!result)
+        {
+            printf("FAIL\n");
+            flint_printf("Check one generator\ni = %wd\n", i);
+            fflush(stdout);
+            flint_abort();
+        }
+
+        fmpz_mod_mpoly_mul(f1, f1, f2, ctx);
+        result = 0;
+        result += !!fmpz_mod_mpoly_is_gen(f1, k1, ctx);
+        result += !!fmpz_mod_mpoly_is_gen(f1, k2, ctx);
+        result += !!fmpz_mod_mpoly_is_gen(f1, -WORD(1), ctx);
+
+        if (result != (fmpz_is_one(fmpz_mod_mpoly_ctx_modulus(ctx)) ? 3 : 0))
+        {
+            printf("FAIL\n");
+            flint_printf("Check product of two generators\ni = %wd\n", i);
+            fflush(stdout);
+            flint_abort();
+        }
+
+        fmpz_mod_mpoly_clear(f1, ctx);
+        fmpz_mod_mpoly_clear(f2, ctx);
+        fmpz_mod_mpoly_ctx_clear(ctx);
+    }
+
+    FLINT_TEST_CLEANUP(state);
+    
+    flint_printf("PASS\n");
+    return 0;
+}
+

--- a/fmpz_mod_mpoly_factor/inlines.c
+++ b/fmpz_mod_mpoly_factor/inlines.c
@@ -1,0 +1,22 @@
+/*
+    Copyright (C) 2022 Daniel Schultz
+
+    This file is part of FLINT.
+
+    FLINT is free software: you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License (LGPL) as published
+    by the Free Software Foundation; either version 2.1 of the License, or
+    (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+*/
+
+#define FMPZ_MOD_MPOLY_FACTOR_INLINES_C
+
+#define ulong ulongxx /* interferes with system includes */
+#include <stdlib.h>
+#include <stdio.h>
+#undef ulong
+#include <gmp.h>
+#include "flint.h"
+#include "ulong_extras.h"
+#include "fmpz_mod_mpoly_factor.h"
+


### PR DESCRIPTION
Found when adding fmpz_mod_mpoly to nemo:

- missing is_gen function
- bug fix in equal_si
- missing includes.c

this whole pr should make it into 2.9.1