### PR TITLE
fix calling sub_ddmmss with slong arguments

### DIFF
--- a/fmpq/cmp.c
+++ b/fmpq/cmp.c
@@ -20,15 +20,15 @@ _fmpq_cmp(const fmpz_t p, const fmpz_t q, const fmpz_t r, const fmpz_t s)
 
     if (!COEFF_IS_MPZ(*p) && !COEFF_IS_MPZ(*q) && !COEFF_IS_MPZ(*r) && !COEFF_IS_MPZ(*s))
     {
-        slong a1, a0, b1, b0;
+        ulong a1, a0, b1, b0;
 
         smul_ppmm(a1, a0, *p, *s);
         smul_ppmm(b1, b0, *q, *r);
         sub_ddmmss(a1, a0, a1, a0, b1, b0);
 
-        if (a1 < 0)
+        if ((slong) a1 < 0)
             return -1;
-        if (a1 > 0)
+        if ((slong) a1 > 0)
             return 1;
         return a0 != 0;
     }

--- a/fmpq/cmp_si.c
+++ b/fmpq/cmp_si.c
@@ -25,16 +25,16 @@ _fmpq_cmp_si(const fmpz_t p, const fmpz_t q, slong c)
 
     if (!COEFF_IS_MPZ(*p) && !COEFF_IS_MPZ(*q))
     {
-        slong a1, a0, b1, b0;
+        ulong a1, a0, b1, b0;
 
         a0 = *p;
         a1 = FLINT_SIGN_EXT(a0);
         smul_ppmm(b1, b0, *q, c);
         sub_ddmmss(a1, a0, a1, a0, b1, b0);
 
-        if (a1 < 0)
+        if ((slong) a1 < 0)
             return -1;
-        if (a1 > 0)
+        if ((slong) a1 > 0)
             return 1;
         return a0 != 0;
     }

--- a/fmpq/cmp_ui.c
+++ b/fmpq/cmp_ui.c
@@ -24,16 +24,16 @@ _fmpq_cmp_ui(const fmpz_t p, const fmpz_t q, ulong c)
 
     if (!COEFF_IS_MPZ(*p) && !COEFF_IS_MPZ(*q) && c <= WORD_MAX)
     {
-        slong a1, a0, b1, b0;
+        ulong a1, a0, b1, b0;
 
         a0 = *p;
         a1 = FLINT_SIGN_EXT(a0);
         smul_ppmm(b1, b0, *q, c);
         sub_ddmmss(a1, a0, a1, a0, b1, b0);
 
-        if (a1 < 0)
+        if ((slong) a1 < 0)
             return -1;
-        if (a1 > 0)
+        if ((slong) a1 > 0)
             return 1;
         return a0 != 0;
     }

--- a/longlong.h
+++ b/longlong.h
@@ -218,7 +218,7 @@
   do {                                          \
     mp_limb_t __x;                              \
     __x = (al) - (bl);                          \
-    if ((al) < (bl))                            \
+    if ((mp_limb_t) (al) < (mp_limb_t) (bl))    \
       (sh) = (ah) - (bh) - 1;                   \
     else                                        \
       (sh) = (ah) - (bh);                       \
@@ -451,7 +451,7 @@
   do {									          \
     mp_limb_t __x;								 \
     __x = (al) - (bl);							 \
-    (sh) = (ah) - (bh) - ((al) < (bl));    \
+    (sh) = (ah) - (bh) - ((mp_limb_t) (al) < (mp_limb_t) (bl));    \
     (sl) = __x;								    \
   } while (0)
 

--- a/test/t-add_ssaaaa.c
+++ b/test/t-add_ssaaaa.c
@@ -32,8 +32,11 @@ int main(void)
       al1 = n_randtest(state);
       ah2 = n_randtest(state);
       al2 = n_randtest(state);
-      
-      add_ssaaaa(sh1, sl1, ah1, al1, ah2, al2);
+
+      if (n_randint(state, 10) == 0)
+         add_ssaaaa(sh1, sl1, (slong) ah1, (slong) al1, (slong) ah2, (slong) al2);
+      else
+         add_ssaaaa(sh1, sl1, ah1, al1, ah2, al2);
       
       sl2 = al1 + al2;
       sh2 = (sl1 < al1);

--- a/test/t-sub_ddmmss.c
+++ b/test/t-sub_ddmmss.c
@@ -32,8 +32,11 @@ int main(void)
       ml = n_randtest(state);
       sh = n_randtest(state);
       sl = n_randtest(state);
-      
-      sub_ddmmss(dh1, dl1, mh, ml, sh, sl);
+
+      if (n_randint(state, 10) == 0)
+          sub_ddmmss(dh1, dl1, (slong) mh, (slong) ml, (slong) sh, (slong) sl);
+      else
+          sub_ddmmss(dh1, dl1, mh, ml, sh, sl);
       
       dl2 = ml - sl;
       dh2 = -(sl > ml);


### PR DESCRIPTION
Non-asm implementations of `sub_ddmmss` did not work correctly when passed `slong` instead of `ulong` arguments. This meant that the new `fmpq_cmp` code was broken, causing test failures for Arb on mingw64.

Besides fixing `fmpq_cmp`, this PR adds some casts and improves the test code for `sub_ddmmss` to try to catch future instances of the same problem (there may already be other cases in FLINT where `sub_ddmmss` is called with signed inputs, so it doesn't hurt to write this code more defensively).