### PR TITLE
Add cast to `flint_malloc` call

### DIFF
--- a/nmod_mat.h
+++ b/nmod_mat.h
@@ -362,7 +362,7 @@ nmod_mat_permute_rows(nmod_mat_t mat,
                       slong * perm_store)
 {
 		slong i;
-    mp_limb_t ** mat_tmp = flint_malloc(mat->r * sizeof(mp_limb_t *));
+    mp_limb_t ** mat_tmp = (mp_limb_t **) flint_malloc(mat->r * sizeof(mp_limb_t *));
 
     /* perm_store[i] <- perm_store[perm_act[i]] */
     if (perm_store)


### PR DESCRIPTION
Resolves #1212.