### PR TITLE
Eliminate temp filename based race condition from qsieve_factor

### DIFF
--- a/qsieve/factor.c
+++ b/qsieve/factor.c
@@ -25,7 +25,7 @@
 #if (!defined (__WIN32) || defined(__CYGWIN__)) && !defined(_MSC_VER)
 #include <unistd.h>
 #endif
-#if defined (__WIN32) && !defined(__CYGWIN__)
+#if (defined(__WIN32) && !defined(__CYGWIN__)) || defined(_MSC_VER)
 #include <windows.h>
 #endif
 
@@ -55,7 +55,9 @@ void qsieve_factor(fmpz_factor_t factors, const fmpz_t n)
     fmpz_t temp, temp2, X, Y;
     slong num_facs;
     fmpz * facs;
-    int nchars;
+#if (defined(__WIN32) && !defined(__CYGWIN__)) || defined(_MSC_VER)
+    char temp_path[MAX_PATH];
+#endif
 
     if (fmpz_sgn(n) < 0)
     {
@@ -202,15 +204,22 @@ void qsieve_factor(fmpz_factor_t factors, const fmpz_t n)
     pthread_mutex_init(&qs_inf->mutex, NULL);
 #endif
     
-#if defined (__WIN32) && !defined(__CYGWIN__)
-    srand((int) GetCurrentProcessId());
-#else
-    srand((int) getpid());
-#endif
-    nchars = sprintf(qs_inf->fname, "%d", (int) rand());
-    strcat(qs_inf->fname + nchars, "siqs.dat");
-
+#if (defined(__WIN32) && !defined(__CYGWIN__)) || defined(_MSC_VER)
+    if (GetTempPathA(MAX_PATH, temp_path) == 0)
+    {
+        flint_printf("Exception (qsieve_factor). GetTempPathA() failed.\n");
+        flint_abort();
+    }
+    if (GetTempFileNameA(temp_path, "siqs", /*uUnique*/ TRUE, qs_inf->fname) == 0)
+    {
+        flint_printf("Exception (qsieve_factor). GetTempFileNameA() failed.\n");
+        flint_abort();
+    }
     qs_inf->siqs = fopen(qs_inf->fname, "w");
+#else
+    strcpy(qs_inf->fname, "/tmp/siqsXXXXXX"); /* must be shorter than fname_alloc_size in init.c */
+    qs_inf->siqs = fdopen(mkstemp(qs_inf->fname), "w");
+#endif
 
     for (j = qs_inf->small_primes; j < qs_inf->num_primes; j++)
     {

--- a/qsieve/init.c
+++ b/qsieve/init.c
@@ -11,12 +11,21 @@
 */
 
 #include "qsieve.h"
+#if (defined(__WIN32) && !defined(__CYGWIN__)) || defined(_MSC_VER)
+#include <windows.h>
+#endif
 
 void qsieve_init(qs_t qs_inf, const fmpz_t n)
 {
+    size_t fname_alloc_size;
     slong i;
 
-    qs_inf->fname = (char *) flint_malloc(20); /* space for filename */
+#if (defined(__WIN32) && !defined(__CYGWIN__)) || defined(_MSC_VER)
+    fname_alloc_size = MAX_PATH;
+#else
+    fname_alloc_size = 20;
+#endif
+    qs_inf->fname = (char *) flint_malloc(fname_alloc_size); /* space for filename */
 
     /* store n in struct */
     fmpz_init_set(qs_inf->n, n);


### PR DESCRIPTION
The `qsieve_factor()` function uses a temporary file (with name `qs_inf->fname`) for internal operation.

There were a few issues with this file:

* The name is supposed to be random, yet a prior `srand()` call ensures that different threads will be using an identical "random" name. The ensuing race condition leads to crashes.
* The pre-existence of another file with the same name is not verified.
* The file is created in the current directory instead of some temporary space.

Fix: resorting to standard temporary file approaches (`mkstemp` on POSIX and `GetTempFileName` on Windows).