### PR TITLE
Adding row permutation for ``nmod_mat`` matrices

### DIFF
--- a/doc/source/nmod_mat.rst
+++ b/doc/source/nmod_mat.rst
@@ -243,8 +243,8 @@ Transposition and permutations
 
 .. function:: void nmod_mat_permute_rows(nmod_mat_t mat, const slong * perm_act, slong * perm_store)
 
-    Permutes rows of the matrix `mat` according to permutation `perm_act` and,
-    if ``perm_store`` is not ``NULL``, apply the same permutation to it.
+    Permutes rows of the matrix ``mat`` according to permutation ``perm_act``
+    and, if ``perm_store`` is not ``NULL``, apply the same permutation to it.
 
 
 Addition and subtraction

--- a/doc/source/nmod_mat.rst
+++ b/doc/source/nmod_mat.rst
@@ -210,7 +210,7 @@ Comparison
     Returns a non-zero value if row `i` of ``mat`` is zero.
 
 
-Transpose
+Transposition and permutations
 --------------------------------------------------------------------------------
 
 
@@ -240,6 +240,12 @@ Transpose
     Swaps columns ``i`` and ``c - i`` of ``mat`` for ``0 <= i < c/2``, where
     ``c`` is the number of columns of ``mat``. If ``perm`` is non-``NULL``, the
     permutation of the columns will also be applied to ``perm``.
+
+.. function:: void nmod_mat_permute_rows(nmod_mat_t mat, const slong * perm_act, slong * perm_store)
+
+    Permutes rows of the matrix `mat` according to permutation `perm_act` and,
+    if ``perm_store`` is not ``NULL``, apply the same permutation to it.
+
 
 Addition and subtraction
 --------------------------------------------------------------------------------

--- a/nmod_mat.h
+++ b/nmod_mat.h
@@ -350,8 +350,6 @@ void nmod_mat_invert_cols(nmod_mat_t mat, slong * perm)
     }
 }
 
-FLINT_DLL void nmod_mat_apply_permutation(nmod_mat_t A, slong * P, slong n);
-
 /* Triangular solving */
 
 FLINT_DLL void nmod_mat_solve_tril(nmod_mat_t X, const nmod_mat_t L, const nmod_mat_t B, int unit);

--- a/nmod_mat.h
+++ b/nmod_mat.h
@@ -28,6 +28,7 @@
 #define ulong mp_limb_t
 
 #include "flint.h"
+#include "perm.h"
 #include "longlong.h"
 #include "ulong_extras.h"
 #include "nmod_vec.h"
@@ -349,6 +350,33 @@ void nmod_mat_invert_cols(nmod_mat_t mat, slong * perm)
         }
     }
 }
+
+/** Permute rows of a matrix `mat` according to `perm_act`, and propagate the
+ * action on `perm_store`.
+ * That is, performs for each appropriate index `i`, the operations
+ * `perm_store[i] <- perm_store[perm_act[i]]`
+ * `rows[i] <- rows[perm_act[i]]` */
+NMOD_MAT_INLINE void
+nmod_mat_permute_rows(nmod_mat_t mat,
+                      const slong * perm_act,
+                      slong * perm_store)
+{
+		slong i;
+    mp_limb_t ** mat_tmp = flint_malloc(mat->r * sizeof(mp_limb_t *));
+
+    /* perm_store[i] <- perm_store[perm_act[i]] */
+    if (perm_store)
+        _perm_compose(perm_store, perm_store, perm_act, mat->r);
+
+    /* rows[i] <- rows[perm_act[i]]  */
+    for (i = 0; i < mat->r; i++)
+        mat_tmp[i] = mat->rows[perm_act[i]];
+    for (i = 0; i < mat->r; i++)
+        mat->rows[i] = mat_tmp[i];
+
+    flint_free(mat_tmp);
+}
+
 
 /* Triangular solving */
 

--- a/nmod_mat/test/t-invert_rows_cols.c
+++ b/nmod_mat/test/t-invert_rows_cols.c
@@ -39,6 +39,8 @@ main(void)
         nmod_mat_init(A, m, n, mod);
         nmod_mat_init(B, m, n, mod);
 
