### PR TITLE
Minor fixes in documentation

### DIFF
--- a/doc/source/fq_default_mat.rst
+++ b/doc/source/fq_default_mat.rst
@@ -191,7 +191,17 @@ Random matrix generation
     Sets the elements of ``mat`` to random elements of
     `\mathbf{F}_{q}`, given by ``ctx``.
 
-.. function:: void fq_default_mat_randrank(fq_default_mat_t mat, slong rank, flint_rand_t state, const fq_default_ctx_t ctx)
+.. function:: int fq_default_mat_randpermdiag(fq_mat_t mat, flint_rand_t state, fq_struct * diag, slong n, const fq_ctx_t ctx)
+
+    Sets ``mat`` to a random permutation of the diagonal matrix
+    with `n` leading entries given by the vector ``diag``. It is
+    assumed that the main diagonal of ``mat`` has room for at
+    least `n` entries.
+
+    Returns `0` or `1`, depending on whether the permutation is even
+    or odd respectively.
+
+.. function:: void fq_default_mat_randrank(fq_default_mat_t mat, flint_rand_t state, slong rank, const fq_default_ctx_t ctx)
 
     Sets ``mat`` to a random sparse matrix with the given rank,
     having exactly as many non-zero elements as the rank, with the

--- a/doc/source/fq_mat.rst
+++ b/doc/source/fq_mat.rst
@@ -188,7 +188,7 @@ Random matrix generation
     Sets the elements of ``mat`` to random elements of
     `\mathbf{F}_{q}`, given by ``ctx``.
 
-.. function:: int fq_mat_randpermdiag(fq_mat_t mat, fq_struct * diag, slong n, flint_rand_t state, const fq_ctx_t ctx)
+.. function:: int fq_mat_randpermdiag(fq_mat_t mat, flint_rand_t state, fq_struct * diag, slong n, const fq_ctx_t ctx)
 
     Sets ``mat`` to a random permutation of the diagonal matrix
     with `n` leading entries given by the vector ``diag``. It is
@@ -198,7 +198,7 @@ Random matrix generation
     Returns `0` or `1`, depending on whether the permutation is even
     or odd respectively.
 
-.. function:: void fq_mat_randrank(fq_mat_t mat, slong rank, flint_rand_t state, const fq_ctx_t ctx)
+.. function:: void fq_mat_randrank(fq_mat_t mat, flint_rand_t state, slong rank, const fq_ctx_t ctx)
 
     Sets ``mat`` to a random sparse matrix with the given rank,
     having exactly as many non-zero elements as the rank, with the

--- a/doc/source/fq_nmod_mat.rst
+++ b/doc/source/fq_nmod_mat.rst
@@ -187,7 +187,7 @@ Random matrix generation
     Sets the elements of ``mat`` to random elements of
     `\mathbf{F}_{q}`, given by ``ctx``.
 
-.. function:: int fq_nmod_mat_randpermdiag(fq_nmod_mat_t mat, fq_nmod_struct * diag, slong n, flint_rand_t state, const fq_nmod_ctx_t ctx)
+.. function:: int fq_nmod_mat_randpermdiag(fq_nmod_mat_t mat, flint_rand_t state, fq_nmod_struct * diag, slong n, const fq_nmod_ctx_t ctx)
 
     Sets ``mat`` to a random permutation of the diagonal matrix
     with `n` leading entries given by the vector ``diag``. It is
@@ -197,7 +197,7 @@ Random matrix generation
     Returns `0` or `1`, depending on whether the permutation is even
     or odd respectively.
 
-.. function:: void fq_nmod_mat_randrank(fq_nmod_mat_t mat, slong rank, flint_rand_t state, const fq_nmod_ctx_t ctx)
+.. function:: void fq_nmod_mat_randrank(fq_nmod_mat_t mat, flint_rand_t state, slong rank, const fq_nmod_ctx_t ctx)
 
     Sets ``mat`` to a random sparse matrix with the given rank,
     having exactly as many non-zero elements as the rank, with the

--- a/doc/source/fq_zech_mat.rst
+++ b/doc/source/fq_zech_mat.rst
@@ -166,7 +166,7 @@ Random matrix generation
     Sets the elements of ``mat`` to random elements of
     `\mathbf{F}_{q}`, given by ``ctx``.
 
-.. function:: int fq_zech_mat_randpermdiag(fq_zech_mat_t mat, fq_zech_struct * diag, slong n, flint_rand_t state, const fq_zech_ctx_t ctx)
+.. function:: int fq_zech_mat_randpermdiag(fq_zech_mat_t mat, flint_rand_t state, fq_zech_struct * diag, slong n, const fq_zech_ctx_t ctx)
 
     Sets ``mat`` to a random permutation of the diagonal matrix
     with `n` leading entries given by the vector ``diag``. It is
@@ -176,7 +176,7 @@ Random matrix generation
     Returns `0` or `1`, depending on whether the permutation is even
     or odd respectively.
 
-.. function:: void fq_zech_mat_randrank(fq_zech_mat_t mat, slong rank, flint_rand_t state, const fq_zech_ctx_t ctx)
+.. function:: void fq_zech_mat_randrank(fq_zech_mat_t mat, flint_rand_t state, slong rank, const fq_zech_ctx_t ctx)
 
     Sets ``mat`` to a random sparse matrix with the given rank,
     having exactly as many non-zero elements as the rank, with the

--- a/doc/source/nmod_mat.rst
+++ b/doc/source/nmod_mat.rst
@@ -154,7 +154,7 @@ Random matrix generation
     Sets the element to random numbers likely to be close to the modulus
     of the matrix. This is used to test potential overflow-related bugs.
 
-.. function:: int nmod_mat_randpermdiag(nmod_mat_t mat, mp_limb_t * diag, slong n, flint_rand_t state)
+.. function:: int nmod_mat_randpermdiag(nmod_mat_t mat, flint_rand_t state, mp_srcptr * diag, slong n)
 
     Sets ``mat`` to a random permutation of the diagonal matrix 
     with `n` leading entries given by the vector ``diag``. It is 
@@ -164,7 +164,7 @@ Random matrix generation
     Returns `0` or `1`, depending on whether the permutation is even 
     or odd respectively.
 
-.. function:: void nmod_mat_randrank(nmod_mat_t mat, slong rank, flint_rand_t state)
+.. function:: void nmod_mat_randrank(nmod_mat_t mat, flint_rand_t state, slong rank)
 
     Sets ``mat`` to a random sparse matrix with the given rank, 
     having exactly as many non-zero elements as the rank, with the 


### PR DESCRIPTION
In the documentation, this corrects the order of arguments for functions filling `nmod` and `fq` matrices "randomly". Specifically, `randrank` and `randpermdiag` were those with orders of arguments that were inconsistent with the code.

This also adds the documentation for `fq_default_mat_randpermdiag` which was missing.