### PR TITLE
Group declaration of struct into `fmpz_types.h`

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -91,7 +91,13 @@ SOURCES = $(patsubst %, %/*.c, $(DIRS))                                 \
 _HEADERS = flint.h             longlong.h          flint-config.h       \
            gmpcompat.h         fmpz-conversions.h  NTL-interface.h      \
            fft_tuning.h        profiler.h          templates.h          \
-           exception.h         hashmap.h
+           exception.h         hashmap.h                                \
+		                                                                \
+           mpoly_types.h                                                \
+           fmpz_types.h        fmpq_types.h                             \
+           nmod_types.h        fmpz_mod_types.h                         \
+           arf_types.h         acf_types.h                              \
+           arb_types.h         acb_types.h
 HEADERS = $(patsubst %, $(SRC_DIR)/%, $(_HEADERS))                      \
           $(patsubst %, %.h, $(subst $(SRC_DIR)/generic_files,,$(DIRS)))\
           $(patsubst %, %.h, $(TEMPLATE_DIRS))

--- a/src/acb.h
+++ b/src/acb.h
@@ -21,21 +21,11 @@
 #include <stdio.h>
 #include "arf.h"
 #include "arb.h"
+#include "acb_types.h"
 
 #ifdef __cplusplus
 extern "C" {
 #endif
-
-typedef struct
-{
-    arb_struct real;
-    arb_struct imag;
-}
-acb_struct;
-
-typedef acb_struct acb_t[1];
-typedef acb_struct * acb_ptr;
-typedef const acb_struct * acb_srcptr;
 
 #define acb_realref(x) (&(x)->real)
 #define acb_imagref(x) (&(x)->imag)

--- a/src/acb_mat.h
+++ b/src/acb_mat.h
@@ -30,18 +30,6 @@
 extern "C" {
 #endif
 
-
-typedef struct
-{
-    acb_ptr entries;
-    slong r;
-    slong c;
-    acb_ptr * rows;
-}
-acb_mat_struct;
-
-typedef acb_mat_struct acb_mat_t[1];
-
 #define acb_mat_entry(mat,i,j) ((mat)->rows[i] + (j))
 #define acb_mat_nrows(mat) ((mat)->r)
 #define acb_mat_ncols(mat) ((mat)->c)

--- a/src/acb_poly.h
+++ b/src/acb_poly.h
@@ -26,17 +26,6 @@
 extern "C" {
 #endif
 
-typedef struct
-{
-    acb_ptr coeffs;
-    slong alloc;
-    slong length;
-}
-acb_poly_struct;
-
-typedef acb_poly_struct acb_poly_t[1];
-
-
 /* Memory management */
 
 void acb_poly_init(acb_poly_t poly);

--- a/src/acb_types.h
+++ b/src/acb_types.h
@@ -1,0 +1,57 @@
+/*
+    Copyright (C) 2023 Albin Ahlbäck
+
+    This file is part of FLINT.
+
+    FLINT is free software: you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License (LGPL) as published
+    by the Free Software Foundation; either version 2.1 of the License, or
+    (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+*/
+
+#ifndef ACB_TYPES_H
+#define ACB_TYPES_H
+
+#include "arb_types.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef struct
+{
+    arb_struct real;
+    arb_struct imag;
+}
+acb_struct;
+
+typedef acb_struct acb_t[1];
+typedef acb_struct * acb_ptr;
+typedef const acb_struct * acb_srcptr;
+
+typedef struct
+{
+    acb_ptr entries;
+    slong r;
+    slong c;
+    acb_ptr * rows;
+}
+acb_mat_struct;
+
+typedef acb_mat_struct acb_mat_t[1];
+
+typedef struct
+{
+    acb_ptr coeffs;
+    slong alloc;
+    slong length;
+}
+acb_poly_struct;
+
+typedef acb_poly_struct acb_poly_t[1];
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* ACB_TYPES_H */

--- a/src/acf.h
+++ b/src/acf.h
@@ -19,21 +19,11 @@
 #endif
 
 #include "arf.h"
+#include "acf_types.h"
 
 #ifdef __cplusplus
 extern "C" {
 #endif
-
-typedef struct
-{
-    arf_struct real;
-    arf_struct imag;
-}
-acf_struct;
-
-typedef acf_struct acf_t[1];
-typedef acf_struct * acf_ptr;
-typedef const acf_struct * acf_srcptr;
 
 #define acf_realref(x) (&(x)->real)
 #define acf_imagref(x) (&(x)->imag)

--- a/src/acf_types.h
+++ b/src/acf_types.h
@@ -1,0 +1,36 @@
+/*
+    Copyright (C) 2023 Albin Ahlbäck
+
+    This file is part of FLINT.
+
+    FLINT is free software: you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License (LGPL) as published
+    by the Free Software Foundation; either version 2.1 of the License, or
+    (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+*/
+
+#ifndef ACF_TYPES_H
+#define ACF_TYPES_H
+
+#include "arf_types.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef struct
+{
+    arf_struct real;
+    arf_struct imag;
+}
+acf_struct;
+
+typedef acf_struct acf_t[1];
+typedef acf_struct * acf_ptr;
+typedef const acf_struct * acf_srcptr;
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* ACF_TYPES_H */

--- a/src/arb.h
+++ b/src/arb.h
@@ -21,6 +21,7 @@
 #include <stdio.h>
 #include "mag.h"
 #include "arf.h"
+#include "arb_types.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -36,17 +37,6 @@ extern "C" {
 
 ARB_DLL extern const char * arb_version;
 double arb_test_multiplier(void);
-
-typedef struct
-{
-    arf_struct mid;
-    mag_struct rad;
-}
-arb_struct;
-
-typedef arb_struct arb_t[1];
-typedef arb_struct * arb_ptr;
-typedef const arb_struct * arb_srcptr;
 
 #define arb_midref(x) (&(x)->mid)
 #define arb_radref(x) (&(x)->rad)

--- a/src/arb_calc.h
+++ b/src/arb_calc.h
@@ -32,17 +32,6 @@ typedef int (*arb_calc_func_t)(arb_ptr out,
 
 /* Root-finding */
 
-typedef struct
-{
-    arf_struct a;
-    arf_struct b;
-}
-arf_interval_struct;
-
-typedef arf_interval_struct arf_interval_t[1];
-typedef arf_interval_struct * arf_interval_ptr;
-typedef const arf_interval_struct * arf_interval_srcptr;
-
 static __inline__ void
 arf_interval_init(arf_interval_t v)
 {

--- a/src/arb_mat.h
+++ b/src/arb_mat.h
@@ -29,17 +29,6 @@
 extern "C" {
 #endif
 
-typedef struct
-{
-    arb_ptr entries;
-    slong r;
-    slong c;
-    arb_ptr * rows;
-}
-arb_mat_struct;
-
-typedef arb_mat_struct arb_mat_t[1];
-
 #define arb_mat_entry(mat,i,j) ((mat)->rows[i] + (j))
 #define arb_mat_nrows(mat) ((mat)->r)
 #define arb_mat_ncols(mat) ((mat)->c)

--- a/src/arb_poly.h
+++ b/src/arb_poly.h
@@ -28,17 +28,6 @@
 extern "C" {
 #endif
 
-typedef struct
-{
-    arb_ptr coeffs;
-    slong alloc;
-    slong length;
-}
-arb_poly_struct;
-
-typedef arb_poly_struct arb_poly_t[1];
-
-
 /* Memory management */
 
 void arb_poly_init(arb_poly_t poly);

--- a/src/arb_types.h
+++ b/src/arb_types.h
@@ -1,0 +1,68 @@
+/*
+    Copyright (C) 2023 Albin Ahlbäck
+
+    This file is part of FLINT.
+
+    FLINT is free software: you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License (LGPL) as published
+    by the Free Software Foundation; either version 2.1 of the License, or
+    (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+*/
+
+#ifndef ARB_TYPES_H
+#define ARB_TYPES_H
+
+#include "arf_types.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef struct
+{
+    fmpz exp;
+    mp_limb_t man;
+}
+mag_struct;
+
+typedef mag_struct mag_t[1];
+typedef mag_struct * mag_ptr;
+typedef const mag_struct * mag_srcptr;
+
+typedef struct
+{
+    arf_struct mid;
+    mag_struct rad;
+}
+arb_struct;
+
+typedef arb_struct arb_t[1];
+typedef arb_struct * arb_ptr;
+typedef const arb_struct * arb_srcptr;
+
+typedef struct
+{
+    arb_ptr entries;
+    slong r;
+    slong c;
+    arb_ptr * rows;
+}
+arb_mat_struct;
+
+typedef arb_mat_struct arb_mat_t[1];
+
+typedef struct
+{
+    arb_ptr coeffs;
+    slong alloc;
+    slong length;
+}
+arb_poly_struct;
+
+typedef arb_poly_struct arb_poly_t[1];
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* ARB_TYPES_H */

--- a/src/arf.h
+++ b/src/arf.h
@@ -27,6 +27,7 @@
 #include "flint.h"
 #include "fmpq.h"
 #include "mag.h"
+#include "arf_types.h"
 
 #if defined(_MSC_VER) && defined(ARB_BUILD_DLL)
 #define ARB_DLL __declspec(dllexport)
@@ -115,9 +116,6 @@ arf_rnd_to_mpfr(arf_rnd_t rnd)
 /* Assumes non-special value */
 #define ARF_NEG(x) (ARF_XSIZE(x) ^= 1)
 
-/* Note: may also be hardcoded in a few places. */
-#define ARF_NOPTR_LIMBS 2
-
 /* Direct access to the limb data. */
 #define ARF_NOPTR_D(x)   ((x)->d.noptr.d)
 #define ARF_PTR_D(x)     ((x)->d.ptr.d)
@@ -137,38 +135,6 @@ arf_rnd_to_mpfr(arf_rnd_t rnd)
         ARF_XSIZE(x) = 0;           \
     } while (0)
 
-
-typedef struct
-{
-    mp_limb_t d[ARF_NOPTR_LIMBS];
-}
-mantissa_noptr_struct;
-
-typedef struct
-{
-    mp_size_t alloc;
-    mp_ptr d;
-}
-mantissa_ptr_struct;
-
-typedef union
-{
-    mantissa_noptr_struct noptr;
-    mantissa_ptr_struct ptr;
-}
-mantissa_struct;
-
-typedef struct
-{
-    fmpz exp;
-    mp_size_t size;
-    mantissa_struct d;
-}
-arf_struct;
-
-typedef arf_struct arf_t[1];
-typedef arf_struct * arf_ptr;
-typedef const arf_struct * arf_srcptr;
 
 void _arf_promote(arf_t x, mp_size_t n);
 

--- a/src/arf_types.h
+++ b/src/arf_types.h
@@ -1,0 +1,71 @@
+/*
+    Copyright (C) 2023 Albin Ahlbäck
+
+    This file is part of FLINT.
+
+    FLINT is free software: you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License (LGPL) as published
+    by the Free Software Foundation; either version 2.1 of the License, or
+    (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+*/
+
+#ifndef ARF_TYPES_H
+#define ARF_TYPES_H
+
+#include "flint.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* Note: may also be hardcoded in a few places. */
+#define ARF_NOPTR_LIMBS 2
+
+typedef struct
+{
+    mp_limb_t d[ARF_NOPTR_LIMBS];
+}
+mantissa_noptr_struct;
+
+typedef struct
+{
+    mp_size_t alloc;
+    mp_ptr d;
+}
+mantissa_ptr_struct;
+
+typedef union
+{
+    mantissa_noptr_struct noptr;
+    mantissa_ptr_struct ptr;
+}
+mantissa_struct;
+
+typedef struct
+{
+    fmpz exp;
+    mp_size_t size;
+    mantissa_struct d;
+}
+arf_struct;
+
+typedef arf_struct arf_t[1];
+typedef arf_struct * arf_ptr;
+typedef const arf_struct * arf_srcptr;
+
+typedef struct
+{
+    arf_struct a;
+    arf_struct b;
+}
+arf_interval_struct;
+
+typedef arf_interval_struct arf_interval_t[1];
+typedef arf_interval_struct * arf_interval_ptr;
+typedef const arf_interval_struct * arf_interval_srcptr;
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* ARF_TYPES_H */

--- a/src/flint.h
+++ b/src/flint.h
@@ -452,8 +452,17 @@ FLINT_INLINE slong flint_mul_sizes(slong x, slong y)
 
 #include "exception.h"
 
-/* defined ahead of fmpz.h and fmpq.h so that the types
-   are usable in prototypes without importing those headers */
+/* Defined ahead of nmod.h, fmpz.h and fmpq.h so that the types are usable in
+ * prototypes without importing those headers */
+
+typedef struct
+{
+   mp_limb_t n;
+   mp_limb_t ninv;
+   flint_bitcnt_t norm;
+}
+nmod_t;
+
 typedef slong fmpz;
 typedef fmpz fmpz_t[1];
 

--- a/src/fmpq.h
+++ b/src/fmpq.h
@@ -29,21 +29,11 @@
 #include "flint.h"
 #include "fmpz.h"
 #include "fmpz_vec.h"
-
+#include "fmpq_types.h"
 
 #ifdef __cplusplus
- extern "C" {
+extern "C" {
 #endif
-
-/* already defined in flint.h
-typedef struct
-{
-    fmpz num;
-    fmpz den;
-}
-fmpq;
-
-typedef fmpq fmpq_t[1]; */
 
 #define fmpq_numref(__x) (&(__x)->num)
 #define fmpq_denref(__y) (&(__y)->den)

--- a/src/fmpq_mat.h
+++ b/src/fmpq_mat.h
@@ -22,22 +22,13 @@
 #include "flint.h"
 #include "fmpz.h"
 #include "fmpz_mat.h"
+#include "fmpq_types.h"
 #include "fmpq_poly.h"
 #include "fmpq.h"
 
 #ifdef __cplusplus
- extern "C" {
+extern "C" {
 #endif
-
-typedef struct
-{
-    fmpq * entries;
-    slong r;
-    slong c;
-    fmpq ** rows;
-} fmpq_mat_struct;
-
-typedef fmpq_mat_struct fmpq_mat_t[1];
 
 FMPQ_MAT_INLINE
 fmpq * fmpq_mat_entry(const fmpq_mat_t mat, slong i, slong j)

--- a/src/fmpq_mpoly.h
+++ b/src/fmpq_mpoly.h
@@ -30,17 +30,10 @@
 #include "fmpz_mpoly.h"
 
 #ifdef __cplusplus
- extern "C" {
+extern "C" {
 #endif
 
 /* Context object ************************************************************/
-
-typedef struct
-{
-    fmpz_mpoly_ctx_t zctx;
-} fmpq_mpoly_ctx_struct;
-
-typedef fmpq_mpoly_ctx_struct fmpq_mpoly_ctx_t[1];
 
 FMPQ_MPOLY_INLINE
 void fmpq_mpoly_ctx_init(fmpq_mpoly_ctx_t ctx, 
@@ -75,22 +68,6 @@ ordering_t fmpq_mpoly_ctx_ord(const fmpq_mpoly_ctx_t ctx)
 }
 
 /* Polynomials over Q ********************************************************/
-
-/*
-    A polynomial f is represented as
-        content * zpoly,
-    where zpoly should have positive leading coefficient and trivial content.
-    If f is zero, then the representation should have
-        content = 0 and zpoly = 0
-*/
-
-typedef struct
-{                       /* non zero case:                   |  zero case: */
-    fmpq_t content;     /* positive or negative content     |  zero       */
-    fmpz_mpoly_t zpoly; /* contentless poly, lc is positive |  zero       */
-} fmpq_mpoly_struct;
-
-typedef fmpq_mpoly_struct fmpq_mpoly_t[1];
 
 FMPQ_MPOLY_INLINE
 fmpq * fmpq_mpoly_content_ref(fmpq_mpoly_t A, const fmpq_mpoly_ctx_t ctx)

--- a/src/fmpq_mpoly_factor.h
+++ b/src/fmpq_mpoly_factor.h
@@ -29,18 +29,8 @@
 #include "fmpz_mpoly_factor.h"
 
 #ifdef __cplusplus
- extern "C" {
+extern "C" {
 #endif
-
-typedef struct {
-    fmpq_t constant;
-    fmpq_mpoly_struct * poly;
-    fmpz * exp;
-    slong num;
-    slong alloc;
-} fmpq_mpoly_factor_struct;
-
-typedef fmpq_mpoly_factor_struct fmpq_mpoly_factor_t[1];
 
 FLINT_DLL void fmpq_mpoly_factor_init(fmpq_mpoly_factor_t f,
                                                    const fmpq_mpoly_ctx_t ctx);

--- a/src/fmpq_poly.h
+++ b/src/fmpq_poly.h
@@ -23,25 +23,16 @@
 #include <gmp.h>
 #include "fmpz.h"
 #include "fmpq.h"
+#include "fmpq_types.h"
 #include "fmpz_vec.h"
 #include "fmpz_poly.h"
 #include "flint.h"
 
 #ifdef __cplusplus
- extern "C" {
+extern "C" {
 #endif
 
 /*  Type definitions  ********************************************************/
-
-typedef struct
-{
-    fmpz * coeffs;
-    slong alloc;
-    slong length;
-    fmpz_t den;
-} fmpq_poly_struct;
-
-typedef fmpq_poly_struct fmpq_poly_t[1];
 
 typedef struct
 {

--- a/src/fmpq_types.h
+++ b/src/fmpq_types.h
@@ -1,0 +1,76 @@
+/*
+    Copyright (C) 2023 Albin Ahlbäck
+
+    This file is part of FLINT.
+
+    FLINT is free software: you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License (LGPL) as published
+    by the Free Software Foundation; either version 2.1 of the License, or
+    (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+*/
+
+#ifndef FMPQ_TYPES_H
+#define FMPQ_TYPES_H
+
+#include "fmpz_types.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef struct
+{
+    fmpq * entries;
+    slong r;
+    slong c;
+    fmpq ** rows;
+}
+fmpq_mat_struct;
+
+typedef fmpq_mat_struct fmpq_mat_t[1];
+
+typedef struct
+{
+    fmpz * coeffs;
+    slong alloc;
+    slong length;
+    fmpz_t den;
+}
+fmpq_poly_struct;
+
+typedef fmpq_poly_struct fmpq_poly_t[1];
+
+/*
+    A polynomial f is represented as
+        content * zpoly,
+    where zpoly should have positive leading coefficient and trivial content.
+    If f is zero, then the representation should have
+        content = 0 and zpoly = 0
+*/
+
+typedef struct
+{                       /* non zero case:                   |  zero case: */
+    fmpq_t content;     /* positive or negative content     |  zero       */
+    fmpz_mpoly_t zpoly; /* contentless poly, lc is positive |  zero       */
+}
+fmpq_mpoly_struct;
+
+typedef fmpq_mpoly_struct fmpq_mpoly_t[1];
+
+typedef struct
+{
+    fmpq_t constant;
+    fmpq_mpoly_struct * poly;
+    fmpz * exp;
+    slong num;
+    slong alloc;
+}
+fmpq_mpoly_factor_struct;
+
+typedef fmpq_mpoly_factor_struct fmpq_mpoly_factor_t[1];
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* FMPQ_TYPES_H */

--- a/src/fmpq_vec.h
+++ b/src/fmpq_vec.h
@@ -23,7 +23,7 @@
 #include "flint.h"
 
 #ifdef __cplusplus
- extern "C" {
+extern "C" {
 #endif
 
 /*  Memory management  *******************************************************/

--- a/src/fmpz.h
+++ b/src/fmpz.h
@@ -28,6 +28,7 @@
 #define ulong mp_limb_t
 
 #include "flint.h"
+#include "fmpz_types.h"
 #include "nmod_vec.h"
 #include "fmpz-conversions.h"
 

--- a/src/fmpz_factor.h
+++ b/src/fmpz_factor.h
@@ -18,23 +18,11 @@
 #define FMPZ_FACTOR_INLINE static __inline__
 #endif
 
-#include <gmp.h>
-#include "flint.h"
+#include "fmpz.h"
 
 #ifdef __cplusplus
- extern "C" {
+extern "C" {
 #endif
-
-typedef struct
-{
-    int sign;
-    fmpz * p;
-    ulong * exp;
-    slong alloc;
-    slong num;
-} fmpz_factor_struct;
-
-typedef fmpz_factor_struct fmpz_factor_t[1];
 
 /* Utility functions *********************************************************/
 

--- a/src/fmpz_mat.h
+++ b/src/fmpz_mat.h
@@ -37,16 +37,6 @@
  extern "C" {
 #endif
 
-typedef struct
-{
-    fmpz * entries;
-    slong r;
-    slong c;
-    fmpz ** rows;
-} fmpz_mat_struct;
-
-typedef fmpz_mat_struct fmpz_mat_t[1];
-
 /* Element access  ********************************************************/
 
 FMPZ_MAT_INLINE

--- a/src/fmpz_mod.h
+++ b/src/fmpz_mod.h
@@ -31,10 +31,11 @@
 #include "ulong_extras.h"
 #include "fmpz.h"
 #include "fmpz_vec.h"
+#include "fmpz_mod_types.h"
 
 
 #ifdef __cplusplus
- extern "C" {
+extern "C" {
 #endif
 
 /* all of the data we need to do arithmetic mod n ****************************/
@@ -49,16 +50,6 @@
     A special case for the multiplication for 3-word shows no signs of
     diminishing returns, but it is not implemented currently.
 */
-typedef struct fmpz_mod_ctx {
-    fmpz_t n;
-    void (* add_fxn)(fmpz_t, const fmpz_t, const fmpz_t, const struct fmpz_mod_ctx *);
-    void (* sub_fxn)(fmpz_t, const fmpz_t, const fmpz_t, const struct fmpz_mod_ctx *);
-    void (* mul_fxn)(fmpz_t, const fmpz_t, const fmpz_t, const struct fmpz_mod_ctx *);
-    nmod_t mod;
-    ulong n_limbs[3];
-    ulong ninv_limbs[3];
-} fmpz_mod_ctx_struct;
-typedef fmpz_mod_ctx_struct fmpz_mod_ctx_t[1];
 
 FLINT_DLL void fmpz_mod_ctx_init(fmpz_mod_ctx_t ctx, const fmpz_t n);
 

--- a/src/fmpz_mod_mat.h
+++ b/src/fmpz_mod_mat.h
@@ -32,16 +32,6 @@
 #define FMPZ_MOD_MAT_SOLVE_TRI_ROWS_CUTOFF 64
 #define FMPZ_MOD_MAT_SOLVE_TRI_COLS_CUTOFF 64
 
-typedef struct
-{
-    fmpz_mat_t mat;
-    fmpz_t mod;
-}
-fmpz_mod_mat_struct;
-
-/* fmpz_mod_mat_t allows reference-like semantics for fmpz_mod_mat_struct */
-typedef fmpz_mod_mat_struct fmpz_mod_mat_t[1];
-
 /* Element access  ********************************************************/
 
 FMPZ_MOD_MAT_INLINE

--- a/src/fmpz_mod_mpoly.h
+++ b/src/fmpz_mod_mpoly.h
@@ -33,34 +33,10 @@
 #include "n_poly.h"
 
 #ifdef __cplusplus
- extern "C" {
+extern "C" {
 #endif
 
 /* type definitions **********************************************************/
-
-typedef struct
-{
-    mpoly_ctx_t minfo;
-    fmpz_mod_ctx_t ffinfo;
-} fmpz_mod_mpoly_ctx_struct;
-
-typedef fmpz_mod_mpoly_ctx_struct fmpz_mod_mpoly_ctx_t[1];
-
-/*
-    fmpz_mod_mpoly_t
-    sparse multivariates with fmpz_mod coeffs
-*/
-typedef struct
-{
-    fmpz * coeffs;
-    ulong * exps;
-    slong length;
-    flint_bitcnt_t bits;    /* number of bits per exponent */
-    slong coeffs_alloc;     /* abs size in mp_limb_t units */
-    slong exps_alloc;       /* abs size in ulong units */
-} fmpz_mod_mpoly_struct;
-
-typedef fmpz_mod_mpoly_struct fmpz_mod_mpoly_t[1];
 
 /*
     fmpz_mod_mpoly_univar_t

--- a/src/fmpz_mod_mpoly_factor.h
+++ b/src/fmpz_mod_mpoly_factor.h
@@ -30,20 +30,8 @@
 #include "fmpz_mod_mpoly.h"
 
 #ifdef __cplusplus
- extern "C" {
+extern "C" {
 #endif
-
-/* type definitions **********************************************************/
-
-typedef struct {
-    fmpz_t constant;
-    fmpz_mod_mpoly_struct * poly;
-    fmpz * exp;
-    slong num;
-    slong alloc;
-} fmpz_mod_mpoly_factor_struct;
-
-typedef fmpz_mod_mpoly_factor_struct fmpz_mod_mpoly_factor_t[1];
 
 FMPZ_MOD_MPOLY_FACTOR_INLINE
 void fmpz_mod_mpoly_factor_init(fmpz_mod_mpoly_factor_t f,

--- a/src/fmpz_mod_poly.h
+++ b/src/fmpz_mod_poly.h
@@ -34,24 +34,16 @@
 #include "fmpz_mod_mat.h"
 
 #ifdef __cplusplus
- extern "C" {
+extern "C" {
 #endif
 
 #define FMPZ_MOD_POLY_HGCD_CUTOFF  128      /* HGCD: Basecase -> Recursion      */
 #define FMPZ_MOD_POLY_GCD_CUTOFF  256       /* GCD:  Euclidean -> HGCD          */
 
 #define FMPZ_MOD_POLY_INV_NEWTON_CUTOFF  64 /* Inv series newton: Basecase -> Newton */
-#define FMPZ_MOD_POLY_DIV_DIVCONQUER_CUTOFF 
+#define FMPZ_MOD_POLY_DIV_DIVCONQUER_CUTOFF
+
 /*  Type definitions *********************************************************/
-
-typedef struct
-{
-    fmpz * coeffs;
-    slong alloc;
-    slong length;
-} fmpz_mod_poly_struct;
-
-typedef fmpz_mod_poly_struct fmpz_mod_poly_t[1];
 
 typedef struct
 {

--- a/src/fmpz_mod_poly_factor.h
+++ b/src/fmpz_mod_poly_factor.h
@@ -30,20 +30,10 @@
 #include "fmpz.h"
 
 #ifdef __cplusplus
- extern "C" {
+extern "C" {
 #endif
 
 /* Factoring  ****************************************************************/
-
-typedef struct
-{
-    fmpz_mod_poly_struct *poly;
-    slong *exp;
-    slong num;
-    slong alloc;
-} fmpz_mod_poly_factor_struct;
-
-typedef fmpz_mod_poly_factor_struct fmpz_mod_poly_factor_t[1];
 
 FLINT_DLL void fmpz_mod_poly_factor_init(fmpz_mod_poly_factor_t fac,
                                                      const fmpz_mod_ctx_t ctx);

--- a/src/fmpz_mod_types.h
+++ b/src/fmpz_mod_types.h
@@ -1,0 +1,94 @@
+/*
+    Copyright (C) 2023 Albin Ahlbäck
+
+    This file is part of FLINT.
+
+    FLINT is free software: you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License (LGPL) as published
+    by the Free Software Foundation; either version 2.1 of the License, or
+    (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+*/
+
+#ifndef FMPZ_MOD_TYPES_H
+#define FMPZ_MOD_TYPES_H
+
+#include "fmpz.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef struct fmpz_mod_ctx
+{
+    fmpz_t n;
+    void (* add_fxn)(fmpz_t, const fmpz_t, const fmpz_t, const struct fmpz_mod_ctx *);
+    void (* sub_fxn)(fmpz_t, const fmpz_t, const fmpz_t, const struct fmpz_mod_ctx *);
+    void (* mul_fxn)(fmpz_t, const fmpz_t, const fmpz_t, const struct fmpz_mod_ctx *);
+    nmod_t mod;
+    ulong n_limbs[3];
+    ulong ninv_limbs[3];
+}
+fmpz_mod_ctx_struct;
+
+typedef fmpz_mod_ctx_struct fmpz_mod_ctx_t[1];
+
+typedef struct
+{
+    fmpz_mat_t mat;
+    fmpz_t mod;
+}
+fmpz_mod_mat_struct;
+
+typedef fmpz_mod_mat_struct fmpz_mod_mat_t[1];
+
+typedef struct
+{
+    fmpz * coeffs;
+    slong alloc;
+    slong length;
+}
+fmpz_mod_poly_struct;
+
+typedef fmpz_mod_poly_struct fmpz_mod_poly_t[1];
+
+typedef struct
+{
+    fmpz_mod_poly_struct * poly;
+    slong *exp;
+    slong num;
+    slong alloc;
+}
+fmpz_mod_poly_factor_struct;
+
+typedef fmpz_mod_poly_factor_struct fmpz_mod_poly_factor_t[1];
+
+typedef struct
+{
+    fmpz * coeffs;
+    ulong * exps;
+    slong length;
+    flint_bitcnt_t bits;    /* number of bits per exponent */
+    slong coeffs_alloc;     /* abs size in mp_limb_t units */
+    slong exps_alloc;       /* abs size in ulong units */
+}
+fmpz_mod_mpoly_struct;
+
+typedef fmpz_mod_mpoly_struct fmpz_mod_mpoly_t[1];
+
+typedef struct
+{
+    fmpz_t constant;
+    fmpz_mod_mpoly_struct * poly;
+    fmpz * exp;
+    slong num;
+    slong alloc;
+}
+fmpz_mod_mpoly_factor_struct;
+
+typedef fmpz_mod_mpoly_factor_struct fmpz_mod_mpoly_factor_t[1];
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* FMPZ_MOD_TYPES_H */

--- a/src/fmpz_mod_vec.h
+++ b/src/fmpz_mod_vec.h
@@ -23,7 +23,7 @@
 #include "fmpz_mod.h"
 
 #ifdef __cplusplus
- extern "C" {
+extern "C" {
 #endif
 
 FLINT_DLL void _fmpz_mod_vec_set_fmpz_vec(fmpz * A, const fmpz * B, slong len,

--- a/src/fmpz_mpoly.h
+++ b/src/fmpz_mpoly.h
@@ -37,35 +37,8 @@
 #include "n_poly.h"
 
 #ifdef __cplusplus
- extern "C" {
+extern "C" {
 #endif
-
-/* Type definitions **********************************************************/
-
-/*
-    context object for fmpz_mpoly
-*/
-typedef struct
-{
-    mpoly_ctx_t minfo;
-} fmpz_mpoly_ctx_struct;
-
-typedef fmpz_mpoly_ctx_struct fmpz_mpoly_ctx_t[1];
-
-/*
-    fmpz_mpoly_t
-    sparse multivariates with fmpz coeffs
-*/
-typedef struct
-{
-   fmpz * coeffs; /* alloc fmpzs */
-   ulong * exps;
-   slong alloc;
-   slong length;
-   flint_bitcnt_t bits;     /* number of bits per exponent */
-} fmpz_mpoly_struct;
-
-typedef fmpz_mpoly_struct fmpz_mpoly_t[1];
 
 FMPZ_MPOLY_INLINE
 fmpz * fmpz_mpoly_term_coeff_ref(fmpz_mpoly_t A, slong i,

--- a/src/fmpz_mpoly_factor.h
+++ b/src/fmpz_mpoly_factor.h
@@ -43,17 +43,6 @@ FLINT_DLL void tuple_next(fmpz * alpha, slong n);
 
 /*****************************************************************************/
 
-typedef struct {
-    fmpz_t constant;
-    fmpz_t constant_den;        /* should be one after normal operations */
-    fmpz_mpoly_struct * poly;
-    fmpz * exp;
-    slong num;
-    slong alloc;
-} fmpz_mpoly_factor_struct;
-
-typedef fmpz_mpoly_factor_struct fmpz_mpoly_factor_t[1];
-
 FMPZ_MPOLY_FACTOR_INLINE
 void fmpz_mpoly_factor_init(fmpz_mpoly_factor_t f, const fmpz_mpoly_ctx_t ctx)
 {

--- a/src/fmpz_mpoly_q.h
+++ b/src/fmpz_mpoly_q.h
@@ -28,15 +28,6 @@ extern "C" {
 
 #include "calcium.h"
 
-typedef struct
-{
-    fmpz_mpoly_struct num;
-    fmpz_mpoly_struct den;
-}
-fmpz_mpoly_q_struct;
-
-typedef fmpz_mpoly_q_struct fmpz_mpoly_q_t[1];
-
 #define fmpz_mpoly_q_numref(x) (&((x)->num))
 #define fmpz_mpoly_q_denref(x) (&((x)->den))
 

--- a/src/fmpz_poly.h
+++ b/src/fmpz_poly.h
@@ -47,30 +47,11 @@
 
 typedef struct
 {
-    fmpz * coeffs;
-    slong alloc;
-    slong length;
-} fmpz_poly_struct;
-
-typedef fmpz_poly_struct fmpz_poly_t[1];
-
-typedef struct
-{
    fmpz ** powers;
    slong len;
 } fmpz_poly_powers_precomp_struct;
 
 typedef fmpz_poly_powers_precomp_struct fmpz_poly_powers_precomp_t[1];
-
-typedef struct {
-    fmpz c;
-    fmpz_poly_struct *p;
-    slong *exp;
-    slong num;
-    slong alloc;
-} fmpz_poly_factor_struct;
-
-typedef fmpz_poly_factor_struct fmpz_poly_factor_t[1];
 
 typedef struct
 {

--- a/src/fmpz_poly_factor.h
+++ b/src/fmpz_poly_factor.h
@@ -34,7 +34,7 @@
 #include "nmod_poly.h"
 
 #ifdef __cplusplus
- extern "C" {
+extern "C" {
 #endif
 
 FLINT_DLL void fmpz_poly_factor_init(fmpz_poly_factor_t fac);

--- a/src/fmpz_poly_mat.h
+++ b/src/fmpz_poly_mat.h
@@ -25,20 +25,10 @@
 #include "fmpz_poly.h"
 
 #ifdef __cplusplus
- extern "C" {
+extern "C" {
 #endif
 
 /* Types *********************************************************************/
-
-typedef struct
-{
-    fmpz_poly_struct * entries;
-    slong r;
-    slong c;
-    fmpz_poly_struct ** rows;
-} fmpz_poly_mat_struct;
-
-typedef fmpz_poly_mat_struct fmpz_poly_mat_t[1];
 
 FMPZ_POLY_MAT_INLINE
 fmpz_poly_struct * fmpz_poly_mat_entry(const fmpz_poly_mat_t mat, slong i, slong j)

--- a/src/fmpz_poly_q.h
+++ b/src/fmpz_poly_q.h
@@ -30,16 +30,8 @@
 #include "fmpz_poly.h"
 
 #ifdef __cplusplus
- extern "C" {
+extern "C" {
 #endif
-
-typedef struct
-{
-    fmpz_poly_struct *num;
-    fmpz_poly_struct *den;
-} fmpz_poly_q_struct;
-
-typedef fmpz_poly_q_struct fmpz_poly_q_t[1];
 
 /* Accessing numerator and denominator ***************************************/
 

--- a/src/fmpz_types.h
+++ b/src/fmpz_types.h
@@ -1,0 +1,133 @@
+/*
+    Copyright (C) 2023 Albin Ahlbäck
+
+    This file is part of FLINT.
+
+    FLINT is free software: you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License (LGPL) as published
+    by the Free Software Foundation; either version 2.1 of the License, or
+    (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+*/
+
+#ifndef FMPZ_TYPES_H
+#define FMPZ_TYPES_H
+
+#include "flint.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef struct
+{
+    int sign;
+    fmpz * p;
+    ulong * exp;
+    slong alloc;
+    slong num;
+}
+fmpz_factor_struct;
+
+typedef fmpz_factor_struct fmpz_factor_t[1];
+
+typedef struct
+{
+    fmpz * coeffs;
+    slong alloc;
+    slong length;
+}
+fmpz_poly_struct;
+
+typedef fmpz_poly_struct fmpz_poly_t[1];
+
+typedef struct
+{
+    fmpz c;
+    fmpz_poly_struct *p;
+    slong *exp;
+    slong num;
+    slong alloc;
+}
+fmpz_poly_factor_struct;
+
+typedef fmpz_poly_factor_struct fmpz_poly_factor_t[1];
+
+typedef struct
+{
+    fmpz * entries;
+    slong r;
+    slong c;
+    fmpz ** rows;
+}
+fmpz_mat_struct;
+
+typedef fmpz_mat_struct fmpz_mat_t[1];
+
+typedef struct
+{
+    fmpz_poly_struct * entries;
+    slong r;
+    slong c;
+    fmpz_poly_struct ** rows;
+}
+fmpz_poly_mat_struct;
+
+typedef fmpz_poly_mat_struct fmpz_poly_mat_t[1];
+
+typedef struct
+{
+   fmpz * coeffs; /* alloc fmpzs */
+   ulong * exps;
+   slong alloc;
+   slong length;
+   flint_bitcnt_t bits;     /* number of bits per exponent */
+}
+fmpz_mpoly_struct;
+
+typedef fmpz_mpoly_struct fmpz_mpoly_t[1];
+
+typedef struct
+{
+    fmpz_t constant;
+    fmpz_t constant_den;        /* should be one after normal operations */
+    fmpz_mpoly_struct * poly;
+    fmpz * exp;
+    slong num;
+    slong alloc;
+}
+fmpz_mpoly_factor_struct;
+
+typedef fmpz_mpoly_factor_struct fmpz_mpoly_factor_t[1];
+
+typedef struct
+{
+    fmpz_poly_struct *num;
+    fmpz_poly_struct *den;
+}
+fmpz_poly_q_struct;
+
+typedef fmpz_poly_q_struct fmpz_poly_q_t[1];
+
+typedef struct
+{
+    fmpz_mpoly_struct num;
+    fmpz_mpoly_struct den;
+}
+fmpz_mpoly_q_struct;
+
+typedef fmpz_mpoly_q_struct fmpz_mpoly_q_t[1];
+
+typedef struct
+{
+    fmpz a;
+    fmpz b;
+}
+fmpzi_struct;
+
+typedef fmpzi_struct fmpzi_t[1];
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* FMPZ_TYPES_H */

--- a/src/fmpzi.h
+++ b/src/fmpzi.h
@@ -24,15 +24,6 @@
 extern "C" {
 #endif
 
-typedef struct
-{
-    fmpz a;
-    fmpz b;
-}
-fmpzi_struct;
-
-typedef fmpzi_struct fmpzi_t[1];
-
 #define fmpzi_realref(x) (&((x)->a))
 #define fmpzi_imagref(x) (&((x)->b))
 

--- a/src/mag.h
+++ b/src/mag.h
@@ -23,6 +23,7 @@
 #include "flint.h"
 #include "fmpz.h"
 #include "fmpz_extras.h"
+#include "arb_types.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -177,17 +178,6 @@ __mag_fixmul32(mp_limb_t x, mp_limb_t y)
         MAG_EXP(x) -= __t; \
     } while (0)
 
-
-typedef struct
-{
-    fmpz exp;
-    mp_limb_t man;
-}
-mag_struct;
-
-typedef mag_struct mag_t[1];
-typedef mag_struct * mag_ptr;
-typedef const mag_struct * mag_srcptr;
 
 MAG_INLINE void
 mag_init(mag_t x)

--- a/src/mpoly.h
+++ b/src/mpoly.h
@@ -28,7 +28,7 @@
 #define ulong mp_limb_t
 
 #include "string.h"
-#include "flint.h"
+#include "mpoly_types.h"
 #include "fmpz.h"
 #include "fmpz_mat.h"
 #include "fmpq.h"
@@ -63,28 +63,7 @@ MPOLY_INLINE slong mpoly_divide_threads(slong n, double la, double lb)
 }
 
 
-typedef enum {
-    ORD_LEX,
-    ORD_DEGLEX,
-    ORD_DEGREVLEX
-} ordering_t;
-
-#define MPOLY_NUM_ORDERINGS 3
-
 /* context *******************************************************************/
-
-typedef struct
-{
-    slong nvars;    /* number of variables */
-    slong nfields;  /* number of fields in exponent vector */
-    ordering_t ord; /* monomial ordering */
-    int deg;        /* is ord a degree ordering? */
-    int rev;        /* is ord a reversed ordering? */
-    slong lut_words_per_exp[FLINT_BITS];
-    unsigned char lut_fix_bits[FLINT_BITS]; /* FLINT_BITS < 256 */
-} mpoly_ctx_struct;
-
-typedef mpoly_ctx_struct mpoly_ctx_t[1];
 
 FLINT_DLL void mpoly_ctx_init(mpoly_ctx_t ctx, slong nvars, const ordering_t ord);
 

--- a/src/mpoly_types.h
+++ b/src/mpoly_types.h
@@ -56,6 +56,14 @@ fmpz_mpoly_ctx_struct;
 
 typedef fmpz_mpoly_ctx_struct fmpz_mpoly_ctx_t[1];
 
+typedef struct
+{
+    fmpz_mpoly_ctx_t zctx;
+}
+fmpq_mpoly_ctx_struct;
+
+typedef fmpq_mpoly_ctx_struct fmpq_mpoly_ctx_t[1];
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/mpoly_types.h
+++ b/src/mpoly_types.h
@@ -13,6 +13,7 @@
 #define MPOLY_TYPES_H
 
 #include "flint.h"
+#include "fmpz_mod_types.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -63,6 +64,15 @@ typedef struct
 fmpq_mpoly_ctx_struct;
 
 typedef fmpq_mpoly_ctx_struct fmpq_mpoly_ctx_t[1];
+
+typedef struct
+{
+    mpoly_ctx_t minfo;
+    fmpz_mod_ctx_t ffinfo;
+}
+fmpz_mod_mpoly_ctx_struct;
+
+typedef fmpz_mod_mpoly_ctx_struct fmpz_mod_mpoly_ctx_t[1];
 
 #ifdef __cplusplus
 }

--- a/src/mpoly_types.h
+++ b/src/mpoly_types.h
@@ -42,6 +42,15 @@ typedef mpoly_ctx_struct mpoly_ctx_t[1];
 typedef struct
 {
     mpoly_ctx_t minfo;
+    nmod_t mod;
+}
+nmod_mpoly_ctx_struct;
+
+typedef nmod_mpoly_ctx_struct nmod_mpoly_ctx_t[1];
+
+typedef struct
+{
+    mpoly_ctx_t minfo;
 }
 fmpz_mpoly_ctx_struct;
 

--- a/src/mpoly_types.h
+++ b/src/mpoly_types.h
@@ -1,0 +1,54 @@
+/*
+    Copyright (C) 2023 Albin Ahlbäck
+
+    This file is part of FLINT.
+
+    FLINT is free software: you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License (LGPL) as published
+    by the Free Software Foundation; either version 2.1 of the License, or
+    (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+*/
+
+#ifndef MPOLY_TYPES_H
+#define MPOLY_TYPES_H
+
+#include "flint.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef enum {
+    ORD_LEX,
+    ORD_DEGLEX,
+    ORD_DEGREVLEX
+} ordering_t;
+
+#define MPOLY_NUM_ORDERINGS 3
+
+typedef struct
+{
+    slong nvars;    /* number of variables */
+    slong nfields;  /* number of fields in exponent vector */
+    ordering_t ord; /* monomial ordering */
+    int deg;        /* is ord a degree ordering? */
+    int rev;        /* is ord a reversed ordering? */
+    slong lut_words_per_exp[FLINT_BITS];
+    unsigned char lut_fix_bits[FLINT_BITS]; /* FLINT_BITS < 256 */
+} mpoly_ctx_struct;
+
+typedef mpoly_ctx_struct mpoly_ctx_t[1];
+
+typedef struct
+{
+    mpoly_ctx_t minfo;
+}
+fmpz_mpoly_ctx_struct;
+
+typedef fmpz_mpoly_ctx_struct fmpz_mpoly_ctx_t[1];
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* MPOLY_TYPES_H */

--- a/src/nmod.h
+++ b/src/nmod.h
@@ -28,19 +28,11 @@
 
 #include "longlong.h"
 #include "ulong_extras.h"
-#include "flint.h"
+#include "nmod_types.h"
 
 #ifdef __cplusplus
- extern "C" {
+extern "C" {
 #endif
-
-typedef struct
-{
-   mp_limb_t n;
-   mp_limb_t ninv;
-   flint_bitcnt_t norm;
-} nmod_t;
-
 
 #define NMOD_RED2(r, a_hi, a_lo, mod) \
    do { \

--- a/src/nmod_mat.h
+++ b/src/nmod_mat.h
@@ -36,21 +36,8 @@
 #include "thread_support.h"
 
 #ifdef __cplusplus
- extern "C" {
+extern "C" {
 #endif
-
-typedef struct
-{
-    mp_limb_t * entries;
-    slong r;
-    slong c;
-    mp_limb_t ** rows;
-    nmod_t mod;
-}
-nmod_mat_struct;
-
-/* nmod_mat_t allows reference-like semantics for nmod_mat_struct */
-typedef nmod_mat_struct nmod_mat_t[1];
 
 #define nmod_mat_entry(mat,i,j) ((mat)->rows[(i)][(j)])
 

--- a/src/nmod_mpoly.h
+++ b/src/nmod_mpoly.h
@@ -40,38 +40,8 @@
 
 
 #ifdef __cplusplus
- extern "C" {
+extern "C" {
 #endif
-
-
-/* Type definitions **********************************************************/
-
-/*
-    context object for nmod_mpoly
-*/
-typedef struct
-{
-    mpoly_ctx_t minfo;
-    nmod_t mod;
-} nmod_mpoly_ctx_struct;
-
-typedef nmod_mpoly_ctx_struct nmod_mpoly_ctx_t[1];
-
-/*
-    nmod_mpoly_t
-    sparse multivariates with nmod coeffs
-*/
-typedef struct
-{
-    mp_limb_t * coeffs;
-    ulong * exps;
-    slong length;
-    flint_bitcnt_t bits;    /* number of bits per exponent */
-    slong coeffs_alloc;     /* abs size in mp_limb_t units */
-    slong exps_alloc;       /* abs size in ulong units */
-} nmod_mpoly_struct;
-
-typedef nmod_mpoly_struct nmod_mpoly_t[1];
 
 NMOD_MPOLY_INLINE
 mp_limb_t * nmod_mpoly_term_coeff_ref(nmod_mpoly_t A, slong i,

--- a/src/nmod_mpoly_factor.h
+++ b/src/nmod_mpoly_factor.h
@@ -60,16 +60,6 @@ FLINT_DLL void nmod_mat_init_nullspace_tr(nmod_mat_t X, nmod_mat_t tmp);
 
 /*****************************************************************************/
 
-typedef struct {
-    mp_limb_t constant;
-    nmod_mpoly_struct * poly;
-    fmpz * exp;
-    slong num;
-    slong alloc;
-} nmod_mpoly_factor_struct;
-
-typedef nmod_mpoly_factor_struct nmod_mpoly_factor_t[1];
-
 NMOD_MPOLY_FACTOR_INLINE
 void nmod_mpoly_factor_init(nmod_mpoly_factor_t f, const nmod_mpoly_ctx_t ctx)
 {

--- a/src/nmod_poly.h
+++ b/src/nmod_poly.h
@@ -37,22 +37,12 @@
 #include "thread_support.h"
 
 #ifdef __cplusplus
-    extern "C" {
+extern "C" {
 #endif
 
 #define NMOD_POLY_HGCD_CUTOFF  100      /* HGCD: Basecase -> Recursion      */
 #define NMOD_POLY_GCD_CUTOFF  340       /* GCD:  Euclidean -> HGCD          */
 #define NMOD_POLY_SMALL_GCD_CUTOFF 200  /* GCD (small n): Euclidean -> HGCD */
-
-typedef struct
-{
-    mp_ptr coeffs;
-    slong alloc;
-    slong length;
-    nmod_t mod;
-} nmod_poly_struct;
-
-typedef nmod_poly_struct nmod_poly_t[1];
 
 typedef struct
 {
@@ -1410,7 +1400,7 @@ NMOD_POLY_INLINE const nmod_poly_struct * nmod_berlekamp_massey_R_poly(
 }
 
 #ifdef __cplusplus
-    }
+}
 #endif
 
 #include "nmod_poly_factor.h"

--- a/src/nmod_poly_factor.h
+++ b/src/nmod_poly_factor.h
@@ -36,16 +36,8 @@
 #include "fmpz.h"
 
 #ifdef __cplusplus
-    extern "C" {
+extern "C" {
 #endif
-
-typedef struct
-{
-    nmod_poly_struct *p;
-    slong *exp;
-    slong num;
-    slong alloc;
-} nmod_poly_factor_struct;
 
 typedef struct
 {
@@ -60,8 +52,6 @@ typedef struct
 nmod_poly_interval_poly_arg_t;
 
 /* Factoring  ****************************************************************/
-
-typedef nmod_poly_factor_struct nmod_poly_factor_t[1];
 
 FLINT_DLL void nmod_poly_factor_init(nmod_poly_factor_t fac);
 
@@ -164,7 +154,7 @@ FLINT_DLL int nmod_poly_roots_factored(nmod_poly_factor_t r,
 FLINT_DLL void nmod_poly_factor_get_nmod_poly(nmod_poly_t z, nmod_poly_factor_t fac, slong i);
 
 #ifdef __cplusplus
-    }
+}
 #endif
 
 #endif

--- a/src/nmod_poly_mat.h
+++ b/src/nmod_poly_mat.h
@@ -26,21 +26,8 @@
 #include "nmod_mat.h"
 
 #ifdef __cplusplus
- extern "C" {
+extern "C" {
 #endif
-
-/* Types *********************************************************************/
-
-typedef struct
-{
-    nmod_poly_struct * entries;
-    slong r;
-    slong c;
-    nmod_poly_struct ** rows;
-    mp_limb_t modulus;
-} nmod_poly_mat_struct;
-
-typedef nmod_poly_mat_struct nmod_poly_mat_t[1];
 
 NMOD_POLY_MAT_INLINE
 nmod_poly_struct * nmod_poly_mat_entry(const nmod_poly_mat_t mat, slong i, slong j)

--- a/src/nmod_types.h
+++ b/src/nmod_types.h
@@ -1,0 +1,95 @@
+/*
+    Copyright (C) 2023 Albin Ahlbäck
+
+    This file is part of FLINT.
+
+    FLINT is free software: you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License (LGPL) as published
+    by the Free Software Foundation; either version 2.1 of the License, or
+    (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+*/
+
+#ifndef NMOD_TYPES_H
+#define NMOD_TYPES_H
+
+#include "flint.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef struct
+{
+    mp_limb_t * entries;
+    slong r;
+    slong c;
+    mp_limb_t ** rows;
+    nmod_t mod;
+}
+nmod_mat_struct;
+
+typedef nmod_mat_struct nmod_mat_t[1];
+
+typedef struct
+{
+    mp_ptr coeffs;
+    slong alloc;
+    slong length;
+    nmod_t mod;
+}
+nmod_poly_struct;
+
+typedef nmod_poly_struct nmod_poly_t[1];
+
+typedef struct
+{
+    nmod_poly_struct * p;
+    slong *exp;
+    slong num;
+    slong alloc;
+}
+nmod_poly_factor_struct;
+
+typedef nmod_poly_factor_struct nmod_poly_factor_t[1];
+
+typedef struct
+{
+    nmod_poly_struct * entries;
+    slong r;
+    slong c;
+    nmod_poly_struct ** rows;
+    mp_limb_t modulus;
+}
+nmod_poly_mat_struct;
+
+typedef nmod_poly_mat_struct nmod_poly_mat_t[1];
+
+typedef struct
+{
+    mp_limb_t * coeffs;
+    ulong * exps;
+    slong length;
+    flint_bitcnt_t bits;    /* number of bits per exponent */
+    slong coeffs_alloc;     /* abs size in mp_limb_t units */
+    slong exps_alloc;       /* abs size in ulong units */
+} nmod_mpoly_struct;
+
+typedef nmod_mpoly_struct nmod_mpoly_t[1];
+
+typedef struct
+{
+    mp_limb_t constant;
+    nmod_mpoly_struct * poly;
+    fmpz * exp;
+    slong num;
+    slong alloc;
+}
+nmod_mpoly_factor_struct;
+
+typedef nmod_mpoly_factor_struct nmod_mpoly_factor_t[1];
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* NMOD_TYPES_H */

--- a/src/nmod_vec.h
+++ b/src/nmod_vec.h
@@ -29,7 +29,7 @@
 #include "nmod.h"
 
 #ifdef __cplusplus
- extern "C" {
+extern "C" {
 #endif
 
 #define NMOD_VEC_NORM(vec, i)                   \


### PR DESCRIPTION
Is this good? I did not include `fmpz_lll` as I believe that is rarely used, and could not be considered a "basic" type. I also did not include `fmpz_mod*` as I consider that another type.