+        nmod_mat_randtest(A, state);
+
         nmod_mat_set(B, A);
 
         nmod_mat_invert_rows(A, NULL);

--- a/nmod_mat/test/t-permute_rows.c
+++ b/nmod_mat/test/t-permute_rows.c
@@ -1,0 +1,97 @@
+/*
+    Copyright (C) 2023 Vincent Neiger
+
+    This file is part of FLINT.
+
+    FLINT is free software: you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License (LGPL) as published
+    by the Free Software Foundation; either version 2.1 of the License, or
+    (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+*/
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <limits.h>
+#include <gmp.h>
+#include "flint.h"
+#include "nmod_mat.h"
+#include "ulong_extras.h"
+
+int
+main(void)
+{
+    slong m, n, mod, rep;
+    FLINT_TEST_INIT(state);
+
+
+    flint_printf("permute_rows....");
+    fflush(stdout);
+
+    for (rep = 0; rep < 1000 * flint_test_multiplier(); rep++)
+    {
+        nmod_mat_t mat, matt;
+        slong * perm_act;
+				slong * perm_store;
+				slong * perm;
+        slong i, j;
+
+        m = n_randint(state, 10);
+        n = n_randint(state, 10);
+        mod = n_randtest_not_zero(state);
+
+        nmod_mat_init(mat, m, n, mod);
+        nmod_mat_randtest(mat, state);
+
+				perm_act = _perm_init(m);
+        _perm_randtest(perm_act, m, state);
+				perm_store = _perm_init(m);
+        _perm_randtest(perm_store, m, state);
+        /* perm = copy of perm_store for testing purpose */
+				perm = _perm_init(m);
+        for (i = 0; i < m; i++)
+            perm[i] = perm_store[i];
+
+        nmod_mat_init_set(matt, mat);
+        nmod_mat_permute_rows(matt, perm_act, perm_store);
+
+        for (i = 0; i < m; i++)
+        {
+            if (perm_store && perm_store[i] != perm[perm_act[i]])
+            {
+                flint_printf("FAIL: auxiliary permutation not correctly permuted by perm_act\n");
+                flint_printf("input permutation:\n");
+                _perm_print(perm, m);
+                flint_printf("acting permutation:\n");
+                _perm_print(perm_act, m);
+                flint_printf("resulting permutation:\n");
+                _perm_print(perm_store, m);
+                fflush(stdout);
+                flint_abort();
+            }
+            for (j = 0; j < n; j++)
+            {
+                if (nmod_mat_entry(matt, i, j) != nmod_mat_entry(mat, perm_act[i], j))
+                {
+                    flint_printf("FAIL: matrix not correctly row-permuted by perm_act\n");
+                    flint_printf("first matrix:\n");
+                    nmod_mat_print_pretty(mat);
+                    flint_printf("second matrix:\n");
+                    nmod_mat_print_pretty(matt);
+                    fflush(stdout);
+                    flint_abort();
+                }
+            }
+        }
+
+        nmod_mat_clear(mat);
+        nmod_mat_clear(matt);
+        _perm_clear(perm_act);
+        _perm_clear(perm);
+        _perm_clear(perm_store);
+    }
+
+    FLINT_TEST_CLEANUP(state);
+
+    flint_printf("PASS\n");
+    return 0;
+}


### PR DESCRIPTION
This is related to #1171 . This adds a function ``nmod_mat_permute_rows`` and corresponding documentation. The function takes a matrix, a permutation ``perm``, and applies the latter to the rows of the former. Because this is often convenient and for consistency with other similar functions (swap rows, invert rows, ...), a third argument can be used to provide another permutation or integer vector that will be itself permuted according to ``perm``.

Additions:
- the above described function 
- corresponding documentation
- corresponding test file ``t-permute_rows.c``

This removes a declaration which had no corresponding definition in the library (see #1171 ).

This also makes a minor modification in the test file ``nmod_mat/t-invert_rows_cols.c`` where the matrix was not initialized with values, so that the test could only pass. Now the matrix is filled via ``randtest`` and the test still passes.