### PR TITLE
Fixing the zero polynomial case in left shift for `nmod_poly`

### DIFF
--- a/doc/source/nmod_mat.rst
+++ b/doc/source/nmod_mat.rst
@@ -21,7 +21,7 @@ Memory management
 .. function:: void nmod_mat_init(nmod_mat_t mat, slong rows, slong cols, mp_limb_t n)
 
     Initialises ``mat`` to a ``rows``-by-``cols`` matrix with 
-    coefficients modulo~`n`, where `n` can be any nonzero integer that 
+    coefficients modulo `n`, where `n` can be any nonzero integer that 
     fits in a limb. All elements are set to zero.
 
 .. function:: void nmod_mat_init_set(nmod_mat_t mat, nmod_mat_t src)
@@ -71,7 +71,7 @@ Basic properties and manipulation
 
 .. function:: void nmod_mat_set_entry(nmod_mat_t mat, slong i, slong j, mp_limb_t x)
 
-    Set the entry at row `i` and column `j` of the matrix ``mat` to
+    Set the entry at row `i` and column `j` of the matrix ``mat`` to
     ``x``.
     
 .. function:: slong nmod_mat_nrows(nmod_mat_t mat)
@@ -202,7 +202,7 @@ Comparison
 
 .. function:: int nmod_mat_equal(nmod_mat_t mat1, nmod_mat_t mat2)
 
-    Returns nonzero if mat1 and mat2 have the same dimensions and elements,
+    Returns nonzero if ``mat1`` and ``mat2`` have the same dimensions and elements,
     and zero otherwise. The moduli are ignored.
 
 .. function:: int nmod_mat_is_zero_row(const nmod_mat_t mat, slong i)

--- a/nmod_poly/shift_left.c
+++ b/nmod_poly/shift_left.c
@@ -22,6 +22,12 @@ void _nmod_poly_shift_left(mp_ptr res, mp_srcptr poly, slong len, slong k)
 
 void nmod_poly_shift_left(nmod_poly_t res, const nmod_poly_t poly, slong k)
 {
+    if (nmod_poly_is_zero(poly))
+    {
+        nmod_poly_zero(res);
+        return;
+    }
+
     nmod_poly_fit_length(res, poly->length + k);
    
     _nmod_poly_shift_left(res->coeffs, poly->coeffs, poly->length, k);


### PR DESCRIPTION
This provides a fix for #1216 .

Along with a few typo fixes in `nmod_mat` documentation.