### PR TITLE
Remove redefining of `ulong`

### DIFF
--- a/src/arith/inlines.c
+++ b/src/arith/inlines.c
@@ -11,7 +11,6 @@
 
 #define ARITH_INLINES_C
 
-#define ulong ulongxx /* interferes with system includes */
 #include <stdlib.h>
 #include <gmp.h>
 #include "flint.h"

--- a/src/arith/inlines.c
+++ b/src/arith/inlines.c
@@ -13,7 +13,6 @@
 
 #define ulong ulongxx /* interferes with system includes */
 #include <stdlib.h>
-#undef ulong
 #include <gmp.h>
 #include "flint.h"
 #include "arith.h"

--- a/src/d_mat.h
+++ b/src/d_mat.h
@@ -20,7 +20,6 @@
 #define D_MAT_INLINE static __inline__
 #endif
 
-#define ulong ulongxx /* interferes with system includes */
 #include <stdio.h>
 
 #include <gmp.h>

--- a/src/d_mat.h
+++ b/src/d_mat.h
@@ -20,10 +20,8 @@
 #define D_MAT_INLINE static __inline__
 #endif
 
-#undef ulong
 #define ulong ulongxx /* interferes with system includes */
 #include <stdio.h>
-#undef ulong
 
 #include <gmp.h>
 #define ulong mp_limb_t

--- a/src/d_mat.h
+++ b/src/d_mat.h
@@ -23,7 +23,6 @@
 #include <stdio.h>
 
 #include <gmp.h>
-#define ulong mp_limb_t
 #include "flint.h"
 #include "d_vec.h"
 

--- a/src/d_mat/inlines.c
+++ b/src/d_mat/inlines.c
@@ -13,7 +13,6 @@
 
 #define ulong ulongxx /* interferes with system includes */
 #include <stdlib.h>
-#undef ulong
 #include <gmp.h>
 #include "flint.h"
 #include "d_mat.h"

--- a/src/d_mat/inlines.c
+++ b/src/d_mat/inlines.c
@@ -11,7 +11,6 @@
 
 #define D_MAT_INLINES_C
 
-#define ulong ulongxx /* interferes with system includes */
 #include <stdlib.h>
 #include <gmp.h>
 #include "flint.h"

--- a/src/double_extras.h
+++ b/src/double_extras.h
@@ -18,10 +18,8 @@
 #define DOUBLE_EXTRAS_INLINE static __inline__
 #endif
 
-#undef ulong
 #define ulong ulongxx /* interferes with system includes */
 #include <math.h>
-#undef ulong
 #include <float.h>
 #include <gmp.h>
 #include "flint.h"

--- a/src/double_extras.h
+++ b/src/double_extras.h
@@ -23,7 +23,6 @@
 #include <gmp.h>
 #include "flint.h"
 
-#define ulong mp_limb_t
 
 #ifdef __cplusplus
  extern "C" {

--- a/src/double_extras.h
+++ b/src/double_extras.h
@@ -18,7 +18,6 @@
 #define DOUBLE_EXTRAS_INLINE static __inline__
 #endif
 
-#define ulong ulongxx /* interferes with system includes */
 #include <math.h>
 #include <float.h>
 #include <gmp.h>

--- a/src/double_extras/inlines.c
+++ b/src/double_extras/inlines.c
@@ -13,7 +13,6 @@
 
 #define ulong ulongxx /* interferes with system includes */
 #include <stdlib.h>
-#undef ulong
 #include <gmp.h>
 #include "flint.h"
 #include "double_extras.h"

--- a/src/double_extras/inlines.c
+++ b/src/double_extras/inlines.c
@@ -11,7 +11,6 @@
 
 #define DOUBLE_EXTRAS_INLINES_C
 
-#define ulong ulongxx /* interferes with system includes */
 #include <stdlib.h>
 #include <gmp.h>
 #include "flint.h"

--- a/src/fft.h
+++ b/src/fft.h
@@ -18,7 +18,6 @@
 #define FFT_INLINE static __inline__
 #endif
 
-#define ulong ulongxx /* interferes with system includes */
 #include <stdlib.h>
 #include <stdio.h>
 

--- a/src/fft.h
+++ b/src/fft.h
@@ -22,7 +22,6 @@
 #include <stdio.h>
 
 #include <gmp.h>
-#define ulong mp_limb_t
 #include "flint.h"
 #include "mpn_extras.h"
 

--- a/src/fft.h
+++ b/src/fft.h
@@ -18,11 +18,9 @@
 #define FFT_INLINE static __inline__
 #endif
 
-#undef ulong
 #define ulong ulongxx /* interferes with system includes */
 #include <stdlib.h>
 #include <stdio.h>
-#undef ulong
 
 #include <gmp.h>
 #define ulong mp_limb_t

--- a/src/fft/inlines.c
+++ b/src/fft/inlines.c
@@ -11,7 +11,6 @@
 
 #define FFT_INLINES_C
 
-#define ulong ulongxx /* interferes with system includes */
 #include <stdlib.h>
 #include <gmp.h>
 #include "flint.h"

--- a/src/fft/inlines.c
+++ b/src/fft/inlines.c
@@ -13,7 +13,6 @@
 
 #define ulong ulongxx /* interferes with system includes */
 #include <stdlib.h>
-#undef ulong
 #include <gmp.h>
 #include "flint.h"
 #include "fft.h"

--- a/src/flint.h
+++ b/src/flint.h
@@ -12,7 +12,6 @@
 #ifndef FLINT_H
 #define FLINT_H
 
-#undef ulong
 #define ulong ulongxx /* ensure vendor doesn't typedef ulong */
 #if !defined(_MSC_VER)
 #include <sys/param.h> /* for BSD define */
@@ -31,7 +30,6 @@
 #include "limits.h"
 #include "longlong.h"
 #include "flint-config.h"
-#undef ulong
 
 #ifdef FLINT_INLINES_C
 #define FLINT_INLINE FLINT_DLL

--- a/src/flint.h
+++ b/src/flint.h
@@ -12,7 +12,6 @@
 #ifndef FLINT_H
 #define FLINT_H
 
-#define ulong ulongxx /* ensure vendor doesn't typedef ulong */
 #if !defined(_MSC_VER)
 #include <sys/param.h> /* for BSD define */
 #endif

--- a/src/fmpq.h
+++ b/src/fmpq.h
@@ -19,7 +19,6 @@
 #define FMPQ_INLINE static __inline__
 #endif
 
-#define ulong ulongxx /* interferes with system includes */
 #include <stdio.h>
 
 #include <gmp.h>

--- a/src/fmpq.h
+++ b/src/fmpq.h
@@ -22,7 +22,6 @@
 #include <stdio.h>
 
 #include <gmp.h>
-#define ulong mp_limb_t
 #include "flint.h"
 #include "fmpz.h"
 #include "fmpz_vec.h"

--- a/src/fmpq.h
+++ b/src/fmpq.h
@@ -19,10 +19,8 @@
 #define FMPQ_INLINE static __inline__
 #endif
 
-#undef ulong
 #define ulong ulongxx /* interferes with system includes */
 #include <stdio.h>
-#undef ulong
 
 #include <gmp.h>
 #define ulong mp_limb_t

--- a/src/fmpq/inlines.c
+++ b/src/fmpq/inlines.c
@@ -13,7 +13,6 @@
 
 #define ulong ulongxx /* interferes with system includes */
 #include <stdlib.h>
-#undef ulong
 #include <gmp.h>
 #include "flint.h"
 #include "ulong_extras.h"

--- a/src/fmpq/inlines.c
+++ b/src/fmpq/inlines.c
@@ -11,7 +11,6 @@
 
 #define FMPQ_INLINES_C
 
-#define ulong ulongxx /* interferes with system includes */
 #include <stdlib.h>
 #include <gmp.h>
 #include "flint.h"

--- a/src/fmpq_mat/inlines.c
+++ b/src/fmpq_mat/inlines.c
@@ -13,7 +13,6 @@
 
 #define ulong ulongxx /* interferes with system includes */
 #include <stdlib.h>
-#undef ulong
 #include <gmp.h>
 #include "flint.h"
 #include "fmpq_mat.h"

--- a/src/fmpq_mat/inlines.c
+++ b/src/fmpq_mat/inlines.c
@@ -11,7 +11,6 @@
 
 #define FMPQ_MAT_INLINES_C
 
-#define ulong ulongxx /* interferes with system includes */
 #include <stdlib.h>
 #include <gmp.h>
 #include "flint.h"

--- a/src/fmpq_mpoly.h
+++ b/src/fmpq_mpoly.h
@@ -18,10 +18,8 @@
 #define FMPQ_MPOLY_INLINE static __inline__
 #endif
 
-#undef ulong
 #define ulong ulongxx /* interferes with system includes */
 #include <stdio.h>
-#undef ulong
 
 #include <gmp.h>
 #define ulong mp_limb_t

--- a/src/fmpq_mpoly.h
+++ b/src/fmpq_mpoly.h
@@ -18,7 +18,6 @@
 #define FMPQ_MPOLY_INLINE static __inline__
 #endif
 
-#define ulong ulongxx /* interferes with system includes */
 #include <stdio.h>
 
 #include <gmp.h>

--- a/src/fmpq_mpoly.h
+++ b/src/fmpq_mpoly.h
@@ -21,7 +21,6 @@
 #include <stdio.h>
 
 #include <gmp.h>
-#define ulong mp_limb_t
 
 #include "fmpq_poly.h"
 #include "fmpz_mpoly.h"

--- a/src/fmpq_mpoly/inlines.c
+++ b/src/fmpq_mpoly/inlines.c
@@ -11,7 +11,6 @@
 
 #define FMPQ_MPOLY_INLINES_C
 
-#define ulong ulongxx /* interferes with system includes */
 #include <stdlib.h>
 #include <stdio.h>
 #include <gmp.h>

--- a/src/fmpq_mpoly/inlines.c
+++ b/src/fmpq_mpoly/inlines.c
@@ -14,7 +14,6 @@
 #define ulong ulongxx /* interferes with system includes */
 #include <stdlib.h>
 #include <stdio.h>
-#undef ulong
 #include <gmp.h>
 #include "flint.h"
 #include "ulong_extras.h"

--- a/src/fmpq_mpoly_factor.h
+++ b/src/fmpq_mpoly_factor.h
@@ -20,7 +20,6 @@
 
 #include <stdio.h>
 #include <gmp.h>
-#define ulong mp_limb_t
 
 #include "fmpq_mpoly.h"
 #include "fmpz_mpoly_factor.h"

--- a/src/fmpq_mpoly_factor.h
+++ b/src/fmpq_mpoly_factor.h
@@ -18,7 +18,6 @@
 #define FMPQ_MPOLY_FACTOR_INLINE static __inline__
 #endif
 
-#define ulong ulongxx /* interferes with system includes */
 #include <stdio.h>
 #include <gmp.h>
 #define ulong mp_limb_t

--- a/src/fmpq_mpoly_factor.h
+++ b/src/fmpq_mpoly_factor.h
@@ -18,10 +18,8 @@
 #define FMPQ_MPOLY_FACTOR_INLINE static __inline__
 #endif
 
-#undef ulong
 #define ulong ulongxx /* interferes with system includes */
 #include <stdio.h>
-#undef ulong
 #include <gmp.h>
 #define ulong mp_limb_t
 

--- a/src/fmpq_mpoly_factor/inlines.c
+++ b/src/fmpq_mpoly_factor/inlines.c
@@ -11,7 +11,6 @@
 
 #define FMPQ_MPOLY_FACTOR_INLINES_C
 
-#define ulong ulongxx /* interferes with system includes */
 #include <stdlib.h>
 #include <stdio.h>
 #include <gmp.h>

--- a/src/fmpq_mpoly_factor/inlines.c
+++ b/src/fmpq_mpoly_factor/inlines.c
@@ -14,7 +14,6 @@
 #define ulong ulongxx /* interferes with system includes */
 #include <stdlib.h>
 #include <stdio.h>
-#undef ulong
 #include <gmp.h>
 #include "flint.h"
 #include "ulong_extras.h"

--- a/src/fmpq_poly/inlines.c
+++ b/src/fmpq_poly/inlines.c
@@ -14,7 +14,6 @@
 #define ulong ulongxx /* interferes with system includes */
 #include <stdlib.h>
 #include <stdio.h>
-#undef ulong
 #include <gmp.h>
 #include "flint.h"
 #include "ulong_extras.h"

--- a/src/fmpq_poly/inlines.c
+++ b/src/fmpq_poly/inlines.c
@@ -11,7 +11,6 @@
 
 #define FMPQ_POLY_INLINES_C
 
-#define ulong ulongxx /* interferes with system includes */
 #include <stdlib.h>
 #include <stdio.h>
 #include <gmp.h>

--- a/src/fmpz.h
+++ b/src/fmpz.h
@@ -18,11 +18,9 @@
 #define FMPZ_INLINE static __inline__
 #endif
 
-#undef ulong
 #define ulong ulongxx/* interferes with system includes */
 #include <stdlib.h>
 #include <stdio.h>
-#undef ulong
 
 #include <gmp.h>
 #define ulong mp_limb_t

--- a/src/fmpz.h
+++ b/src/fmpz.h
@@ -18,7 +18,6 @@
 #define FMPZ_INLINE static __inline__
 #endif
 
-#define ulong ulongxx/* interferes with system includes */
 #include <stdlib.h>
 #include <stdio.h>
 

--- a/src/fmpz.h
+++ b/src/fmpz.h
@@ -22,7 +22,6 @@
 #include <stdio.h>
 
 #include <gmp.h>
-#define ulong mp_limb_t
 
 #include "flint.h"
 #include "fmpz_types.h"

--- a/src/fmpz/divisor_in_residue_class_lenstra.c
+++ b/src/fmpz/divisor_in_residue_class_lenstra.c
@@ -12,7 +12,6 @@
 #define ulong ulongxx /* interferes with system includes */
 #include <stdlib.h>
 #include <stdio.h>
-#undef ulong
 #define ulong mp_limb_t
 #include <gmp.h>
 #include "flint.h"

--- a/src/fmpz/divisor_in_residue_class_lenstra.c
+++ b/src/fmpz/divisor_in_residue_class_lenstra.c
@@ -9,7 +9,6 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
-#define ulong ulongxx /* interferes with system includes */
 #include <stdlib.h>
 #include <stdio.h>
 #define ulong mp_limb_t

--- a/src/fmpz/divisor_in_residue_class_lenstra.c
+++ b/src/fmpz/divisor_in_residue_class_lenstra.c
@@ -11,7 +11,6 @@
 
 #include <stdlib.h>
 #include <stdio.h>
-#define ulong mp_limb_t
 #include <gmp.h>
 #include "flint.h"
 #include "ulong_extras.h"

--- a/src/fmpz/inlines.c
+++ b/src/fmpz/inlines.c
@@ -11,7 +11,6 @@
 
 #define FMPZ_INLINES_C
 
-#define ulong ulongxx /* interferes with system includes */
 #include <stdlib.h>
 #include <gmp.h>
 #include "flint.h"

--- a/src/fmpz/inlines.c
+++ b/src/fmpz/inlines.c
@@ -13,7 +13,6 @@
 
 #define ulong ulongxx /* interferes with system includes */
 #include <stdlib.h>
-#undef ulong
 #include <gmp.h>
 #include "flint.h"
 #include "gmpcompat.h"

--- a/src/fmpz/is_perfect_power.c
+++ b/src/fmpz/is_perfect_power.c
@@ -42,7 +42,6 @@ MA 02110-1301, USA. */
 */
 
 #include <gmp.h>
-#define ulong ulongxx /* interferes with system includes */
 #include <stdio.h> /* for NULL */
 #include "flint.h"
 #include "ulong_extras.h"

--- a/src/fmpz/is_perfect_power.c
+++ b/src/fmpz/is_perfect_power.c
@@ -44,7 +44,6 @@ MA 02110-1301, USA. */
 #include <gmp.h>
 #define ulong ulongxx /* interferes with system includes */
 #include <stdio.h> /* for NULL */
-#undef ulong
 #include "flint.h"
 #include "ulong_extras.h"
 #include "fmpz.h"

--- a/src/fmpz/is_prime.c
+++ b/src/fmpz/is_prime.c
@@ -10,7 +10,6 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
-#define ulong ulongxx /* interferes with system includes */
 #include <stdlib.h>
 #include <stdio.h>
 #include <math.h>

--- a/src/fmpz/is_prime.c
+++ b/src/fmpz/is_prime.c
@@ -14,7 +14,6 @@
 #include <stdlib.h>
 #include <stdio.h>
 #include <math.h>
-#undef ulong
 #define ulong mp_limb_t
 #include <gmp.h>
 #include "flint.h"

--- a/src/fmpz/is_prime.c
+++ b/src/fmpz/is_prime.c
@@ -13,7 +13,6 @@
 #include <stdlib.h>
 #include <stdio.h>
 #include <math.h>
-#define ulong mp_limb_t
 #include <gmp.h>
 #include "flint.h"
 #include "ulong_extras.h"

--- a/src/fmpz/is_prime_morrison.c
+++ b/src/fmpz/is_prime_morrison.c
@@ -12,7 +12,6 @@
 #include <stdlib.h>
 #include <stdio.h>
 #include <time.h>
-#define ulong mp_limb_t
 #include <gmp.h>
 #include "flint.h"
 #include "ulong_extras.h"

--- a/src/fmpz/is_prime_morrison.c
+++ b/src/fmpz/is_prime_morrison.c
@@ -13,7 +13,6 @@
 #include <stdlib.h>
 #include <stdio.h>
 #include <time.h>
-#undef ulong
 #define ulong mp_limb_t
 #include <gmp.h>
 #include "flint.h"

--- a/src/fmpz/is_prime_morrison.c
+++ b/src/fmpz/is_prime_morrison.c
@@ -9,7 +9,6 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
-#define ulong ulongxx /* interferes with system includes */
 #include <stdlib.h>
 #include <stdio.h>
 #include <time.h>

--- a/src/fmpz/is_prime_pocklington.c
+++ b/src/fmpz/is_prime_pocklington.c
@@ -12,7 +12,6 @@
 #include <stdlib.h>
 #include <stdio.h>
 #include <time.h>
-#define ulong mp_limb_t
 #include <gmp.h>
 #include "flint.h"
 #include "ulong_extras.h"

--- a/src/fmpz/is_prime_pocklington.c
+++ b/src/fmpz/is_prime_pocklington.c
@@ -13,7 +13,6 @@
 #include <stdlib.h>
 #include <stdio.h>
 #include <time.h>
-#undef ulong
 #define ulong mp_limb_t
 #include <gmp.h>
 #include "flint.h"

--- a/src/fmpz/is_prime_pocklington.c
+++ b/src/fmpz/is_prime_pocklington.c
@@ -9,7 +9,6 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
-#define ulong ulongxx /* interferes with system includes */
 #include <stdlib.h>
 #include <stdio.h>
 #include <time.h>

--- a/src/fmpz/is_prime_pseudosquare.c
+++ b/src/fmpz/is_prime_pseudosquare.c
@@ -12,7 +12,6 @@
 #define ulong ulongxx /* interferes with system includes */
 #include <stdlib.h>
 #include <stdio.h>
-#undef ulong
 #define ulong mp_limb_t
 #include <gmp.h>
 #include "flint.h"

--- a/src/fmpz/is_prime_pseudosquare.c
+++ b/src/fmpz/is_prime_pseudosquare.c
@@ -9,7 +9,6 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
-#define ulong ulongxx /* interferes with system includes */
 #include <stdlib.h>
 #include <stdio.h>
 #define ulong mp_limb_t

--- a/src/fmpz/is_prime_pseudosquare.c
+++ b/src/fmpz/is_prime_pseudosquare.c
@@ -11,7 +11,6 @@
 
 #include <stdlib.h>
 #include <stdio.h>
-#define ulong mp_limb_t
 #include <gmp.h>
 #include "flint.h"
 #include "ulong_extras.h"

--- a/src/fmpz/is_probabprime_BPSW.c
+++ b/src/fmpz/is_probabprime_BPSW.c
@@ -14,7 +14,6 @@
 #include <stdio.h>
 #include <math.h>
 #include <assert.h>
-#undef ulong
 #define ulong mp_limb_t
 #include <gmp.h>
 #include "flint.h"

--- a/src/fmpz/is_probabprime_BPSW.c
+++ b/src/fmpz/is_probabprime_BPSW.c
@@ -9,7 +9,6 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
-#define ulong ulongxx /* interferes with system includes */
 #include <stdlib.h>
 #include <stdio.h>
 #include <math.h>

--- a/src/fmpz/is_probabprime_BPSW.c
+++ b/src/fmpz/is_probabprime_BPSW.c
@@ -13,7 +13,6 @@
 #include <stdio.h>
 #include <math.h>
 #include <assert.h>
-#define ulong mp_limb_t
 #include <gmp.h>
 #include "flint.h"
 #include "ulong_extras.h"

--- a/src/fmpz/is_probabprime_lucas.c
+++ b/src/fmpz/is_probabprime_lucas.c
@@ -14,7 +14,6 @@
 #include <stdio.h>
 #include <math.h>
 #include <assert.h>
-#undef ulong
 #define ulong mp_limb_t
 #include <gmp.h>
 #include "flint.h"

--- a/src/fmpz/is_probabprime_lucas.c
+++ b/src/fmpz/is_probabprime_lucas.c
@@ -9,7 +9,6 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
-#define ulong ulongxx /* interferes with system includes */
 #include <stdlib.h>
 #include <stdio.h>
 #include <math.h>

--- a/src/fmpz/is_probabprime_lucas.c
+++ b/src/fmpz/is_probabprime_lucas.c
@@ -13,7 +13,6 @@
 #include <stdio.h>
 #include <math.h>
 #include <assert.h>
-#define ulong mp_limb_t
 #include <gmp.h>
 #include "flint.h"
 #include "ulong_extras.h"

--- a/src/fmpz/is_strong_probabprime.c
+++ b/src/fmpz/is_strong_probabprime.c
@@ -14,7 +14,6 @@
 #include <stdio.h>
 #include <math.h>
 #include <assert.h>
-#undef ulong
 #define ulong mp_limb_t
 #include <gmp.h>
 #include "flint.h"

--- a/src/fmpz/is_strong_probabprime.c
+++ b/src/fmpz/is_strong_probabprime.c
@@ -9,7 +9,6 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
-#define ulong ulongxx /* interferes with system includes */
 #include <stdlib.h>
 #include <stdio.h>
 #include <math.h>

--- a/src/fmpz/is_strong_probabprime.c
+++ b/src/fmpz/is_strong_probabprime.c
@@ -13,7 +13,6 @@
 #include <stdio.h>
 #include <math.h>
 #include <assert.h>
-#define ulong mp_limb_t
 #include <gmp.h>
 #include "flint.h"
 #include "ulong_extras.h"

--- a/src/fmpz/lucas_chain.c
+++ b/src/fmpz/lucas_chain.c
@@ -13,7 +13,6 @@
 #include <stdlib.h>
 #include <stdio.h>
 #include <math.h>
-#undef ulong
 #define ulong mp_limb_t
 #include <gmp.h>
 #include "flint.h"

--- a/src/fmpz/lucas_chain.c
+++ b/src/fmpz/lucas_chain.c
@@ -12,7 +12,6 @@
 #include <stdlib.h>
 #include <stdio.h>
 #include <math.h>
-#define ulong mp_limb_t
 #include <gmp.h>
 #include "flint.h"
 #include "ulong_extras.h"

--- a/src/fmpz/lucas_chain.c
+++ b/src/fmpz/lucas_chain.c
@@ -9,7 +9,6 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
-#define ulong ulongxx /* interferes with system includes */
 #include <stdlib.h>
 #include <stdio.h>
 #include <math.h>

--- a/src/fmpz/root.c
+++ b/src/fmpz/root.c
@@ -10,7 +10,6 @@
 */
 
 #include <stdlib.h>
-#define ulong mp_limb_t
 
 #include <gmp.h>
 #include "flint.h"

--- a/src/fmpz/root.c
+++ b/src/fmpz/root.c
@@ -11,7 +11,6 @@
 
 #define ulong ulongxx /* interferes with system includes */
 #include <stdlib.h>
-#undef ulong
 #define ulong mp_limb_t
 
 #include <gmp.h>

--- a/src/fmpz/root.c
+++ b/src/fmpz/root.c
@@ -9,7 +9,6 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
-#define ulong ulongxx /* interferes with system includes */
 #include <stdlib.h>
 #define ulong mp_limb_t
 

--- a/src/fmpz/test/t-out_inp_raw.c
+++ b/src/fmpz/test/t-out_inp_raw.c
@@ -15,7 +15,6 @@
 #undef __STRICT_ANSI__
 #endif
 
-#define ulong ulongxx /* interferes with standard libraries */
 #include <sys/types.h>
 #if (!defined (__WIN32) || defined(__CYGWIN__)) && !defined(_MSC_VER) 
 #include <unistd.h>

--- a/src/fmpz/test/t-out_inp_raw.c
+++ b/src/fmpz/test/t-out_inp_raw.c
@@ -15,7 +15,6 @@
 #undef __STRICT_ANSI__
 #endif
 
-#undef ulong
 #define ulong ulongxx /* interferes with standard libraries */
 #include <sys/types.h>
 #if (!defined (__WIN32) || defined(__CYGWIN__)) && !defined(_MSC_VER) 
@@ -24,7 +23,6 @@
 #include <stdio.h>
 #include <stdlib.h>
 
-#undef ulong
 #include <gmp.h>
 #define ulong mp_limb_t
 

--- a/src/fmpz/test/t-out_inp_raw.c
+++ b/src/fmpz/test/t-out_inp_raw.c
@@ -23,7 +23,6 @@
 #include <stdlib.h>
 
 #include <gmp.h>
-#define ulong mp_limb_t
 
 #include "flint.h"
 #include "fmpz.h"

--- a/src/fmpz_factor/factor_pp1.c
+++ b/src/fmpz_factor/factor_pp1.c
@@ -11,7 +11,6 @@
 
 #define ulong ulongxx /* interferes with system includes */
 #include <string.h>
-#undef ulong
 #define ulong mp_limb_t
 #include <gmp.h>
 #include "flint.h"

--- a/src/fmpz_factor/factor_pp1.c
+++ b/src/fmpz_factor/factor_pp1.c
@@ -10,7 +10,6 @@
 */
 
 #include <string.h>
-#define ulong mp_limb_t
 #include <gmp.h>
 #include "flint.h"
 #include "fmpz.h"

--- a/src/fmpz_factor/factor_pp1.c
+++ b/src/fmpz_factor/factor_pp1.c
@@ -9,7 +9,6 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
-#define ulong ulongxx /* interferes with system includes */
 #include <string.h>
 #define ulong mp_limb_t
 #include <gmp.h>

--- a/src/fmpz_factor/inlines.c
+++ b/src/fmpz_factor/inlines.c
@@ -14,7 +14,6 @@
 #define ulong ulongxx /* interferes with system includes */
 #include <stdlib.h>
 #include <stdio.h>
-#undef ulong
 #include <gmp.h>
 #include "flint.h"
 #include "fmpz.h"

--- a/src/fmpz_factor/inlines.c
+++ b/src/fmpz_factor/inlines.c
@@ -11,7 +11,6 @@
 
 #define FMPZ_FACTOR_INLINES_C
 
-#define ulong ulongxx /* interferes with system includes */
 #include <stdlib.h>
 #include <stdio.h>
 #include <gmp.h>

--- a/src/fmpz_mat.h
+++ b/src/fmpz_mat.h
@@ -19,10 +19,8 @@
 #define FMPZ_MAT_INLINE static __inline__
 #endif
 
-#undef ulong
 #define ulong ulongxx /* interferes with system includes */
 #include <stdio.h>
-#undef ulong
 
 #include <gmp.h>
 #define ulong mp_limb_t

--- a/src/fmpz_mat.h
+++ b/src/fmpz_mat.h
@@ -19,7 +19,6 @@
 #define FMPZ_MAT_INLINE static __inline__
 #endif
 
-#define ulong ulongxx /* interferes with system includes */
 #include <stdio.h>
 
 #include <gmp.h>

--- a/src/fmpz_mat.h
+++ b/src/fmpz_mat.h
@@ -22,7 +22,6 @@
 #include <stdio.h>
 
 #include <gmp.h>
-#define ulong mp_limb_t
 #include "flint.h"
 #include "fmpz.h"
 #include "fmpz_vec.h"

--- a/src/fmpz_mat/inlines.c
+++ b/src/fmpz_mat/inlines.c
@@ -11,7 +11,6 @@
 
 #define FMPZ_MAT_INLINES_C
 
-#define ulong ulongxx /* interferes with system includes */
 #include <stdlib.h>
 #include <stdio.h>
 #include <gmp.h>

--- a/src/fmpz_mat/inlines.c
+++ b/src/fmpz_mat/inlines.c
@@ -14,7 +14,6 @@
 #define ulong ulongxx /* interferes with system includes */
 #include <stdlib.h>
 #include <stdio.h>
-#undef ulong
 #include <gmp.h>
 #include "flint.h"
 #include "ulong_extras.h"

--- a/src/fmpz_mod.h
+++ b/src/fmpz_mod.h
@@ -18,10 +18,8 @@
 #define FMPZ_MOD_INLINE static __inline__
 #endif
 
-#undef ulong
 #define ulong ulongxx /* interferes with system includes */
 #include <stdio.h>
-#undef ulong
 
 #include <gmp.h>
 #define ulong mp_limb_t

--- a/src/fmpz_mod.h
+++ b/src/fmpz_mod.h
@@ -21,7 +21,6 @@
 #include <stdio.h>
 
 #include <gmp.h>
-#define ulong mp_limb_t
 
 #include "flint.h"
 #include "nmod_vec.h"

--- a/src/fmpz_mod.h
+++ b/src/fmpz_mod.h
@@ -18,7 +18,6 @@
 #define FMPZ_MOD_INLINE static __inline__
 #endif
 
-#define ulong ulongxx /* interferes with system includes */
 #include <stdio.h>
 
 #include <gmp.h>

--- a/src/fmpz_mod/inlines.c
+++ b/src/fmpz_mod/inlines.c
@@ -14,7 +14,6 @@
 #define ulong ulongxx /* interferes with system includes */
 #include <stdlib.h>
 #include <stdio.h>
-#undef ulong
 #include <gmp.h>
 #include "flint.h"
 #include "fmpz_mod.h"

--- a/src/fmpz_mod/inlines.c
+++ b/src/fmpz_mod/inlines.c
@@ -11,7 +11,6 @@
 
 #define FMPZ_MOD_INLINES_C
 
-#define ulong ulongxx /* interferes with system includes */
 #include <stdlib.h>
 #include <stdio.h>
 #include <gmp.h>

--- a/src/fmpz_mod_mat/inlines.c
+++ b/src/fmpz_mod_mat/inlines.c
@@ -12,7 +12,6 @@
 
 #define FMPZ_MOD_MAT_INLINES_C
 
-#define ulong ulongxx /* interferes with system includes */
 #include <stdlib.h>
 #include <gmp.h>
 #include "flint.h"

--- a/src/fmpz_mod_mat/inlines.c
+++ b/src/fmpz_mod_mat/inlines.c
@@ -14,7 +14,6 @@
 
 #define ulong ulongxx /* interferes with system includes */
 #include <stdlib.h>
-#undef ulong
 #include <gmp.h>
 #include "flint.h"
 #include "ulong_extras.h"

--- a/src/fmpz_mod_mpoly.h
+++ b/src/fmpz_mod_mpoly.h
@@ -18,7 +18,6 @@
 #define FMPZ_MOD_MPOLY_INLINE static __inline__
 #endif
 
-#define ulong ulongxx /* interferes with system includes */
 #include <stdio.h>
 
 #include <gmp.h>

--- a/src/fmpz_mod_mpoly.h
+++ b/src/fmpz_mod_mpoly.h
@@ -21,7 +21,6 @@
 #include <stdio.h>
 
 #include <gmp.h>
-#define ulong mp_limb_t
 
 #include "flint.h"
 #include "fmpz_mod.h"

--- a/src/fmpz_mod_mpoly.h
+++ b/src/fmpz_mod_mpoly.h
@@ -18,10 +18,8 @@
 #define FMPZ_MOD_MPOLY_INLINE static __inline__
 #endif
 
-#undef ulong
 #define ulong ulongxx /* interferes with system includes */
 #include <stdio.h>
-#undef ulong
 
 #include <gmp.h>
 #define ulong mp_limb_t

--- a/src/fmpz_mod_mpoly/inlines.c
+++ b/src/fmpz_mod_mpoly/inlines.c
@@ -11,7 +11,6 @@
 
 #define FMPZ_MOD_MPOLY_INLINES_C
 
-#define ulong ulongxx /* interferes with system includes */
 #include <stdlib.h>
 #include <stdio.h>
 #include <gmp.h>

--- a/src/fmpz_mod_mpoly/inlines.c
+++ b/src/fmpz_mod_mpoly/inlines.c
@@ -14,7 +14,6 @@
 #define ulong ulongxx /* interferes with system includes */
 #include <stdlib.h>
 #include <stdio.h>
-#undef ulong
 #include <gmp.h>
 #include "flint.h"
 #include "ulong_extras.h"

--- a/src/fmpz_mod_mpoly_factor.h
+++ b/src/fmpz_mod_mpoly_factor.h
@@ -18,10 +18,8 @@
 #define FMPZ_MOD_MPOLY_FACTOR_INLINE static __inline__
 #endif
 
-#undef ulong
 #define ulong ulongxx /* interferes with system includes */
 #include <stdio.h>
-#undef ulong
 #include <gmp.h>
 #define ulong mp_limb_t
 

--- a/src/fmpz_mod_mpoly_factor.h
+++ b/src/fmpz_mod_mpoly_factor.h
@@ -18,7 +18,6 @@
 #define FMPZ_MOD_MPOLY_FACTOR_INLINE static __inline__
 #endif
 
-#define ulong ulongxx /* interferes with system includes */
 #include <stdio.h>
 #include <gmp.h>
 #define ulong mp_limb_t

--- a/src/fmpz_mod_mpoly_factor.h
+++ b/src/fmpz_mod_mpoly_factor.h
@@ -20,7 +20,6 @@
 
 #include <stdio.h>
 #include <gmp.h>
-#define ulong mp_limb_t
 
 #include "n_poly.h"
 #include "nmod_mpoly_factor.h"

--- a/src/fmpz_mod_mpoly_factor/inlines.c
+++ b/src/fmpz_mod_mpoly_factor/inlines.c
@@ -14,7 +14,6 @@
 #define ulong ulongxx /* interferes with system includes */
 #include <stdlib.h>
 #include <stdio.h>
-#undef ulong
 #include <gmp.h>
 #include "flint.h"
 #include "ulong_extras.h"

--- a/src/fmpz_mod_mpoly_factor/inlines.c
+++ b/src/fmpz_mod_mpoly_factor/inlines.c
@@ -11,7 +11,6 @@
 
 #define FMPZ_MOD_MPOLY_FACTOR_INLINES_C
 
-#define ulong ulongxx /* interferes with system includes */
 #include <stdlib.h>
 #include <stdio.h>
 #include <gmp.h>

--- a/src/fmpz_mod_poly.h
+++ b/src/fmpz_mod_poly.h
@@ -19,7 +19,6 @@
 #define FMPZ_MOD_POLY_INLINE static __inline__
 #endif
 
-#define ulong ulongxx /* interferes with system includes */
 #include <stdio.h>
 #include <gmp.h>
 #define ulong mp_limb_t

--- a/src/fmpz_mod_poly.h
+++ b/src/fmpz_mod_poly.h
@@ -19,10 +19,8 @@
 #define FMPZ_MOD_POLY_INLINE static __inline__
 #endif
 
-#undef ulong
 #define ulong ulongxx /* interferes with system includes */
 #include <stdio.h>
-#undef ulong
 #include <gmp.h>
 #define ulong mp_limb_t
 

--- a/src/fmpz_mod_poly.h
+++ b/src/fmpz_mod_poly.h
@@ -21,7 +21,6 @@
 
 #include <stdio.h>
 #include <gmp.h>
-#define ulong mp_limb_t
 
 #include "flint.h"
 #include "fmpz.h"

--- a/src/fmpz_mod_poly/div_newton_n_preinv.c
+++ b/src/fmpz_mod_poly/div_newton_n_preinv.c
@@ -11,12 +11,10 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
-#undef ulong
 #define ulong ulongxx/* interferes with system includes */
 
 #include <stdlib.h>
 
-#undef ulong
 
 #include <gmp.h>
 

--- a/src/fmpz_mod_poly/div_newton_n_preinv.c
+++ b/src/fmpz_mod_poly/div_newton_n_preinv.c
@@ -11,7 +11,6 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
-#define ulong ulongxx/* interferes with system includes */
 
 #include <stdlib.h>
 

--- a/src/fmpz_mod_poly/div_newton_n_preinv.c
+++ b/src/fmpz_mod_poly/div_newton_n_preinv.c
@@ -17,7 +17,6 @@
 
 #include <gmp.h>
 
-#define ulong mp_limb_t
 
 #include "fmpz_vec.h"
 #include "fmpz_mod_poly.h"

--- a/src/fmpz_mod_poly/divrem_newton_n_preinv.c
+++ b/src/fmpz_mod_poly/divrem_newton_n_preinv.c
@@ -9,12 +9,10 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
-#undef ulong
 #define ulong ulongxx/* interferes with system includes */
 
 #include <stdlib.h>
 
-#undef ulong
 
 #include <gmp.h>
 

--- a/src/fmpz_mod_poly/divrem_newton_n_preinv.c
+++ b/src/fmpz_mod_poly/divrem_newton_n_preinv.c
@@ -15,7 +15,6 @@
 
 #include <gmp.h>
 
-#define ulong mp_limb_t
 
 #include "fmpz_vec.h"
 #include "fmpz_mod_poly.h"

--- a/src/fmpz_mod_poly/divrem_newton_n_preinv.c
+++ b/src/fmpz_mod_poly/divrem_newton_n_preinv.c
@@ -9,7 +9,6 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
-#define ulong ulongxx/* interferes with system includes */
 
 #include <stdlib.h>
 

--- a/src/fmpz_mod_poly/inlines.c
+++ b/src/fmpz_mod_poly/inlines.c
@@ -14,7 +14,6 @@
 #define ulong ulongxx /* interferes with system includes */
 #include <stdlib.h>
 #include <stdio.h>
-#undef ulong
 #include <gmp.h>
 #include "flint.h"
 #include "ulong_extras.h"

--- a/src/fmpz_mod_poly/inlines.c
+++ b/src/fmpz_mod_poly/inlines.c
@@ -11,7 +11,6 @@
 
 #define FMPZ_MOD_POLY_INLINES_C
 
-#define ulong ulongxx /* interferes with system includes */
 #include <stdlib.h>
 #include <stdio.h>
 #include <gmp.h>

--- a/src/fmpz_mod_poly/mulmod_preinv.c
+++ b/src/fmpz_mod_poly/mulmod_preinv.c
@@ -11,12 +11,10 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
-#undef ulong
 #define ulong ulongxx/* interferes with system includes */
 
 #include <stdlib.h>
 
-#undef ulong
 
 #include <gmp.h>
 

--- a/src/fmpz_mod_poly/mulmod_preinv.c
+++ b/src/fmpz_mod_poly/mulmod_preinv.c
@@ -17,7 +17,6 @@
 
 #include <gmp.h>
 
-#define ulong mp_limb_t
 
 #include "flint.h"
 #include "fmpz_vec.h"

--- a/src/fmpz_mod_poly/mulmod_preinv.c
+++ b/src/fmpz_mod_poly/mulmod_preinv.c
@@ -11,7 +11,6 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
-#define ulong ulongxx/* interferes with system includes */
 
 #include <stdlib.h>
 

--- a/src/fmpz_mod_poly/powmod_fmpz_binexp_preinv.c
+++ b/src/fmpz_mod_poly/powmod_fmpz_binexp_preinv.c
@@ -19,7 +19,6 @@
 
 #include <gmp.h>
 
-#define ulong mp_limb_t
 
 #include "flint.h"
 #include "fmpz_vec.h"

--- a/src/fmpz_mod_poly/powmod_fmpz_binexp_preinv.c
+++ b/src/fmpz_mod_poly/powmod_fmpz_binexp_preinv.c
@@ -13,7 +13,6 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
-#define ulong ulongxx/* interferes with system includes */
 
 #include <stdlib.h>
 

--- a/src/fmpz_mod_poly/powmod_fmpz_binexp_preinv.c
+++ b/src/fmpz_mod_poly/powmod_fmpz_binexp_preinv.c
@@ -13,12 +13,10 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
-#undef ulong
 #define ulong ulongxx/* interferes with system includes */
 
 #include <stdlib.h>
 
-#undef ulong
 
 #include <gmp.h>
 

--- a/src/fmpz_mod_poly/powmod_ui_binexp_preinv.c
+++ b/src/fmpz_mod_poly/powmod_ui_binexp_preinv.c
@@ -19,7 +19,6 @@
 
 #include <gmp.h>
 
-#define ulong mp_limb_t
 
 #include "flint.h"
 #include "fmpz_vec.h"

--- a/src/fmpz_mod_poly/powmod_ui_binexp_preinv.c
+++ b/src/fmpz_mod_poly/powmod_ui_binexp_preinv.c
@@ -13,7 +13,6 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
-#define ulong ulongxx/* interferes with system includes */
 
 #include <stdlib.h>
 

--- a/src/fmpz_mod_poly/powmod_ui_binexp_preinv.c
+++ b/src/fmpz_mod_poly/powmod_ui_binexp_preinv.c
@@ -13,12 +13,10 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
-#undef ulong
 #define ulong ulongxx/* interferes with system includes */
 
 #include <stdlib.h>
 
-#undef ulong
 
 #include <gmp.h>
 

--- a/src/fmpz_mod_poly/powmod_x_fmpz_preinv.c
+++ b/src/fmpz_mod_poly/powmod_x_fmpz_preinv.c
@@ -19,7 +19,6 @@
 
 #include <gmp.h>
 
-#define ulong mp_limb_t
 
 #include "flint.h"
 #include "fmpz_vec.h"

--- a/src/fmpz_mod_poly/powmod_x_fmpz_preinv.c
+++ b/src/fmpz_mod_poly/powmod_x_fmpz_preinv.c
@@ -13,7 +13,6 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
-#define ulong ulongxx/* interferes with system includes */
 
 #include <stdlib.h>
 

--- a/src/fmpz_mod_poly/powmod_x_fmpz_preinv.c
+++ b/src/fmpz_mod_poly/powmod_x_fmpz_preinv.c
@@ -13,12 +13,10 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
-#undef ulong
 #define ulong ulongxx/* interferes with system includes */
 
 #include <stdlib.h>
 
-#undef ulong
 
 #include <gmp.h>
 

--- a/src/fmpz_mod_poly/test/t-compose_mod_brent_kung_precomp_preinv.c
+++ b/src/fmpz_mod_poly/test/t-compose_mod_brent_kung_precomp_preinv.c
@@ -11,7 +11,6 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
-#define ulong ulongxx/* interferes with system includes */
 
 #include <stdlib.h>
 #include <stdio.h>

--- a/src/fmpz_mod_poly/test/t-compose_mod_brent_kung_precomp_preinv.c
+++ b/src/fmpz_mod_poly/test/t-compose_mod_brent_kung_precomp_preinv.c
@@ -11,13 +11,11 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
-#undef ulong
 #define ulong ulongxx/* interferes with system includes */
 
 #include <stdlib.h>
 #include <stdio.h>
 
-#undef ulong
 
 #include <gmp.h>
 

--- a/src/fmpz_mod_poly/test/t-compose_mod_brent_kung_precomp_preinv.c
+++ b/src/fmpz_mod_poly/test/t-compose_mod_brent_kung_precomp_preinv.c
@@ -18,7 +18,6 @@
 
 #include <gmp.h>
 
-#define ulong mp_limb_t
 
 #include "flint.h"
 #include "fmpz_mod_poly.h"

--- a/src/fmpz_mod_poly/test/t-compose_mod_brent_kung_precomp_preinv_threaded.c
+++ b/src/fmpz_mod_poly/test/t-compose_mod_brent_kung_precomp_preinv_threaded.c
@@ -12,13 +12,11 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
-#undef ulong
 #define ulong ulongxx/* interferes with system includes */
 
 #include <stdlib.h>
 #include <stdio.h>
 
-#undef ulong
 
 #include <gmp.h>
 #include <pthread.h>

--- a/src/fmpz_mod_poly/test/t-compose_mod_brent_kung_precomp_preinv_threaded.c
+++ b/src/fmpz_mod_poly/test/t-compose_mod_brent_kung_precomp_preinv_threaded.c
@@ -12,7 +12,6 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
-#define ulong ulongxx/* interferes with system includes */
 
 #include <stdlib.h>
 #include <stdio.h>

--- a/src/fmpz_mod_poly/test/t-compose_mod_brent_kung_precomp_preinv_threaded.c
+++ b/src/fmpz_mod_poly/test/t-compose_mod_brent_kung_precomp_preinv_threaded.c
@@ -20,7 +20,6 @@
 #include <gmp.h>
 #include <pthread.h>
 
-#define ulong mp_limb_t
 
 #include "flint.h"
 #include "fmpz_mod_poly.h"

--- a/src/fmpz_mod_poly/test/t-compose_mod_brent_kung_preinv.c
+++ b/src/fmpz_mod_poly/test/t-compose_mod_brent_kung_preinv.c
@@ -11,7 +11,6 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
-#define ulong ulongxx/* interferes with system includes */
 
 #include <stdlib.h>
 #include <stdio.h>

--- a/src/fmpz_mod_poly/test/t-compose_mod_brent_kung_preinv.c
+++ b/src/fmpz_mod_poly/test/t-compose_mod_brent_kung_preinv.c
@@ -11,13 +11,11 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
-#undef ulong
 #define ulong ulongxx/* interferes with system includes */
 
 #include <stdlib.h>
 #include <stdio.h>
 
-#undef ulong
 
 #include <gmp.h>
 

--- a/src/fmpz_mod_poly/test/t-compose_mod_brent_kung_preinv.c
+++ b/src/fmpz_mod_poly/test/t-compose_mod_brent_kung_preinv.c
@@ -18,7 +18,6 @@
 
 #include <gmp.h>
 
-#define ulong mp_limb_t
 
 #include "flint.h"
 #include "fmpz_mod_poly.h"

--- a/src/fmpz_mod_poly/test/t-compose_mod_brent_kung_vec_preinv.c
+++ b/src/fmpz_mod_poly/test/t-compose_mod_brent_kung_vec_preinv.c
@@ -11,7 +11,6 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
-#define ulong ulongxx/* interferes with system includes */
 
 #include <stdlib.h>
 #include <stdio.h>

--- a/src/fmpz_mod_poly/test/t-compose_mod_brent_kung_vec_preinv.c
+++ b/src/fmpz_mod_poly/test/t-compose_mod_brent_kung_vec_preinv.c
@@ -11,13 +11,11 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
-#undef ulong
 #define ulong ulongxx/* interferes with system includes */
 
 #include <stdlib.h>
 #include <stdio.h>
 
-#undef ulong
 
 #include <gmp.h>
 

--- a/src/fmpz_mod_poly/test/t-compose_mod_brent_kung_vec_preinv.c
+++ b/src/fmpz_mod_poly/test/t-compose_mod_brent_kung_vec_preinv.c
@@ -18,7 +18,6 @@
 
 #include <gmp.h>
 
-#define ulong mp_limb_t
 
 #include "flint.h"
 #include "fmpz_mod_poly.h"

--- a/src/fmpz_mod_poly/test/t-compose_mod_brent_kung_vec_preinv_threaded.c
+++ b/src/fmpz_mod_poly/test/t-compose_mod_brent_kung_vec_preinv_threaded.c
@@ -19,7 +19,6 @@
 
 #include <gmp.h>
 
-#define ulong mp_limb_t
 
 #include "flint.h"
 #include "fmpz_mod_poly.h"

--- a/src/fmpz_mod_poly/test/t-compose_mod_brent_kung_vec_preinv_threaded.c
+++ b/src/fmpz_mod_poly/test/t-compose_mod_brent_kung_vec_preinv_threaded.c
@@ -12,7 +12,6 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
-#define ulong ulongxx/* interferes with system includes */
 
 #include <stdlib.h>
 #include <stdio.h>

--- a/src/fmpz_mod_poly/test/t-compose_mod_brent_kung_vec_preinv_threaded.c
+++ b/src/fmpz_mod_poly/test/t-compose_mod_brent_kung_vec_preinv_threaded.c
@@ -12,13 +12,11 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
-#undef ulong
 #define ulong ulongxx/* interferes with system includes */
 
 #include <stdlib.h>
 #include <stdio.h>
 
-#undef ulong
 
 #include <gmp.h>
 

--- a/src/fmpz_mod_poly/test/t-div_newton_n_preinv.c
+++ b/src/fmpz_mod_poly/test/t-div_newton_n_preinv.c
@@ -11,7 +11,6 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
-#define ulong ulongxx/* interferes with system includes */
 
 #include <stdlib.h>
 #include <stdio.h>

--- a/src/fmpz_mod_poly/test/t-div_newton_n_preinv.c
+++ b/src/fmpz_mod_poly/test/t-div_newton_n_preinv.c
@@ -11,13 +11,11 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
-#undef ulong
 #define ulong ulongxx/* interferes with system includes */
 
 #include <stdlib.h>
 #include <stdio.h>
 
-#undef ulong
 
 #include <gmp.h>
 

--- a/src/fmpz_mod_poly/test/t-div_newton_n_preinv.c
+++ b/src/fmpz_mod_poly/test/t-div_newton_n_preinv.c
@@ -18,7 +18,6 @@
 
 #include <gmp.h>
 
-#define ulong mp_limb_t
 
 #include "flint.h"
 #include "fmpz.h"

--- a/src/fmpz_mod_poly/test/t-divrem_newton_n_preinv.c
+++ b/src/fmpz_mod_poly/test/t-divrem_newton_n_preinv.c
@@ -11,7 +11,6 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
-#define ulong ulongxx/* interferes with system includes */
 
 #include <stdlib.h>
 #include <stdio.h>

--- a/src/fmpz_mod_poly/test/t-divrem_newton_n_preinv.c
+++ b/src/fmpz_mod_poly/test/t-divrem_newton_n_preinv.c
@@ -11,13 +11,11 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
-#undef ulong
 #define ulong ulongxx/* interferes with system includes */
 
 #include <stdlib.h>
 #include <stdio.h>
 
-#undef ulong
 
 #include <gmp.h>
 

--- a/src/fmpz_mod_poly/test/t-divrem_newton_n_preinv.c
+++ b/src/fmpz_mod_poly/test/t-divrem_newton_n_preinv.c
@@ -18,7 +18,6 @@
 
 #include <gmp.h>
 
-#define ulong mp_limb_t
 
 #include "flint.h"
 #include "fmpz.h"

--- a/src/fmpz_mod_poly/test/t-frobenius_powers_precomp.c
+++ b/src/fmpz_mod_poly/test/t-frobenius_powers_precomp.c
@@ -19,7 +19,6 @@
 
 #include <gmp.h>
 
-#define ulong mp_limb_t
 
 #include "flint.h"
 #include "fmpz_vec.h"

--- a/src/fmpz_mod_poly/test/t-frobenius_powers_precomp.c
+++ b/src/fmpz_mod_poly/test/t-frobenius_powers_precomp.c
@@ -12,7 +12,6 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
-#define ulong ulongxx/* interferes with system includes */
 
 #include <stdlib.h>
 #include <stdio.h>

--- a/src/fmpz_mod_poly/test/t-frobenius_powers_precomp.c
+++ b/src/fmpz_mod_poly/test/t-frobenius_powers_precomp.c
@@ -12,13 +12,11 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
-#undef ulong
 #define ulong ulongxx/* interferes with system includes */
 
 #include <stdlib.h>
 #include <stdio.h>
 
-#undef ulong
 
 #include <gmp.h>
 

--- a/src/fmpz_mod_poly/test/t-mulmod_preinv.c
+++ b/src/fmpz_mod_poly/test/t-mulmod_preinv.c
@@ -19,7 +19,6 @@
 
 #include <gmp.h>
 
-#define ulong mp_limb_t
 
 #include "flint.h"
 #include "fmpz.h"

--- a/src/fmpz_mod_poly/test/t-mulmod_preinv.c
+++ b/src/fmpz_mod_poly/test/t-mulmod_preinv.c
@@ -12,7 +12,6 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
-#define ulong ulongxx/* interferes with system includes */
 
 #include <stdlib.h>
 #include <stdio.h>

--- a/src/fmpz_mod_poly/test/t-mulmod_preinv.c
+++ b/src/fmpz_mod_poly/test/t-mulmod_preinv.c
@@ -12,13 +12,11 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
-#undef ulong
 #define ulong ulongxx/* interferes with system includes */
 
 #include <stdlib.h>
 #include <stdio.h>
 
-#undef ulong
 
 #include <gmp.h>
 

--- a/src/fmpz_mod_poly/test/t-powmod_fmpz_binexp_preinv.c
+++ b/src/fmpz_mod_poly/test/t-powmod_fmpz_binexp_preinv.c
@@ -19,7 +19,6 @@
 
 #include <gmp.h>
 
-#define ulong mp_limb_t
 
 #include "flint.h"
 #include "fmpz_vec.h"

--- a/src/fmpz_mod_poly/test/t-powmod_fmpz_binexp_preinv.c
+++ b/src/fmpz_mod_poly/test/t-powmod_fmpz_binexp_preinv.c
@@ -12,7 +12,6 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
-#define ulong ulongxx/* interferes with system includes */
 
 #include <stdlib.h>
 #include <stdio.h>

--- a/src/fmpz_mod_poly/test/t-powmod_fmpz_binexp_preinv.c
+++ b/src/fmpz_mod_poly/test/t-powmod_fmpz_binexp_preinv.c
@@ -12,13 +12,11 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
-#undef ulong
 #define ulong ulongxx/* interferes with system includes */
 
 #include <stdlib.h>
 #include <stdio.h>
 
-#undef ulong
 
 #include <gmp.h>
 

--- a/src/fmpz_mod_poly/test/t-powmod_ui_binexp_preinv.c
+++ b/src/fmpz_mod_poly/test/t-powmod_ui_binexp_preinv.c
@@ -19,7 +19,6 @@
 
 #include <gmp.h>
 
-#define ulong mp_limb_t
 
 #include "flint.h"
 #include "fmpz_vec.h"

--- a/src/fmpz_mod_poly/test/t-powmod_ui_binexp_preinv.c
+++ b/src/fmpz_mod_poly/test/t-powmod_ui_binexp_preinv.c
@@ -12,7 +12,6 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
-#define ulong ulongxx/* interferes with system includes */
 
 #include <stdlib.h>
 #include <stdio.h>

--- a/src/fmpz_mod_poly/test/t-powmod_ui_binexp_preinv.c
+++ b/src/fmpz_mod_poly/test/t-powmod_ui_binexp_preinv.c
@@ -12,13 +12,11 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
-#undef ulong
 #define ulong ulongxx/* interferes with system includes */
 
 #include <stdlib.h>
 #include <stdio.h>
 
-#undef ulong
 
 #include <gmp.h>
 

--- a/src/fmpz_mod_poly/test/t-powmod_x_fmpz_preinv.c
+++ b/src/fmpz_mod_poly/test/t-powmod_x_fmpz_preinv.c
@@ -19,7 +19,6 @@
 
 #include <gmp.h>
 
-#define ulong mp_limb_t
 
 #include "flint.h"
 #include "fmpz_vec.h"

--- a/src/fmpz_mod_poly/test/t-powmod_x_fmpz_preinv.c
+++ b/src/fmpz_mod_poly/test/t-powmod_x_fmpz_preinv.c
@@ -12,7 +12,6 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
-#define ulong ulongxx/* interferes with system includes */
 
 #include <stdlib.h>
 #include <stdio.h>

--- a/src/fmpz_mod_poly/test/t-powmod_x_fmpz_preinv.c
+++ b/src/fmpz_mod_poly/test/t-powmod_x_fmpz_preinv.c
@@ -12,13 +12,11 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
-#undef ulong
 #define ulong ulongxx/* interferes with system includes */
 
 #include <stdlib.h>
 #include <stdio.h>
 
-#undef ulong
 
 #include <gmp.h>
 

--- a/src/fmpz_mod_poly_factor.h
+++ b/src/fmpz_mod_poly_factor.h
@@ -19,7 +19,6 @@
 #define FMPZ_MOD_POLY_FACTOR_INLINE static __inline__
 #endif
 
-#define ulong ulongxx /* interferes with system includes */
 #include <stdio.h>
 #include <gmp.h>
 #define ulong mp_limb_t

--- a/src/fmpz_mod_poly_factor.h
+++ b/src/fmpz_mod_poly_factor.h
@@ -19,10 +19,8 @@
 #define FMPZ_MOD_POLY_FACTOR_INLINE static __inline__
 #endif
 
-#undef ulong
 #define ulong ulongxx /* interferes with system includes */
 #include <stdio.h>
-#undef ulong
 #include <gmp.h>
 #define ulong mp_limb_t
 

--- a/src/fmpz_mod_poly_factor.h
+++ b/src/fmpz_mod_poly_factor.h
@@ -21,7 +21,6 @@
 
 #include <stdio.h>
 #include <gmp.h>
-#define ulong mp_limb_t
 
 #include "flint.h"
 #include "fmpz.h"

--- a/src/fmpz_mod_poly_factor/factor_distinct_deg.c
+++ b/src/fmpz_mod_poly_factor/factor_distinct_deg.c
@@ -12,7 +12,6 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
-#define ulong ulongxx/* interferes with system includes */
 
 #include <math.h>
 

--- a/src/fmpz_mod_poly_factor/factor_distinct_deg.c
+++ b/src/fmpz_mod_poly_factor/factor_distinct_deg.c
@@ -18,7 +18,6 @@
 
 #include <gmp.h>
 
-#define ulong mp_limb_t
 
 #include "fmpz_mod_poly.h"
 

--- a/src/fmpz_mod_poly_factor/factor_distinct_deg.c
+++ b/src/fmpz_mod_poly_factor/factor_distinct_deg.c
@@ -12,12 +12,10 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
-#undef ulong
 #define ulong ulongxx/* interferes with system includes */
 
 #include <math.h>
 
-#undef ulong
 
 #include <gmp.h>
 

--- a/src/fmpz_mod_poly_factor/factor_distinct_deg_threaded.c
+++ b/src/fmpz_mod_poly_factor/factor_distinct_deg_threaded.c
@@ -11,13 +11,11 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
-#undef ulong
 #define ulong ulongxx/* interferes with system includes */
 
 #include <math.h>
 #include <pthread.h>
 
-#undef ulong
 
 #include <gmp.h>
 

--- a/src/fmpz_mod_poly_factor/factor_distinct_deg_threaded.c
+++ b/src/fmpz_mod_poly_factor/factor_distinct_deg_threaded.c
@@ -18,7 +18,6 @@
 
 #include <gmp.h>
 
-#define ulong mp_limb_t
 
 #include "fmpz_mod_poly.h"
 #include "thread_support.h"

--- a/src/fmpz_mod_poly_factor/factor_distinct_deg_threaded.c
+++ b/src/fmpz_mod_poly_factor/factor_distinct_deg_threaded.c
@@ -11,7 +11,6 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
-#define ulong ulongxx/* interferes with system includes */
 
 #include <math.h>
 #include <pthread.h>

--- a/src/fmpz_mod_poly_factor/inlines.c
+++ b/src/fmpz_mod_poly_factor/inlines.c
@@ -11,7 +11,6 @@
 
 #define FMPZ_MOD_POLY_FACTOR_INLINES_C
 
-#define ulong ulongxx /* interferes with system includes */
 #include <stdlib.h>
 #include <stdio.h>
 #include <gmp.h>

--- a/src/fmpz_mod_poly_factor/inlines.c
+++ b/src/fmpz_mod_poly_factor/inlines.c
@@ -14,7 +14,6 @@
 #define ulong ulongxx /* interferes with system includes */
 #include <stdlib.h>
 #include <stdio.h>
-#undef ulong
 #include <gmp.h>
 #include "flint.h"
 #include "ulong_extras.h"

--- a/src/fmpz_mod_poly_factor/is_irreducible_ddf.c
+++ b/src/fmpz_mod_poly_factor/is_irreducible_ddf.c
@@ -11,7 +11,6 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
-#define ulong ulongxx/* interferes with system includes */
 
 #include <math.h>
 

--- a/src/fmpz_mod_poly_factor/is_irreducible_ddf.c
+++ b/src/fmpz_mod_poly_factor/is_irreducible_ddf.c
@@ -11,12 +11,10 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
-#undef ulong
 #define ulong ulongxx/* interferes with system includes */
 
 #include <math.h>
 
-#undef ulong
 
 #include <gmp.h>
 

--- a/src/fmpz_mod_poly_factor/is_irreducible_ddf.c
+++ b/src/fmpz_mod_poly_factor/is_irreducible_ddf.c
@@ -17,7 +17,6 @@
 
 #include <gmp.h>
 
-#define ulong mp_limb_t
 
 #include "fmpz_mod_poly.h"
 

--- a/src/fmpz_mod_poly_factor/test/t-interval_threaded.c
+++ b/src/fmpz_mod_poly_factor/test/t-interval_threaded.c
@@ -10,13 +10,11 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
-#undef ulong
 #define ulong ulongxx/* interferes with system includes */
 
 #include <stdlib.h>
 #include <stdio.h>
 
-#undef ulong
 
 #include <gmp.h>
 #include <pthread.h>

--- a/src/fmpz_mod_poly_factor/test/t-interval_threaded.c
+++ b/src/fmpz_mod_poly_factor/test/t-interval_threaded.c
@@ -18,7 +18,6 @@
 #include <gmp.h>
 #include <pthread.h>
 
-#define ulong mp_limb_t
 
 #include "flint.h"
 #include "fmpz_mod_poly.h"

--- a/src/fmpz_mod_poly_factor/test/t-interval_threaded.c
+++ b/src/fmpz_mod_poly_factor/test/t-interval_threaded.c
@@ -10,7 +10,6 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
-#define ulong ulongxx/* interferes with system includes */
 
 #include <stdlib.h>
 #include <stdio.h>

--- a/src/fmpz_mpoly.h
+++ b/src/fmpz_mpoly.h
@@ -19,7 +19,6 @@
 #define FMPZ_MPOLY_INLINE static __inline__
 #endif
 
-#define ulong ulongxx /* interferes with system includes */
 #include <stdio.h>
 
 #include <gmp.h>

--- a/src/fmpz_mpoly.h
+++ b/src/fmpz_mpoly.h
@@ -22,7 +22,6 @@
 #include <stdio.h>
 
 #include <gmp.h>
-#define ulong mp_limb_t
 
 #include "flint.h"
 #include "fmpz.h"

--- a/src/fmpz_mpoly.h
+++ b/src/fmpz_mpoly.h
@@ -19,10 +19,8 @@
 #define FMPZ_MPOLY_INLINE static __inline__
 #endif
 
-#undef ulong
 #define ulong ulongxx /* interferes with system includes */
 #include <stdio.h>
-#undef ulong
 
 #include <gmp.h>
 #define ulong mp_limb_t

--- a/src/fmpz_mpoly/inlines.c
+++ b/src/fmpz_mpoly/inlines.c
@@ -11,7 +11,6 @@
 
 #define FMPZ_MPOLY_INLINES_C
 
-#define ulong ulongxx /* interferes with system includes */
 #include <stdlib.h>
 #include <stdio.h>
 #include <gmp.h>

--- a/src/fmpz_mpoly/inlines.c
+++ b/src/fmpz_mpoly/inlines.c
@@ -14,7 +14,6 @@
 #define ulong ulongxx /* interferes with system includes */
 #include <stdlib.h>
 #include <stdio.h>
-#undef ulong
 #include <gmp.h>
 #include "flint.h"
 #include "ulong_extras.h"

--- a/src/fmpz_mpoly_factor.h
+++ b/src/fmpz_mpoly_factor.h
@@ -20,7 +20,6 @@
 
 #include <stdio.h>
 #include <gmp.h>
-#define ulong mp_limb_t
 
 #include "fmpz_mpoly.h"
 #include "fmpq_poly.h"

--- a/src/fmpz_mpoly_factor.h
+++ b/src/fmpz_mpoly_factor.h
@@ -18,7 +18,6 @@
 #define FMPZ_MPOLY_FACTOR_INLINE static __inline__
 #endif
 
-#define ulong ulongxx /* interferes with system includes */
 #include <stdio.h>
 #include <gmp.h>
 #define ulong mp_limb_t

--- a/src/fmpz_mpoly_factor.h
+++ b/src/fmpz_mpoly_factor.h
@@ -18,10 +18,8 @@
 #define FMPZ_MPOLY_FACTOR_INLINE static __inline__
 #endif
 
-#undef ulong
 #define ulong ulongxx /* interferes with system includes */
 #include <stdio.h>
-#undef ulong
 #include <gmp.h>
 #define ulong mp_limb_t
 

--- a/src/fmpz_mpoly_factor/inlines.c
+++ b/src/fmpz_mpoly_factor/inlines.c
@@ -14,7 +14,6 @@
 #define ulong ulongxx /* interferes with system includes */
 #include <stdlib.h>
 #include <stdio.h>
-#undef ulong
 #include <gmp.h>
 #include "flint.h"
 #include "ulong_extras.h"

--- a/src/fmpz_mpoly_factor/inlines.c
+++ b/src/fmpz_mpoly_factor/inlines.c
@@ -11,7 +11,6 @@
 
 #define FMPZ_MPOLY_FACTOR_INLINES_C
 
-#define ulong ulongxx /* interferes with system includes */
 #include <stdlib.h>
 #include <stdio.h>
 #include <gmp.h>

--- a/src/fmpz_poly.h
+++ b/src/fmpz_poly.h
@@ -24,7 +24,6 @@
 #include <stdio.h>
 
 #include <gmp.h>
-#define ulong mp_limb_t
 
 #include "flint.h"
 #include "fmpz.h"

--- a/src/fmpz_poly.h
+++ b/src/fmpz_poly.h
@@ -21,10 +21,8 @@
 #define FMPZ_POLY_INLINE static __inline__
 #endif
 
-#undef ulong
 #define ulong ulongxx /* interferes with system includes */
 #include <stdio.h>
-#undef ulong
 
 #include <gmp.h>
 #define ulong mp_limb_t

--- a/src/fmpz_poly.h
+++ b/src/fmpz_poly.h
@@ -21,7 +21,6 @@
 #define FMPZ_POLY_INLINE static __inline__
 #endif
 
-#define ulong ulongxx /* interferes with system includes */
 #include <stdio.h>
 
 #include <gmp.h>

--- a/src/fmpz_poly/inlines.c
+++ b/src/fmpz_poly/inlines.c
@@ -14,7 +14,6 @@
 #define ulong ulongxx /* interferes with system includes */
 #include <stdlib.h>
 #include <stdio.h>
-#undef ulong
 #include <gmp.h>
 #include "flint.h"
 #include "ulong_extras.h"

--- a/src/fmpz_poly/inlines.c
+++ b/src/fmpz_poly/inlines.c
@@ -11,7 +11,6 @@
 
 #define FMPZ_POLY_INLINES_C
 
-#define ulong ulongxx /* interferes with system includes */
 #include <stdlib.h>
 #include <stdio.h>
 #include <gmp.h>

--- a/src/fmpz_poly_factor.h
+++ b/src/fmpz_poly_factor.h
@@ -20,10 +20,8 @@
 #define FMPZ_POLY_FACTOR_INLINE static __inline__
 #endif
 
-#undef ulong
 #define ulong ulongxx /* interferes with system includes */
 #include <stdio.h>
-#undef ulong
 #include <gmp.h>
 #define ulong mp_limb_t
 

--- a/src/fmpz_poly_factor.h
+++ b/src/fmpz_poly_factor.h
@@ -22,7 +22,6 @@
 
 #include <stdio.h>
 #include <gmp.h>
-#define ulong mp_limb_t
 
 #include "flint.h"
 #include "fmpz.h"

--- a/src/fmpz_poly_factor.h
+++ b/src/fmpz_poly_factor.h
@@ -20,7 +20,6 @@
 #define FMPZ_POLY_FACTOR_INLINE static __inline__
 #endif
 
-#define ulong ulongxx /* interferes with system includes */
 #include <stdio.h>
 #include <gmp.h>
 #define ulong mp_limb_t

--- a/src/fmpz_poly_factor/inlines.c
+++ b/src/fmpz_poly_factor/inlines.c
@@ -11,7 +11,6 @@
 
 #define FMPZ_POLY_FACTOR_INLINES_C
 
-#define ulong ulongxx /* interferes with system includes */
 #include <stdlib.h>
 #include <stdio.h>
 #include <gmp.h>

--- a/src/fmpz_poly_factor/inlines.c
+++ b/src/fmpz_poly_factor/inlines.c
@@ -14,7 +14,6 @@
 #define ulong ulongxx /* interferes with system includes */
 #include <stdlib.h>
 #include <stdio.h>
-#undef ulong
 #include <gmp.h>
 #include "flint.h"
 #include "fmpz_poly.h"

--- a/src/fmpz_poly_mat/inlines.c
+++ b/src/fmpz_poly_mat/inlines.c
@@ -13,7 +13,6 @@
 
 #define ulong ulongxx /* interferes with system includes */
 #include <stdlib.h>
-#undef ulong
 #include <gmp.h>
 #include "flint.h"
 #include "fmpz_poly_mat.h"

--- a/src/fmpz_poly_mat/inlines.c
+++ b/src/fmpz_poly_mat/inlines.c
@@ -11,7 +11,6 @@
 
 #define FMPZ_POLY_MAT_INLINES_C
 
-#define ulong ulongxx /* interferes with system includes */
 #include <stdlib.h>
 #include <gmp.h>
 #include "flint.h"

--- a/src/fmpz_poly_q.h
+++ b/src/fmpz_poly_q.h
@@ -20,7 +20,6 @@
 
 #include <stdlib.h>
 #include <gmp.h>
-#define ulong mp_limb_t
 
 #include "flint.h"
 #include "fmpz.h"

--- a/src/fmpz_poly_q.h
+++ b/src/fmpz_poly_q.h
@@ -18,10 +18,8 @@
 #define FMPZ_POLY_Q_INLINE static __inline__
 #endif
 
-#undef ulong
 #define ulong ulongxx /* interferes with system includes */
 #include <stdlib.h>
-#undef ulong
 #include <gmp.h>
 #define ulong mp_limb_t
 

--- a/src/fmpz_poly_q.h
+++ b/src/fmpz_poly_q.h
@@ -18,7 +18,6 @@
 #define FMPZ_POLY_Q_INLINE static __inline__
 #endif
 
-#define ulong ulongxx /* interferes with system includes */
 #include <stdlib.h>
 #include <gmp.h>
 #define ulong mp_limb_t

--- a/src/fmpz_poly_q/inlines.c
+++ b/src/fmpz_poly_q/inlines.c
@@ -11,7 +11,6 @@
 
 #define FMPZ_POLY_Q_INLINES_C
 
-#define ulong ulongxx /* interferes with system includes */
 #include <stdlib.h>
 #include <gmp.h>
 #include "flint.h"

--- a/src/fmpz_poly_q/inlines.c
+++ b/src/fmpz_poly_q/inlines.c
@@ -13,7 +13,6 @@
 
 #define ulong ulongxx /* interferes with system includes */
 #include <stdlib.h>
-#undef ulong
 #include <gmp.h>
 #include "flint.h"
 #include "fmpz_poly_q.h"

--- a/src/fmpz_vec/inlines.c
+++ b/src/fmpz_vec/inlines.c
@@ -13,7 +13,6 @@
 
 #define ulong ulongxx /* interferes with system includes */
 #include <stdlib.h>
-#undef ulong
 #include <gmp.h>
 #include "flint.h"
 #include "fmpz_vec.h"

--- a/src/fmpz_vec/inlines.c
+++ b/src/fmpz_vec/inlines.c
@@ -11,7 +11,6 @@
 
 #define FMPZ_VEC_INLINES_C
 
-#define ulong ulongxx /* interferes with system includes */
 #include <stdlib.h>
 #include <gmp.h>
 #include "flint.h"

--- a/src/fq/inlines.c
+++ b/src/fq/inlines.c
@@ -11,7 +11,6 @@
 
 #define FQ_INLINES_C
 
-#define ulong ulongxx /* interferes with system includes */
 #include <stdlib.h>
 #include <stdio.h>
 #include <gmp.h>

--- a/src/fq/inlines.c
+++ b/src/fq/inlines.c
@@ -14,7 +14,6 @@
 #define ulong ulongxx /* interferes with system includes */
 #include <stdlib.h>
 #include <stdio.h>
-#undef ulong
 #include <gmp.h>
 #include "flint.h"
 #include "ulong_extras.h"

--- a/src/fq_default/inlines.c
+++ b/src/fq_default/inlines.c
@@ -11,7 +11,6 @@
 
 #define FQ_DEFAULT_INLINES_C
 
-#define ulong ulongxx /* interferes with system includes */
 #include <stdlib.h>
 #include <stdio.h>
 #include <gmp.h>

--- a/src/fq_default/inlines.c
+++ b/src/fq_default/inlines.c
@@ -14,7 +14,6 @@
 #define ulong ulongxx /* interferes with system includes */
 #include <stdlib.h>
 #include <stdio.h>
-#undef ulong
 #include <gmp.h>
 #include "flint.h"
 #include "ulong_extras.h"

--- a/src/fq_default_mat/inlines.c
+++ b/src/fq_default_mat/inlines.c
@@ -14,7 +14,6 @@
 #define ulong ulongxx /* interferes with system includes */
 #include <stdlib.h>
 #include <stdio.h>
-#undef ulong
 #include <gmp.h>
 #include "flint.h"
 #include "ulong_extras.h"

--- a/src/fq_default_mat/inlines.c
+++ b/src/fq_default_mat/inlines.c
@@ -11,7 +11,6 @@
 
 #define FQ_DEFAULT_MAT_INLINES_C
 
-#define ulong ulongxx /* interferes with system includes */
 #include <stdlib.h>
 #include <stdio.h>
 #include <gmp.h>

--- a/src/fq_default_poly/inlines.c
+++ b/src/fq_default_poly/inlines.c
@@ -11,7 +11,6 @@
 
 #define FQ_DEFAULT_POLY_INLINES_C
 
-#define ulong ulongxx /* interferes with system includes */
 #include <stdlib.h>
 #include <stdio.h>
 #include <gmp.h>

--- a/src/fq_default_poly/inlines.c
+++ b/src/fq_default_poly/inlines.c
@@ -14,7 +14,6 @@
 #define ulong ulongxx /* interferes with system includes */
 #include <stdlib.h>
 #include <stdio.h>
-#undef ulong
 #include <gmp.h>
 #include "flint.h"
 #include "ulong_extras.h"

--- a/src/fq_default_poly_factor/inlines.c
+++ b/src/fq_default_poly_factor/inlines.c
@@ -11,7 +11,6 @@
 
 #define FQ_DEFAULT_POLY_FACTOR_INLINES_C
 
-#define ulong ulongxx /* interferes with system includes */
 #include <stdlib.h>
 #include <stdio.h>
 #include <gmp.h>

--- a/src/fq_default_poly_factor/inlines.c
+++ b/src/fq_default_poly_factor/inlines.c
@@ -14,7 +14,6 @@
 #define ulong ulongxx /* interferes with system includes */
 #include <stdlib.h>
 #include <stdio.h>
-#undef ulong
 #include <gmp.h>
 #include "flint.h"
 #include "ulong_extras.h"

--- a/src/fq_mat/inlines.c
+++ b/src/fq_mat/inlines.c
@@ -11,7 +11,6 @@
 
 #define FQ_MAT_INLINES_C
 
-#define ulong ulongxx /* interferes with system includes */
 #include <stdlib.h>
 #include <gmp.h>
 #include "flint.h"

--- a/src/fq_mat/inlines.c
+++ b/src/fq_mat/inlines.c
@@ -13,7 +13,6 @@
 
 #define ulong ulongxx /* interferes with system includes */
 #include <stdlib.h>
-#undef ulong
 #include <gmp.h>
 #include "flint.h"
 #include "fq_mat.h"

--- a/src/fq_nmod/inlines.c
+++ b/src/fq_nmod/inlines.c
@@ -11,7 +11,6 @@
 
 #define FQ_NMOD_INLINES_C
 
-#define ulong ulongxx /* interferes with system includes */
 #include <stdlib.h>
 #include <stdio.h>
 #include <gmp.h>

--- a/src/fq_nmod/inlines.c
+++ b/src/fq_nmod/inlines.c
@@ -14,7 +14,6 @@
 #define ulong ulongxx /* interferes with system includes */
 #include <stdlib.h>
 #include <stdio.h>
-#undef ulong
 #include <gmp.h>
 #include "flint.h"
 #include "ulong_extras.h"

--- a/src/fq_nmod_mat/inlines.c
+++ b/src/fq_nmod_mat/inlines.c
@@ -13,7 +13,6 @@
 
 #define ulong ulongxx /* interferes with system includes */
 #include <stdlib.h>
-#undef ulong
 #include <gmp.h>
 #include "flint.h"
 #include "fq_nmod_mat.h"

--- a/src/fq_nmod_mat/inlines.c
+++ b/src/fq_nmod_mat/inlines.c
@@ -11,7 +11,6 @@
 
 #define FQ_NMOD_MAT_INLINES_C
 
-#define ulong ulongxx /* interferes with system includes */
 #include <stdlib.h>
 #include <gmp.h>
 #include "flint.h"

--- a/src/fq_nmod_mpoly.h
+++ b/src/fq_nmod_mpoly.h
@@ -21,7 +21,6 @@
 #include <stdio.h>
 
 #include <gmp.h>
-#define ulong mp_limb_t
 
 #include "flint.h"
 #include "nmod_vec.h"

--- a/src/fq_nmod_mpoly.h
+++ b/src/fq_nmod_mpoly.h
@@ -18,10 +18,8 @@
 #define FQ_NMOD_MPOLY_INLINE static __inline__
 #endif
 
-#undef ulong
 #define ulong ulongxx /* interferes with system includes */
 #include <stdio.h>
-#undef ulong
 
 #include <gmp.h>
 #define ulong mp_limb_t

--- a/src/fq_nmod_mpoly.h
+++ b/src/fq_nmod_mpoly.h
@@ -18,7 +18,6 @@
 #define FQ_NMOD_MPOLY_INLINE static __inline__
 #endif
 
-#define ulong ulongxx /* interferes with system includes */
 #include <stdio.h>
 
 #include <gmp.h>

--- a/src/fq_nmod_mpoly/inlines.c
+++ b/src/fq_nmod_mpoly/inlines.c
@@ -11,7 +11,6 @@
 
 #define FQ_NMOD_MPOLY_INLINES_C
 
-#define ulong ulongxx /* interferes with system includes */
 #include <stdlib.h>
 #include <stdio.h>
 #include <gmp.h>

--- a/src/fq_nmod_mpoly/inlines.c
+++ b/src/fq_nmod_mpoly/inlines.c
@@ -14,7 +14,6 @@
 #define ulong ulongxx /* interferes with system includes */
 #include <stdlib.h>
 #include <stdio.h>
-#undef ulong
 #include <gmp.h>
 #include "flint.h"
 #include "ulong_extras.h"

--- a/src/fq_nmod_mpoly_factor.h
+++ b/src/fq_nmod_mpoly_factor.h
@@ -18,10 +18,8 @@
 #define FQ_NMOD_MPOLY_FACTOR_INLINE static __inline__
 #endif
 
-#undef ulong
 #define ulong ulongxx /* interferes with system includes */
 #include <stdio.h>
-#undef ulong
 #include <gmp.h>
 #define ulong mp_limb_t
 

--- a/src/fq_nmod_mpoly_factor.h
+++ b/src/fq_nmod_mpoly_factor.h
@@ -20,7 +20,6 @@
 
 #include <stdio.h>
 #include <gmp.h>
-#define ulong mp_limb_t
 
 #include "fq_nmod_mpoly.h"
 #include "nmod_mpoly_factor.h"

--- a/src/fq_nmod_mpoly_factor.h
+++ b/src/fq_nmod_mpoly_factor.h
@@ -18,7 +18,6 @@
 #define FQ_NMOD_MPOLY_FACTOR_INLINE static __inline__
 #endif
 
-#define ulong ulongxx /* interferes with system includes */
 #include <stdio.h>
 #include <gmp.h>
 #define ulong mp_limb_t

--- a/src/fq_nmod_mpoly_factor/inlines.c
+++ b/src/fq_nmod_mpoly_factor/inlines.c
@@ -11,7 +11,6 @@
 
 #define FQ_NMOD_MPOLY_FACTOR_INLINES_C
 
-#define ulong ulongxx /* interferes with system includes */
 #include <stdlib.h>
 #include <stdio.h>
 #include <gmp.h>

--- a/src/fq_nmod_mpoly_factor/inlines.c
+++ b/src/fq_nmod_mpoly_factor/inlines.c
@@ -14,7 +14,6 @@
 #define ulong ulongxx /* interferes with system includes */
 #include <stdlib.h>
 #include <stdio.h>
-#undef ulong
 #include <gmp.h>
 #include "flint.h"
 #include "ulong_extras.h"

--- a/src/fq_nmod_poly/inlines.c
+++ b/src/fq_nmod_poly/inlines.c
@@ -11,7 +11,6 @@
 
 #define FQ_NMOD_POLY_INLINES_C
 
-#define ulong ulongxx /* interferes with system includes */
 #include <stdlib.h>
 #include <stdio.h>
 #include <gmp.h>

--- a/src/fq_nmod_poly/inlines.c
+++ b/src/fq_nmod_poly/inlines.c
@@ -14,7 +14,6 @@
 #define ulong ulongxx /* interferes with system includes */
 #include <stdlib.h>
 #include <stdio.h>
-#undef ulong
 #include <gmp.h>
 #include "flint.h"
 #include "ulong_extras.h"

--- a/src/fq_nmod_poly_factor/inlines.c
+++ b/src/fq_nmod_poly_factor/inlines.c
@@ -11,7 +11,6 @@
 
 #define FQ_NMOD_POLY_FACTOR_INLINES_C
 
-#define ulong ulongxx /* interferes with system includes */
 #include <stdlib.h>
 #include <stdio.h>
 #include <gmp.h>

--- a/src/fq_nmod_poly_factor/inlines.c
+++ b/src/fq_nmod_poly_factor/inlines.c
@@ -14,7 +14,6 @@
 #define ulong ulongxx /* interferes with system includes */
 #include <stdlib.h>
 #include <stdio.h>
-#undef ulong
 #include <gmp.h>
 #include "flint.h"
 #include "ulong_extras.h"

--- a/src/fq_nmod_vec/inlines.c
+++ b/src/fq_nmod_vec/inlines.c
@@ -13,7 +13,6 @@
 
 #define ulong ulongxx /* interferes with system includes */
 #include <stdlib.h>
-#undef ulong
 #include <gmp.h>
 #include "flint.h"
 #include "fq_nmod_vec.h"

--- a/src/fq_nmod_vec/inlines.c
+++ b/src/fq_nmod_vec/inlines.c
@@ -11,7 +11,6 @@
 
 #define FQ_NMOD_VEC_INLINES_C
 
-#define ulong ulongxx /* interferes with system includes */
 #include <stdlib.h>
 #include <gmp.h>
 #include "flint.h"

--- a/src/fq_poly/inlines.c
+++ b/src/fq_poly/inlines.c
@@ -14,7 +14,6 @@
 #define ulong ulongxx /* interferes with system includes */
 #include <stdlib.h>
 #include <stdio.h>
-#undef ulong
 #include <gmp.h>
 #include "flint.h"
 #include "fq_poly.h"

--- a/src/fq_poly/inlines.c
+++ b/src/fq_poly/inlines.c
@@ -11,7 +11,6 @@
 
 #define FQ_POLY_INLINES_C
 
-#define ulong ulongxx /* interferes with system includes */
 #include <stdlib.h>
 #include <stdio.h>
 #include <gmp.h>

--- a/src/fq_poly_factor/inlines.c
+++ b/src/fq_poly_factor/inlines.c
@@ -11,7 +11,6 @@
 
 #include <stdlib.h>
 #include <stdio.h>
-#undef ulong
 #include <gmp.h>
 #include "flint.h"
 #include "ulong_extras.h"

--- a/src/fq_vec/inlines.c
+++ b/src/fq_vec/inlines.c
@@ -13,7 +13,6 @@
 
 #define ulong ulongxx /* interferes with system includes */
 #include <stdlib.h>
-#undef ulong
 #include <gmp.h>
 #include "flint.h"
 #include "fq_vec.h"

--- a/src/fq_vec/inlines.c
+++ b/src/fq_vec/inlines.c
@@ -11,7 +11,6 @@
 
 #define FQ_VEC_INLINES_C
 
-#define ulong ulongxx /* interferes with system includes */
 #include <stdlib.h>
 #include <gmp.h>
 #include "flint.h"

--- a/src/fq_zech/inlines.c
+++ b/src/fq_zech/inlines.c
@@ -11,7 +11,6 @@
 
 #define FQ_ZECH_INLINES_C
 
-#define ulong ulongxx /* interferes with system includes */
 #include <stdlib.h>
 #include <stdio.h>
 #include <gmp.h>

--- a/src/fq_zech/inlines.c
+++ b/src/fq_zech/inlines.c
@@ -14,7 +14,6 @@
 #define ulong ulongxx /* interferes with system includes */
 #include <stdlib.h>
 #include <stdio.h>
-#undef ulong
 #include <gmp.h>
 #include "flint.h"
 #include "ulong_extras.h"

--- a/src/fq_zech_mat/inlines.c
+++ b/src/fq_zech_mat/inlines.c
@@ -13,7 +13,6 @@
 
 #define ulong ulongxx /* interferes with system includes */
 #include <stdlib.h>
-#undef ulong
 #include <gmp.h>
 #include "flint.h"
 #include "fq_zech_mat.h"

--- a/src/fq_zech_mat/inlines.c
+++ b/src/fq_zech_mat/inlines.c
@@ -11,7 +11,6 @@
 
 #define FQ_ZECH_MAT_INLINES_C
 
-#define ulong ulongxx /* interferes with system includes */
 #include <stdlib.h>
 #include <gmp.h>
 #include "flint.h"

--- a/src/fq_zech_mpoly.h
+++ b/src/fq_zech_mpoly.h
@@ -21,7 +21,6 @@
 #include <stdio.h>
 
 #include <gmp.h>
-#define ulong mp_limb_t
 
 #include "flint.h"
 #include "nmod_vec.h"

--- a/src/fq_zech_mpoly.h
+++ b/src/fq_zech_mpoly.h
@@ -18,7 +18,6 @@
 #define FQ_ZECH_MPOLY_INLINE static __inline__
 #endif
 
-#define ulong ulongxx /* interferes with system includes */
 #include <stdio.h>
 
 #include <gmp.h>

--- a/src/fq_zech_mpoly.h
+++ b/src/fq_zech_mpoly.h
@@ -18,10 +18,8 @@
 #define FQ_ZECH_MPOLY_INLINE static __inline__
 #endif
 
-#undef ulong
 #define ulong ulongxx /* interferes with system includes */
 #include <stdio.h>
-#undef ulong
 
 #include <gmp.h>
 #define ulong mp_limb_t

--- a/src/fq_zech_mpoly_factor.h
+++ b/src/fq_zech_mpoly_factor.h
@@ -18,10 +18,8 @@
 #define FQ_ZECH_MPOLY_FACTOR_INLINE static __inline__
 #endif
 
-#undef ulong
 #define ulong ulongxx /* interferes with system includes */
 #include <stdio.h>
-#undef ulong
 #include <gmp.h>
 #define ulong mp_limb_t
 

--- a/src/fq_zech_mpoly_factor.h
+++ b/src/fq_zech_mpoly_factor.h
@@ -20,7 +20,6 @@
 
 #include <stdio.h>
 #include <gmp.h>
-#define ulong mp_limb_t
 
 #include "fq_zech_mpoly.h"
 #include "nmod_mpoly_factor.h"

--- a/src/fq_zech_mpoly_factor.h
+++ b/src/fq_zech_mpoly_factor.h
@@ -18,7 +18,6 @@
 #define FQ_ZECH_MPOLY_FACTOR_INLINE static __inline__
 #endif
 
-#define ulong ulongxx /* interferes with system includes */
 #include <stdio.h>
 #include <gmp.h>
 #define ulong mp_limb_t

--- a/src/fq_zech_poly/inlines.c
+++ b/src/fq_zech_poly/inlines.c
@@ -14,7 +14,6 @@
 #define ulong ulongxx /* interferes with system includes */
 #include <stdlib.h>
 #include <stdio.h>
-#undef ulong
 #include <gmp.h>
 #include "flint.h"
 #include "fq_zech_poly.h"

--- a/src/fq_zech_poly/inlines.c
+++ b/src/fq_zech_poly/inlines.c
@@ -11,7 +11,6 @@
 
 #define FQ_ZECH_POLY_INLINES_C
 
-#define ulong ulongxx /* interferes with system includes */
 #include <stdlib.h>
 #include <stdio.h>
 #include <gmp.h>

--- a/src/fq_zech_poly_factor/inlines.c
+++ b/src/fq_zech_poly_factor/inlines.c
@@ -11,7 +11,6 @@
 
 #define FQ_ZECH_POLY_FACTOR_INLINES_C
 
-#define ulong ulongxx /* interferes with system includes */
 #include <stdlib.h>
 #include <stdio.h>
 #include <gmp.h>

--- a/src/fq_zech_poly_factor/inlines.c
+++ b/src/fq_zech_poly_factor/inlines.c
@@ -14,7 +14,6 @@
 #define ulong ulongxx /* interferes with system includes */
 #include <stdlib.h>
 #include <stdio.h>
-#undef ulong
 #include <gmp.h>
 #include "flint.h"
 #include "ulong_extras.h"

--- a/src/fq_zech_vec/inlines.c
+++ b/src/fq_zech_vec/inlines.c
@@ -13,7 +13,6 @@
 
 #define ulong ulongxx /* interferes with system includes */
 #include <stdlib.h>
-#undef ulong
 #include <gmp.h>
 #include "flint.h"
 #include "fq_zech_vec.h"

--- a/src/fq_zech_vec/inlines.c
+++ b/src/fq_zech_vec/inlines.c
@@ -11,7 +11,6 @@
 
 #define FQ_ZECH_VEC_INLINES_C
 
-#define ulong ulongxx /* interferes with system includes */
 #include <stdlib.h>
 #include <gmp.h>
 #include "flint.h"

--- a/src/long_extras/inlines.c
+++ b/src/long_extras/inlines.c
@@ -13,7 +13,6 @@
 
 #define ulong ulongxx /* interferes with system includes */
 #include <stdlib.h>
-#undef ulong
 #include <gmp.h>
 #include "flint.h"
 #include "long_extras.h"

--- a/src/long_extras/inlines.c
+++ b/src/long_extras/inlines.c
@@ -11,7 +11,6 @@
 
 #define LONG_EXTRAS_INLINES_C
 
-#define ulong ulongxx /* interferes with system includes */
 #include <stdlib.h>
 #include <gmp.h>
 #include "flint.h"

--- a/src/mpf_mat/inlines.c
+++ b/src/mpf_mat/inlines.c
@@ -11,7 +11,6 @@
 
 #define MPF_MAT_INLINES_C
 
-#define ulong ulongxx /* interferes with system includes */
 #include <stdlib.h>
 #include <gmp.h>
 #include "flint.h"

--- a/src/mpf_mat/inlines.c
+++ b/src/mpf_mat/inlines.c
@@ -13,7 +13,6 @@
 
 #define ulong ulongxx /* interferes with system includes */
 #include <stdlib.h>
-#undef ulong
 #include <gmp.h>
 #include "flint.h"
 #include "mpf_mat.h"

--- a/src/mpoly.h
+++ b/src/mpoly.h
@@ -19,10 +19,8 @@
 #define MPOLY_INLINE static __inline__
 #endif
 
-#undef ulong
 #define ulong ulongxx /* interferes with system includes */
 #include <stdio.h>
-#undef ulong
 
 #include <gmp.h>
 #define ulong mp_limb_t

--- a/src/mpoly.h
+++ b/src/mpoly.h
@@ -22,7 +22,6 @@
 #include <stdio.h>
 
 #include <gmp.h>
-#define ulong mp_limb_t
 
 #include "string.h"
 #include "mpoly_types.h"

--- a/src/mpoly.h
+++ b/src/mpoly.h
@@ -19,7 +19,6 @@
 #define MPOLY_INLINE static __inline__
 #endif
 
-#define ulong ulongxx /* interferes with system includes */
 #include <stdio.h>
 
 #include <gmp.h>

--- a/src/mpoly/inlines.c
+++ b/src/mpoly/inlines.c
@@ -14,7 +14,6 @@
 #define ulong ulongxx /* interferes with system includes */
 #include <stdlib.h>
 #include <stdio.h>
-#undef ulong
 #include <gmp.h>
 #include "flint.h"
 #include "ulong_extras.h"

--- a/src/mpoly/inlines.c
+++ b/src/mpoly/inlines.c
@@ -11,7 +11,6 @@
 
 #define MPOLY_INLINES_C
 
-#define ulong ulongxx /* interferes with system includes */
 #include <stdlib.h>
 #include <stdio.h>
 #include <gmp.h>

--- a/src/n_poly.h
+++ b/src/n_poly.h
@@ -20,7 +20,6 @@
 
 #include <stdio.h>
 #include <gmp.h>
-#define ulong mp_limb_t
 
 #include "nmod_poly.h"
 #include "fq_nmod_poly.h"

--- a/src/n_poly.h
+++ b/src/n_poly.h
@@ -18,10 +18,8 @@
 #define N_POLY_INLINE static __inline__
 #endif
 
-#undef ulong
 #define ulong ulongxx /* interferes with system includes */
 #include <stdio.h>
-#undef ulong
 #include <gmp.h>
 #define ulong mp_limb_t
 

--- a/src/n_poly.h
+++ b/src/n_poly.h
@@ -18,7 +18,6 @@
 #define N_POLY_INLINE static __inline__
 #endif
 
-#define ulong ulongxx /* interferes with system includes */
 #include <stdio.h>
 #include <gmp.h>
 #define ulong mp_limb_t

--- a/src/nmod.h
+++ b/src/nmod.h
@@ -21,7 +21,6 @@
 
 #include <stdlib.h>
 #include <gmp.h>
-#define ulong mp_limb_t
 
 #include "longlong.h"
 #include "ulong_extras.h"

--- a/src/nmod.h
+++ b/src/nmod.h
@@ -19,10 +19,8 @@
 #define NMOD_INLINE static __inline__
 #endif
 
-#undef ulong
 #define ulong ulongxx /* interferes with system includes */
 #include <stdlib.h>
-#undef ulong
 #include <gmp.h>
 #define ulong mp_limb_t
 

--- a/src/nmod.h
+++ b/src/nmod.h
@@ -19,7 +19,6 @@
 #define NMOD_INLINE static __inline__
 #endif
 
-#define ulong ulongxx /* interferes with system includes */
 #include <stdlib.h>
 #include <gmp.h>
 #define ulong mp_limb_t

--- a/src/nmod/inlines.c
+++ b/src/nmod/inlines.c
@@ -11,7 +11,6 @@
 
 #define NMOD_INLINES_C
 
-#define ulong ulongxx /* interferes with system includes */
 #include <stdlib.h>
 #include <gmp.h>
 #include "flint.h"

--- a/src/nmod/inlines.c
+++ b/src/nmod/inlines.c
@@ -13,7 +13,6 @@
 
 #define ulong ulongxx /* interferes with system includes */
 #include <stdlib.h>
-#undef ulong
 #include <gmp.h>
 #include "flint.h"
 #include "nmod.h"

--- a/src/nmod_mat.h
+++ b/src/nmod_mat.h
@@ -20,7 +20,6 @@
 #define NMOD_MAT_INLINE static __inline__
 #endif
 
-#define ulong ulongxx /* interferes with system includes */
 #include <stdlib.h>
 #include <gmp.h>
 #define ulong mp_limb_t

--- a/src/nmod_mat.h
+++ b/src/nmod_mat.h
@@ -20,10 +20,8 @@
 #define NMOD_MAT_INLINE static __inline__
 #endif
 
-#undef ulong
 #define ulong ulongxx /* interferes with system includes */
 #include <stdlib.h>
-#undef ulong
 #include <gmp.h>
 #define ulong mp_limb_t
 

--- a/src/nmod_mat.h
+++ b/src/nmod_mat.h
@@ -22,7 +22,6 @@
 
 #include <stdlib.h>
 #include <gmp.h>
-#define ulong mp_limb_t
 
 #include "flint.h"
 #include "perm.h"

--- a/src/nmod_mat/inlines.c
+++ b/src/nmod_mat/inlines.c
@@ -12,7 +12,6 @@
 
 #define NMOD_MAT_INLINES_C
 
-#define ulong ulongxx /* interferes with system includes */
 #include <stdlib.h>
 #include <gmp.h>
 #include "flint.h"

--- a/src/nmod_mat/inlines.c
+++ b/src/nmod_mat/inlines.c
@@ -14,7 +14,6 @@
 
 #define ulong ulongxx /* interferes with system includes */
 #include <stdlib.h>
-#undef ulong
 #include <gmp.h>
 #include "flint.h"
 #include "ulong_extras.h"

--- a/src/nmod_mpoly.h
+++ b/src/nmod_mpoly.h
@@ -21,7 +21,6 @@
 #include <stdio.h>
 
 #include <gmp.h>
-#define ulong mp_limb_t
 
 #include "flint.h"
 #include "nmod_vec.h"

--- a/src/nmod_mpoly.h
+++ b/src/nmod_mpoly.h
@@ -18,7 +18,6 @@
 #define NMOD_MPOLY_INLINE static __inline__
 #endif
 
-#define ulong ulongxx /* interferes with system includes */
 #include <stdio.h>
 
 #include <gmp.h>

--- a/src/nmod_mpoly.h
+++ b/src/nmod_mpoly.h
@@ -18,10 +18,8 @@
 #define NMOD_MPOLY_INLINE static __inline__
 #endif
 
-#undef ulong
 #define ulong ulongxx /* interferes with system includes */
 #include <stdio.h>
-#undef ulong
 
 #include <gmp.h>
 #define ulong mp_limb_t

--- a/src/nmod_mpoly/inlines.c
+++ b/src/nmod_mpoly/inlines.c
@@ -11,7 +11,6 @@
 
 #define NMOD_MPOLY_INLINES_C
 
-#define ulong ulongxx /* interferes with system includes */
 #include <stdlib.h>
 #include <stdio.h>
 #include <gmp.h>

--- a/src/nmod_mpoly/inlines.c
+++ b/src/nmod_mpoly/inlines.c
@@ -14,7 +14,6 @@
 #define ulong ulongxx /* interferes with system includes */
 #include <stdlib.h>
 #include <stdio.h>
-#undef ulong
 #include <gmp.h>
 #include "flint.h"
 #include "ulong_extras.h"

--- a/src/nmod_mpoly_factor.h
+++ b/src/nmod_mpoly_factor.h
@@ -18,7 +18,6 @@
 #define NMOD_MPOLY_FACTOR_INLINE static __inline__
 #endif
 
-#define ulong ulongxx /* interferes with system includes */
 #include <stdio.h>
 #include <gmp.h>
 #define ulong mp_limb_t

--- a/src/nmod_mpoly_factor.h
+++ b/src/nmod_mpoly_factor.h
@@ -20,7 +20,6 @@
 
 #include <stdio.h>
 #include <gmp.h>
-#define ulong mp_limb_t
 
 #include "nmod_mpoly.h"
 #include "n_poly.h"

--- a/src/nmod_mpoly_factor.h
+++ b/src/nmod_mpoly_factor.h
@@ -18,10 +18,8 @@
 #define NMOD_MPOLY_FACTOR_INLINE static __inline__
 #endif
 
-#undef ulong
 #define ulong ulongxx /* interferes with system includes */
 #include <stdio.h>
-#undef ulong
 #include <gmp.h>
 #define ulong mp_limb_t
 

--- a/src/nmod_mpoly_factor/inlines.c
+++ b/src/nmod_mpoly_factor/inlines.c
@@ -14,7 +14,6 @@
 #define ulong ulongxx /* interferes with system includes */
 #include <stdlib.h>
 #include <stdio.h>
-#undef ulong
 #include <gmp.h>
 #include "flint.h"
 #include "ulong_extras.h"

--- a/src/nmod_mpoly_factor/inlines.c
+++ b/src/nmod_mpoly_factor/inlines.c
@@ -11,7 +11,6 @@
 
 #define NMOD_MPOLY_FACTOR_INLINES_C
 
-#define ulong ulongxx /* interferes with system includes */
 #include <stdlib.h>
 #include <stdio.h>
 #include <gmp.h>

--- a/src/nmod_poly.h
+++ b/src/nmod_poly.h
@@ -24,7 +24,6 @@
 
 #include <stdio.h>
 #include <gmp.h>
-#define ulong mp_limb_t
 
 #include "flint.h"
 #include "nmod_vec.h"

--- a/src/nmod_poly.h
+++ b/src/nmod_poly.h
@@ -22,10 +22,8 @@
 #define NMOD_POLY_INLINE static __inline__
 #endif
 
-#undef ulong
 #define ulong ulongxx /* interferes with system includes */
 #include <stdio.h>
-#undef ulong
 #include <gmp.h>
 #define ulong mp_limb_t
 

--- a/src/nmod_poly.h
+++ b/src/nmod_poly.h
@@ -22,7 +22,6 @@
 #define NMOD_POLY_INLINE static __inline__
 #endif
 
-#define ulong ulongxx /* interferes with system includes */
 #include <stdio.h>
 #include <gmp.h>
 #define ulong mp_limb_t

--- a/src/nmod_poly/div_newton_n_preinv.c
+++ b/src/nmod_poly/div_newton_n_preinv.c
@@ -11,12 +11,10 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
-#undef ulong
 #define ulong ulongxx/* interferes with system includes */
 
 #include <stdlib.h>
 
-#undef ulong
 
 #include <gmp.h>
 

--- a/src/nmod_poly/div_newton_n_preinv.c
+++ b/src/nmod_poly/div_newton_n_preinv.c
@@ -11,7 +11,6 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
-#define ulong ulongxx/* interferes with system includes */
 
 #include <stdlib.h>
 

--- a/src/nmod_poly/div_newton_n_preinv.c
+++ b/src/nmod_poly/div_newton_n_preinv.c
@@ -17,7 +17,6 @@
 
 #include <gmp.h>
 
-#define ulong mp_limb_t
 
 #include "flint.h"
 #include "nmod_vec.h"

--- a/src/nmod_poly/divrem_newton_n_preinv.c
+++ b/src/nmod_poly/divrem_newton_n_preinv.c
@@ -10,7 +10,6 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
-#define ulong ulongxx/* interferes with system includes */
 
 #include <stdlib.h>
 

--- a/src/nmod_poly/divrem_newton_n_preinv.c
+++ b/src/nmod_poly/divrem_newton_n_preinv.c
@@ -10,12 +10,10 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
-#undef ulong
 #define ulong ulongxx/* interferes with system includes */
 
 #include <stdlib.h>
 
-#undef ulong
 
 #include <gmp.h>
 

--- a/src/nmod_poly/divrem_newton_n_preinv.c
+++ b/src/nmod_poly/divrem_newton_n_preinv.c
@@ -16,7 +16,6 @@
 
 #include <gmp.h>
 
-#define ulong mp_limb_t
 
 #include "flint.h"
 #include "nmod_vec.h"

--- a/src/nmod_poly/inlines.c
+++ b/src/nmod_poly/inlines.c
@@ -12,7 +12,6 @@
 
 #define NMOD_POLY_INLINES_C
 
-#define ulong ulongxx /* interferes with system includes */
 #include <stdlib.h>
 #include <stdio.h>
 #include <gmp.h>

--- a/src/nmod_poly/inlines.c
+++ b/src/nmod_poly/inlines.c
@@ -15,7 +15,6 @@
 #define ulong ulongxx /* interferes with system includes */
 #include <stdlib.h>
 #include <stdio.h>
-#undef ulong
 #include <gmp.h>
 #include "flint.h"
 #include "ulong_extras.h"

--- a/src/nmod_poly/mulmod_preinv.c
+++ b/src/nmod_poly/mulmod_preinv.c
@@ -10,7 +10,6 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
-#define ulong ulongxx/* interferes with system includes */
 
 #include <stdlib.h>
 

--- a/src/nmod_poly/mulmod_preinv.c
+++ b/src/nmod_poly/mulmod_preinv.c
@@ -10,12 +10,10 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
-#undef ulong
 #define ulong ulongxx/* interferes with system includes */
 
 #include <stdlib.h>
 
-#undef ulong
 
 #include <gmp.h>
 

--- a/src/nmod_poly/mulmod_preinv.c
+++ b/src/nmod_poly/mulmod_preinv.c
@@ -16,7 +16,6 @@
 
 #include <gmp.h>
 
-#define ulong mp_limb_t
 
 #include "flint.h"
 #include "nmod_vec.h"

--- a/src/nmod_poly/powmod_fmpz_binexp_preinv.c
+++ b/src/nmod_poly/powmod_fmpz_binexp_preinv.c
@@ -18,7 +18,6 @@
 
 #include <gmp.h>
 
-#define ulong mp_limb_t
 
 #include "flint.h"
 #include "nmod_vec.h"

--- a/src/nmod_poly/powmod_fmpz_binexp_preinv.c
+++ b/src/nmod_poly/powmod_fmpz_binexp_preinv.c
@@ -12,7 +12,6 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
-#define ulong ulongxx/* interferes with system includes */
 
 #include <stdlib.h>
 

--- a/src/nmod_poly/powmod_fmpz_binexp_preinv.c
+++ b/src/nmod_poly/powmod_fmpz_binexp_preinv.c
@@ -12,12 +12,10 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
-#undef ulong
 #define ulong ulongxx/* interferes with system includes */
 
 #include <stdlib.h>
 
-#undef ulong
 
 #include <gmp.h>
 

--- a/src/nmod_poly/powmod_mpz_binexp_preinv.c
+++ b/src/nmod_poly/powmod_mpz_binexp_preinv.c
@@ -12,7 +12,6 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
-#define ulong ulongxx/* interferes with system includes */
 
 #include <stdlib.h>
 

--- a/src/nmod_poly/powmod_mpz_binexp_preinv.c
+++ b/src/nmod_poly/powmod_mpz_binexp_preinv.c
@@ -12,12 +12,10 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
-#undef ulong
 #define ulong ulongxx/* interferes with system includes */
 
 #include <stdlib.h>
 
-#undef ulong
 
 #include <gmp.h>
 

--- a/src/nmod_poly/powmod_mpz_binexp_preinv.c
+++ b/src/nmod_poly/powmod_mpz_binexp_preinv.c
@@ -18,7 +18,6 @@
 
 #include <gmp.h>
 
-#define ulong mp_limb_t
 
 #include "flint.h"
 #include "gmpcompat.h"

--- a/src/nmod_poly/powmod_ui_binexp_preinv.c
+++ b/src/nmod_poly/powmod_ui_binexp_preinv.c
@@ -18,7 +18,6 @@
 
 #include <gmp.h>
 
-#define ulong mp_limb_t
 
 #include "flint.h"
 #include "nmod_vec.h"

--- a/src/nmod_poly/powmod_ui_binexp_preinv.c
+++ b/src/nmod_poly/powmod_ui_binexp_preinv.c
@@ -12,7 +12,6 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
-#define ulong ulongxx/* interferes with system includes */
 
 #include <stdlib.h>
 

--- a/src/nmod_poly/powmod_ui_binexp_preinv.c
+++ b/src/nmod_poly/powmod_ui_binexp_preinv.c
@@ -12,12 +12,10 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
-#undef ulong
 #define ulong ulongxx/* interferes with system includes */
 
 #include <stdlib.h>
 
-#undef ulong
 
 #include <gmp.h>
 

--- a/src/nmod_poly/powmod_x_fmpz_preinv.c
+++ b/src/nmod_poly/powmod_x_fmpz_preinv.c
@@ -19,7 +19,6 @@
 
 #include <gmp.h>
 
-#define ulong mp_limb_t
 
 #include "flint.h"
 #include "nmod_vec.h"

--- a/src/nmod_poly/powmod_x_fmpz_preinv.c
+++ b/src/nmod_poly/powmod_x_fmpz_preinv.c
@@ -13,7 +13,6 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
-#define ulong ulongxx/* interferes with system includes */
 
 #include <stdlib.h>
 

--- a/src/nmod_poly/powmod_x_fmpz_preinv.c
+++ b/src/nmod_poly/powmod_x_fmpz_preinv.c
@@ -13,12 +13,10 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
-#undef ulong
 #define ulong ulongxx/* interferes with system includes */
 
 #include <stdlib.h>
 
-#undef ulong
 
 #include <gmp.h>
 

--- a/src/nmod_poly/powmod_x_ui_preinv.c
+++ b/src/nmod_poly/powmod_x_ui_preinv.c
@@ -18,7 +18,6 @@
 
 #include <gmp.h>
 
-#define ulong mp_limb_t
 
 #include "flint.h"
 #include "nmod_vec.h"

--- a/src/nmod_poly/powmod_x_ui_preinv.c
+++ b/src/nmod_poly/powmod_x_ui_preinv.c
@@ -12,7 +12,6 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
-#define ulong ulongxx/* interferes with system includes */
 
 #include <stdlib.h>
 

--- a/src/nmod_poly/powmod_x_ui_preinv.c
+++ b/src/nmod_poly/powmod_x_ui_preinv.c
@@ -12,12 +12,10 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
-#undef ulong
 #define ulong ulongxx/* interferes with system includes */
 
 #include <stdlib.h>
 
-#undef ulong
 
 #include <gmp.h>
 

--- a/src/nmod_poly/test/t-compose_mod_brent_kung_precomp_preinv.c
+++ b/src/nmod_poly/test/t-compose_mod_brent_kung_precomp_preinv.c
@@ -17,7 +17,6 @@
 
 #include <gmp.h>
 
-#define ulong mp_limb_t
 
 #include "flint.h"
 #include "nmod_poly.h"

--- a/src/nmod_poly/test/t-compose_mod_brent_kung_precomp_preinv.c
+++ b/src/nmod_poly/test/t-compose_mod_brent_kung_precomp_preinv.c
@@ -10,13 +10,11 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
-#undef ulong
 #define ulong ulongxx/* interferes with system includes */
 
 #include <stdlib.h>
 #include <stdio.h>
 
-#undef ulong
 
 #include <gmp.h>
 

--- a/src/nmod_poly/test/t-compose_mod_brent_kung_precomp_preinv.c
+++ b/src/nmod_poly/test/t-compose_mod_brent_kung_precomp_preinv.c
@@ -10,7 +10,6 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
-#define ulong ulongxx/* interferes with system includes */
 
 #include <stdlib.h>
 #include <stdio.h>

--- a/src/nmod_poly/test/t-compose_mod_brent_kung_precomp_preinv_threaded.c
+++ b/src/nmod_poly/test/t-compose_mod_brent_kung_precomp_preinv_threaded.c
@@ -11,7 +11,6 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
-#define ulong ulongxx/* interferes with system includes */
 
 #include <stdlib.h>
 #include <stdio.h>

--- a/src/nmod_poly/test/t-compose_mod_brent_kung_precomp_preinv_threaded.c
+++ b/src/nmod_poly/test/t-compose_mod_brent_kung_precomp_preinv_threaded.c
@@ -19,7 +19,6 @@
 #include <gmp.h>
 #include <pthread.h>
 
-#define ulong mp_limb_t
 
 #include "flint.h"
 #include "nmod_poly.h"

--- a/src/nmod_poly/test/t-compose_mod_brent_kung_precomp_preinv_threaded.c
+++ b/src/nmod_poly/test/t-compose_mod_brent_kung_precomp_preinv_threaded.c
@@ -11,13 +11,11 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
-#undef ulong
 #define ulong ulongxx/* interferes with system includes */
 
 #include <stdlib.h>
 #include <stdio.h>
 
-#undef ulong
 
 #include <gmp.h>
 #include <pthread.h>

--- a/src/nmod_poly/test/t-compose_mod_brent_kung_preinv.c
+++ b/src/nmod_poly/test/t-compose_mod_brent_kung_preinv.c
@@ -17,7 +17,6 @@
 
 #include <gmp.h>
 
-#define ulong mp_limb_t
 
 #include "flint.h"
 #include "nmod_poly.h"

--- a/src/nmod_poly/test/t-compose_mod_brent_kung_preinv.c
+++ b/src/nmod_poly/test/t-compose_mod_brent_kung_preinv.c
@@ -10,13 +10,11 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
-#undef ulong
 #define ulong ulongxx/* interferes with system includes */
 
 #include <stdlib.h>
 #include <stdio.h>
 
-#undef ulong
 
 #include <gmp.h>
 

--- a/src/nmod_poly/test/t-compose_mod_brent_kung_preinv.c
+++ b/src/nmod_poly/test/t-compose_mod_brent_kung_preinv.c
@@ -10,7 +10,6 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
-#define ulong ulongxx/* interferes with system includes */
 
 #include <stdlib.h>
 #include <stdio.h>

--- a/src/nmod_poly/test/t-compose_mod_brent_kung_vec_preinv.c
+++ b/src/nmod_poly/test/t-compose_mod_brent_kung_vec_preinv.c
@@ -17,7 +17,6 @@
 
 #include <gmp.h>
 
-#define ulong mp_limb_t
 
 #include "flint.h"
 #include "nmod_poly.h"

--- a/src/nmod_poly/test/t-compose_mod_brent_kung_vec_preinv.c
+++ b/src/nmod_poly/test/t-compose_mod_brent_kung_vec_preinv.c
@@ -10,13 +10,11 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
-#undef ulong
 #define ulong ulongxx/* interferes with system includes */
 
 #include <stdlib.h>
 #include <stdio.h>
 
-#undef ulong
 
 #include <gmp.h>
 

--- a/src/nmod_poly/test/t-compose_mod_brent_kung_vec_preinv.c
+++ b/src/nmod_poly/test/t-compose_mod_brent_kung_vec_preinv.c
@@ -10,7 +10,6 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
-#define ulong ulongxx/* interferes with system includes */
 
 #include <stdlib.h>
 #include <stdio.h>

--- a/src/nmod_poly/test/t-compose_mod_brent_kung_vec_preinv_threaded.c
+++ b/src/nmod_poly/test/t-compose_mod_brent_kung_vec_preinv_threaded.c
@@ -11,7 +11,6 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
-#define ulong ulongxx/* interferes with system includes */
 
 #include <stdlib.h>
 #include <stdio.h>

--- a/src/nmod_poly/test/t-compose_mod_brent_kung_vec_preinv_threaded.c
+++ b/src/nmod_poly/test/t-compose_mod_brent_kung_vec_preinv_threaded.c
@@ -18,7 +18,6 @@
 
 #include <gmp.h>
 
-#define ulong mp_limb_t
 
 #include "flint.h"
 #include "nmod_poly.h"

--- a/src/nmod_poly/test/t-compose_mod_brent_kung_vec_preinv_threaded.c
+++ b/src/nmod_poly/test/t-compose_mod_brent_kung_vec_preinv_threaded.c
@@ -11,13 +11,11 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
-#undef ulong
 #define ulong ulongxx/* interferes with system includes */
 
 #include <stdlib.h>
 #include <stdio.h>
 
-#undef ulong
 
 #include <gmp.h>
 

--- a/src/nmod_poly/test/t-div_newton_n_preinv.c
+++ b/src/nmod_poly/test/t-div_newton_n_preinv.c
@@ -17,7 +17,6 @@
 
 #include <gmp.h>
 
-#define ulong mp_limb_t
 
 #include "flint.h"
 #include "nmod_poly.h"

--- a/src/nmod_poly/test/t-div_newton_n_preinv.c
+++ b/src/nmod_poly/test/t-div_newton_n_preinv.c
@@ -10,13 +10,11 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
-#undef ulong
 #define ulong ulongxx/* interferes with system includes */
 
 #include <stdlib.h>
 #include <stdio.h>
 
-#undef ulong
 
 #include <gmp.h>
 

--- a/src/nmod_poly/test/t-div_newton_n_preinv.c
+++ b/src/nmod_poly/test/t-div_newton_n_preinv.c
@@ -10,7 +10,6 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
-#define ulong ulongxx/* interferes with system includes */
 
 #include <stdlib.h>
 #include <stdio.h>

--- a/src/nmod_poly/test/t-divrem_newton_n_preinv.c
+++ b/src/nmod_poly/test/t-divrem_newton_n_preinv.c
@@ -17,7 +17,6 @@
 
 #include <gmp.h>
 
-#define ulong mp_limb_t
 
 #include "flint.h"
 #include "nmod_poly.h"

--- a/src/nmod_poly/test/t-divrem_newton_n_preinv.c
+++ b/src/nmod_poly/test/t-divrem_newton_n_preinv.c
@@ -10,13 +10,11 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
-#undef ulong
 #define ulong ulongxx/* interferes with system includes */
 
 #include <stdlib.h>
 #include <stdio.h>
 
-#undef ulong
 
 #include <gmp.h>
 

--- a/src/nmod_poly/test/t-divrem_newton_n_preinv.c
+++ b/src/nmod_poly/test/t-divrem_newton_n_preinv.c
@@ -10,7 +10,6 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
-#define ulong ulongxx/* interferes with system includes */
 
 #include <stdlib.h>
 #include <stdio.h>

--- a/src/nmod_poly/test/t-powmod_fmpz_binexp_preinv.c
+++ b/src/nmod_poly/test/t-powmod_fmpz_binexp_preinv.c
@@ -11,7 +11,6 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
-#define ulong ulongxx/* interferes with system includes */
 
 #include <stdlib.h>
 #include <stdio.h>

--- a/src/nmod_poly/test/t-powmod_fmpz_binexp_preinv.c
+++ b/src/nmod_poly/test/t-powmod_fmpz_binexp_preinv.c
@@ -18,7 +18,6 @@
 
 #include <gmp.h>
 
-#define ulong mp_limb_t
 
 #include "flint.h"
 #include "nmod_vec.h"

--- a/src/nmod_poly/test/t-powmod_fmpz_binexp_preinv.c
+++ b/src/nmod_poly/test/t-powmod_fmpz_binexp_preinv.c
@@ -11,13 +11,11 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
-#undef ulong
 #define ulong ulongxx/* interferes with system includes */
 
 #include <stdlib.h>
 #include <stdio.h>
 
-#undef ulong
 
 #include <gmp.h>
 

--- a/src/nmod_poly/test/t-powmod_mpz_binexp_preinv.c
+++ b/src/nmod_poly/test/t-powmod_mpz_binexp_preinv.c
@@ -11,7 +11,6 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
-#define ulong ulongxx/* interferes with system includes */
 
 #include <stdlib.h>
 #include <stdio.h>

--- a/src/nmod_poly/test/t-powmod_mpz_binexp_preinv.c
+++ b/src/nmod_poly/test/t-powmod_mpz_binexp_preinv.c
@@ -11,13 +11,11 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
-#undef ulong
 #define ulong ulongxx/* interferes with system includes */
 
 #include <stdlib.h>
 #include <stdio.h>
 
-#undef ulong
 
 #include <gmp.h>
 

--- a/src/nmod_poly/test/t-powmod_mpz_binexp_preinv.c
+++ b/src/nmod_poly/test/t-powmod_mpz_binexp_preinv.c
@@ -18,7 +18,6 @@
 
 #include <gmp.h>
 
-#define ulong mp_limb_t
 
 #include "flint.h"
 #include "gmpcompat.h"

--- a/src/nmod_poly/test/t-powmod_ui_binexp_preinv.c
+++ b/src/nmod_poly/test/t-powmod_ui_binexp_preinv.c
@@ -11,7 +11,6 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
-#define ulong ulongxx/* interferes with system includes */
 
 #include <stdlib.h>
 #include <stdio.h>

--- a/src/nmod_poly/test/t-powmod_ui_binexp_preinv.c
+++ b/src/nmod_poly/test/t-powmod_ui_binexp_preinv.c
@@ -18,7 +18,6 @@
 
 #include <gmp.h>
 
-#define ulong mp_limb_t
 
 #include "flint.h"
 #include "nmod_vec.h"

--- a/src/nmod_poly/test/t-powmod_ui_binexp_preinv.c
+++ b/src/nmod_poly/test/t-powmod_ui_binexp_preinv.c
@@ -11,13 +11,11 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
-#undef ulong
 #define ulong ulongxx/* interferes with system includes */
 
 #include <stdlib.h>
 #include <stdio.h>
 
-#undef ulong
 
 #include <gmp.h>
 

--- a/src/nmod_poly/test/t-powmod_x_fmpz_binexp.c
+++ b/src/nmod_poly/test/t-powmod_x_fmpz_binexp.c
@@ -11,7 +11,6 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
-#define ulong ulongxx/* interferes with system includes */
 
 #include <stdlib.h>
 #include <stdio.h>

--- a/src/nmod_poly/test/t-powmod_x_fmpz_binexp.c
+++ b/src/nmod_poly/test/t-powmod_x_fmpz_binexp.c
@@ -18,7 +18,6 @@
 
 #include <gmp.h>
 
-#define ulong mp_limb_t
 
 #include "flint.h"
 #include "nmod_vec.h"

--- a/src/nmod_poly/test/t-powmod_x_fmpz_binexp.c
+++ b/src/nmod_poly/test/t-powmod_x_fmpz_binexp.c
@@ -11,13 +11,11 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
-#undef ulong
 #define ulong ulongxx/* interferes with system includes */
 
 #include <stdlib.h>
 #include <stdio.h>
 
-#undef ulong
 
 #include <gmp.h>
 

--- a/src/nmod_poly/test/t-powmod_x_ui_binexp.c
+++ b/src/nmod_poly/test/t-powmod_x_ui_binexp.c
@@ -11,7 +11,6 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
-#define ulong ulongxx/* interferes with system includes */
 
 #include <stdlib.h>
 #include <stdio.h>

--- a/src/nmod_poly/test/t-powmod_x_ui_binexp.c
+++ b/src/nmod_poly/test/t-powmod_x_ui_binexp.c
@@ -18,7 +18,6 @@
 
 #include <gmp.h>
 
-#define ulong mp_limb_t
 
 #include "flint.h"
 #include "nmod_vec.h"

--- a/src/nmod_poly/test/t-powmod_x_ui_binexp.c
+++ b/src/nmod_poly/test/t-powmod_x_ui_binexp.c
@@ -11,13 +11,11 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
-#undef ulong
 #define ulong ulongxx/* interferes with system includes */
 
 #include <stdlib.h>
 #include <stdio.h>
 
-#undef ulong
 
 #include <gmp.h>
 

--- a/src/nmod_poly_factor.h
+++ b/src/nmod_poly_factor.h
@@ -22,7 +22,6 @@
 #define NMOD_POLY_FACTOR_INLINE static __inline__
 #endif
 
-#define ulong ulongxx /* interferes with system includes */
 #include <stdio.h>
 #include <gmp.h>
 #define ulong mp_limb_t

--- a/src/nmod_poly_factor.h
+++ b/src/nmod_poly_factor.h
@@ -24,7 +24,6 @@
 
 #include <stdio.h>
 #include <gmp.h>
-#define ulong mp_limb_t
 
 #include "flint.h"
 #include "nmod_vec.h"

--- a/src/nmod_poly_factor.h
+++ b/src/nmod_poly_factor.h
@@ -22,10 +22,8 @@
 #define NMOD_POLY_FACTOR_INLINE static __inline__
 #endif
 
-#undef ulong
 #define ulong ulongxx /* interferes with system includes */
 #include <stdio.h>
-#undef ulong
 #include <gmp.h>
 #define ulong mp_limb_t
 

--- a/src/nmod_poly_factor/factor_distinct_deg.c
+++ b/src/nmod_poly_factor/factor_distinct_deg.c
@@ -11,10 +11,8 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
-#undef ulong
 #define ulong ulongxx/* interferes with system includes */
 #include <math.h>
-#undef ulong
 #include <gmp.h>
 #define ulong mp_limb_t
 #include "nmod_poly.h"

--- a/src/nmod_poly_factor/factor_distinct_deg.c
+++ b/src/nmod_poly_factor/factor_distinct_deg.c
@@ -11,7 +11,6 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
-#define ulong ulongxx/* interferes with system includes */
 #include <math.h>
 #include <gmp.h>
 #define ulong mp_limb_t

--- a/src/nmod_poly_factor/factor_distinct_deg.c
+++ b/src/nmod_poly_factor/factor_distinct_deg.c
@@ -13,7 +13,6 @@
 
 #include <math.h>
 #include <gmp.h>
-#define ulong mp_limb_t
 #include "nmod_poly.h"
 
 void nmod_poly_factor_distinct_deg(nmod_poly_factor_t res,

--- a/src/nmod_poly_factor/factor_distinct_deg_threaded.c
+++ b/src/nmod_poly_factor/factor_distinct_deg_threaded.c
@@ -11,12 +11,10 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
-#undef ulong
 #define ulong ulongxx/* interferes with system includes */
 
 #include <math.h>
 #include <pthread.h>
-#undef ulong
 #include <gmp.h>
 #define ulong mp_limb_t
 #include "nmod_poly.h"

--- a/src/nmod_poly_factor/factor_distinct_deg_threaded.c
+++ b/src/nmod_poly_factor/factor_distinct_deg_threaded.c
@@ -15,7 +15,6 @@
 #include <math.h>
 #include <pthread.h>
 #include <gmp.h>
-#define ulong mp_limb_t
 #include "nmod_poly.h"
 
 void

--- a/src/nmod_poly_factor/factor_distinct_deg_threaded.c
+++ b/src/nmod_poly_factor/factor_distinct_deg_threaded.c
@@ -11,7 +11,6 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
-#define ulong ulongxx/* interferes with system includes */
 
 #include <math.h>
 #include <pthread.h>

--- a/src/nmod_poly_factor/inlines.c
+++ b/src/nmod_poly_factor/inlines.c
@@ -11,7 +11,6 @@
 
 #define NMOD_POLY_FACTOR_INLINES_C
 
-#define ulong ulongxx /* interferes with system includes */
 #include <stdlib.h>
 #include <stdio.h>
 #include <gmp.h>

--- a/src/nmod_poly_factor/inlines.c
+++ b/src/nmod_poly_factor/inlines.c
@@ -14,7 +14,6 @@
 #define ulong ulongxx /* interferes with system includes */
 #include <stdlib.h>
 #include <stdio.h>
-#undef ulong
 #include <gmp.h>
 #include "flint.h"
 #include "ulong_extras.h"

--- a/src/nmod_poly_factor/is_irreducible_ddf.c
+++ b/src/nmod_poly_factor/is_irreducible_ddf.c
@@ -11,10 +11,8 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
-#undef ulong
 #define ulong ulongxx/* interferes with system includes */
 #include <math.h>
-#undef ulong
 #include <gmp.h>
 #define ulong mp_limb_t
 #include "nmod_poly.h"

--- a/src/nmod_poly_factor/is_irreducible_ddf.c
+++ b/src/nmod_poly_factor/is_irreducible_ddf.c
@@ -11,7 +11,6 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
-#define ulong ulongxx/* interferes with system includes */
 #include <math.h>
 #include <gmp.h>
 #define ulong mp_limb_t

--- a/src/nmod_poly_factor/is_irreducible_ddf.c
+++ b/src/nmod_poly_factor/is_irreducible_ddf.c
@@ -13,7 +13,6 @@
 
 #include <math.h>
 #include <gmp.h>
-#define ulong mp_limb_t
 #include "nmod_poly.h"
 
 int nmod_poly_is_irreducible_ddf(const nmod_poly_t poly)

--- a/src/nmod_poly_factor/test/t-interval_threaded.c
+++ b/src/nmod_poly_factor/test/t-interval_threaded.c
@@ -18,7 +18,6 @@
 
 #include <gmp.h>
 
-#define ulong mp_limb_t
 
 #include "flint.h"
 #include "nmod_poly.h"

--- a/src/nmod_poly_factor/test/t-interval_threaded.c
+++ b/src/nmod_poly_factor/test/t-interval_threaded.c
@@ -10,14 +10,12 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
-#undef ulong
 #define ulong ulongxx/* interferes with system includes */
 
 #include <stdlib.h>
 #include <stdio.h>
 #include <pthread.h>
 
-#undef ulong
 
 #include <gmp.h>
 

--- a/src/nmod_poly_factor/test/t-interval_threaded.c
+++ b/src/nmod_poly_factor/test/t-interval_threaded.c
@@ -10,7 +10,6 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
-#define ulong ulongxx/* interferes with system includes */
 
 #include <stdlib.h>
 #include <stdio.h>

--- a/src/nmod_poly_factor/test/t-is_irreducible_ddf.c
+++ b/src/nmod_poly_factor/test/t-is_irreducible_ddf.c
@@ -10,13 +10,11 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
-#undef ulong
 #define ulong ulongxx/* interferes with system includes */
 
 #include <stdlib.h>
 #include <stdio.h>
 
-#undef ulong
 
 #include <gmp.h>
 

--- a/src/nmod_poly_factor/test/t-is_irreducible_ddf.c
+++ b/src/nmod_poly_factor/test/t-is_irreducible_ddf.c
@@ -10,7 +10,6 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
-#define ulong ulongxx/* interferes with system includes */
 
 #include <stdlib.h>
 #include <stdio.h>

--- a/src/nmod_poly_factor/test/t-is_irreducible_ddf.c
+++ b/src/nmod_poly_factor/test/t-is_irreducible_ddf.c
@@ -17,7 +17,6 @@
 
 #include <gmp.h>
 
-#define ulong mp_limb_t
 
 #include "flint.h"
 #include "nmod_vec.h"

--- a/src/nmod_poly_factor/test/t-is_irreducible_rabin.c
+++ b/src/nmod_poly_factor/test/t-is_irreducible_rabin.c
@@ -9,13 +9,11 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
-#undef ulong
 #define ulong ulongxx/* interferes with system includes */
 
 #include <stdlib.h>
 #include <stdio.h>
 
-#undef ulong
 
 #include <gmp.h>
 

--- a/src/nmod_poly_factor/test/t-is_irreducible_rabin.c
+++ b/src/nmod_poly_factor/test/t-is_irreducible_rabin.c
@@ -9,7 +9,6 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
-#define ulong ulongxx/* interferes with system includes */
 
 #include <stdlib.h>
 #include <stdio.h>

--- a/src/nmod_poly_factor/test/t-is_irreducible_rabin.c
+++ b/src/nmod_poly_factor/test/t-is_irreducible_rabin.c
@@ -16,7 +16,6 @@
 
 #include <gmp.h>
 
-#define ulong mp_limb_t
 
 #include "flint.h"
 #include "nmod_vec.h"

--- a/src/nmod_poly_mat/inlines.c
+++ b/src/nmod_poly_mat/inlines.c
@@ -11,7 +11,6 @@
 
 #define NMOD_POLY_MAT_INLINES_C
 
-#define ulong ulongxx /* interferes with system includes */
 #include <stdlib.h>
 #include <gmp.h>
 #include "flint.h"

--- a/src/nmod_poly_mat/inlines.c
+++ b/src/nmod_poly_mat/inlines.c
@@ -13,7 +13,6 @@
 
 #define ulong ulongxx /* interferes with system includes */
 #include <stdlib.h>
-#undef ulong
 #include <gmp.h>
 #include "flint.h"
 #include "nmod_poly_mat.h"

--- a/src/nmod_vec.h
+++ b/src/nmod_vec.h
@@ -21,7 +21,6 @@
 
 #include <stdlib.h>
 #include <gmp.h>
-#define ulong mp_limb_t
 
 #include "nmod.h"
 

--- a/src/nmod_vec.h
+++ b/src/nmod_vec.h
@@ -19,7 +19,6 @@
 #define NMOD_VEC_INLINE static __inline__
 #endif
 
-#define ulong ulongxx /* interferes with system includes */
 #include <stdlib.h>
 #include <gmp.h>
 #define ulong mp_limb_t

--- a/src/nmod_vec.h
+++ b/src/nmod_vec.h
@@ -19,10 +19,8 @@
 #define NMOD_VEC_INLINE static __inline__
 #endif
 
-#undef ulong
 #define ulong ulongxx /* interferes with system includes */
 #include <stdlib.h>
-#undef ulong
 #include <gmp.h>
 #define ulong mp_limb_t
 

--- a/src/nmod_vec/inlines.c
+++ b/src/nmod_vec/inlines.c
@@ -11,7 +11,6 @@
 
 #define NMOD_VEC_INLINES_C
 
-#define ulong ulongxx /* interferes with system includes */
 #include <stdlib.h>
 #include <gmp.h>
 #include "flint.h"

--- a/src/nmod_vec/inlines.c
+++ b/src/nmod_vec/inlines.c
@@ -13,7 +13,6 @@
 
 #define ulong ulongxx /* interferes with system includes */
 #include <stdlib.h>
-#undef ulong
 #include <gmp.h>
 #include "flint.h"
 #include "nmod_vec.h"

--- a/src/padic.h
+++ b/src/padic.h
@@ -22,7 +22,6 @@
 #include <stdio.h>
 
 #include <gmp.h>
-#define ulong mp_limb_t
 
 #include "flint.h"
 #include "fmpz.h"

--- a/src/padic.h
+++ b/src/padic.h
@@ -18,11 +18,9 @@
 #define PADIC_INLINE static __inline__
 #endif
 
-#undef ulong
 #define ulong ulongxx /* interferes with system includes */
 #include <stdlib.h>
 #include <stdio.h>
-#undef ulong
 
 #include <gmp.h>
 #define ulong mp_limb_t

--- a/src/padic.h
+++ b/src/padic.h
@@ -18,7 +18,6 @@
 #define PADIC_INLINE static __inline__
 #endif
 
-#define ulong ulongxx /* interferes with system includes */
 #include <stdlib.h>
 #include <stdio.h>
 

--- a/src/padic/inlines.c
+++ b/src/padic/inlines.c
@@ -11,7 +11,6 @@
 
 #define PADIC_INLINES_C
 
-#define ulong ulongxx /* interferes with system includes */
 #include <stdlib.h>
 #include <stdio.h>
 #include <gmp.h>

--- a/src/padic/inlines.c
+++ b/src/padic/inlines.c
@@ -14,7 +14,6 @@
 #define ulong ulongxx /* interferes with system includes */
 #include <stdlib.h>
 #include <stdio.h>
-#undef ulong
 #include <gmp.h>
 #include "flint.h"
 #include "ulong_extras.h"

--- a/src/padic_mat.h
+++ b/src/padic_mat.h
@@ -20,7 +20,6 @@
 
 #include <stdio.h>
 #include <gmp.h>
-#define ulong mp_limb_t
 
 #include "flint.h"
 #include "fmpz.h"

--- a/src/padic_mat.h
+++ b/src/padic_mat.h
@@ -18,7 +18,6 @@
 #define PADIC_MAT_INLINE static __inline__
 #endif
 
-#define ulong ulongxx /* interferes with system includes */
 #include <stdio.h>
 #include <gmp.h>
 #define ulong mp_limb_t

--- a/src/padic_mat.h
+++ b/src/padic_mat.h
@@ -18,10 +18,8 @@
 #define PADIC_MAT_INLINE static __inline__
 #endif
 
-#undef ulong
 #define ulong ulongxx /* interferes with system includes */
 #include <stdio.h>
-#undef ulong
 #include <gmp.h>
 #define ulong mp_limb_t
 

--- a/src/padic_mat/inlines.c
+++ b/src/padic_mat/inlines.c
@@ -13,7 +13,6 @@
 
 #define ulong ulongxx /* interferes with system includes */
 #include <stdlib.h>
-#undef ulong
 #include <gmp.h>
 #include "flint.h"
 #include "padic_mat.h"

--- a/src/padic_mat/inlines.c
+++ b/src/padic_mat/inlines.c
@@ -11,7 +11,6 @@
 
 #define PADIC_MAT_INLINES_C
 
-#define ulong ulongxx /* interferes with system includes */
 #include <stdlib.h>
 #include <gmp.h>
 #include "flint.h"

--- a/src/padic_poly.h
+++ b/src/padic_poly.h
@@ -18,7 +18,6 @@
 #define PADIC_POLY_INLINE static __inline__
 #endif
 
-#define ulong ulongxx/* interferes with system includes */
 #include <limits.h>
 
 #include <gmp.h>

--- a/src/padic_poly.h
+++ b/src/padic_poly.h
@@ -21,7 +21,6 @@
 #include <limits.h>
 
 #include <gmp.h>
-#define ulong mp_limb_t
 
 #include "fmpz.h"
 #include "fmpq.h"

--- a/src/padic_poly.h
+++ b/src/padic_poly.h
@@ -18,10 +18,8 @@
 #define PADIC_POLY_INLINE static __inline__
 #endif
 
-#undef ulong
 #define ulong ulongxx/* interferes with system includes */
 #include <limits.h>
-#undef ulong
 
 #include <gmp.h>
 #define ulong mp_limb_t

--- a/src/padic_poly/inlines.c
+++ b/src/padic_poly/inlines.c
@@ -11,7 +11,6 @@
 
 #define PADIC_POLY_INLINES_C
 
-#define ulong ulongxx /* interferes with system includes */
 #include <stdlib.h>
 #include <gmp.h>
 #include "flint.h"

--- a/src/padic_poly/inlines.c
+++ b/src/padic_poly/inlines.c
@@ -13,7 +13,6 @@
 
 #define ulong ulongxx /* interferes with system includes */
 #include <stdlib.h>
-#undef ulong
 #include <gmp.h>
 #include "flint.h"
 #include "padic_poly.h"

--- a/src/perm.h
+++ b/src/perm.h
@@ -21,7 +21,6 @@
 #include <stdlib.h>
 #include <stdio.h>
 #include <gmp.h>
-#define ulong mp_limb_t
 
 #include "flint.h"
 

--- a/src/perm.h
+++ b/src/perm.h
@@ -18,11 +18,9 @@
 #define PERM_INLINE static __inline__
 #endif
 
-#undef ulong
 #define ulong ulongxx /* interferes with system includes */
 #include <stdlib.h>
 #include <stdio.h>
-#undef ulong
 #include <gmp.h>
 #define ulong mp_limb_t
 

--- a/src/perm.h
+++ b/src/perm.h
@@ -18,7 +18,6 @@
 #define PERM_INLINE static __inline__
 #endif
 
-#define ulong ulongxx /* interferes with system includes */
 #include <stdlib.h>
 #include <stdio.h>
 #include <gmp.h>

--- a/src/perm/inlines.c
+++ b/src/perm/inlines.c
@@ -13,7 +13,6 @@
 
 #define ulong ulongxx /* interferes with system includes */
 #include <stdlib.h>
-#undef ulong
 #include <gmp.h>
 #include "flint.h"
 #include "perm.h"

--- a/src/perm/inlines.c
+++ b/src/perm/inlines.c
@@ -11,7 +11,6 @@
 
 #define PERM_INLINES_C
 
-#define ulong ulongxx /* interferes with system includes */
 #include <stdlib.h>
 #include <gmp.h>
 #include "flint.h"

--- a/src/profiler.h
+++ b/src/profiler.h
@@ -45,7 +45,6 @@ FLINT_DLL int gettimeofday(struct timeval * p, void * tz);
 #elif !defined(_MSC_VER)
 #include <sys/resource.h>
 #endif
-#define ulong mp_limb_t
 
 #ifdef __cplusplus
  extern "C" {

--- a/src/profiler.h
+++ b/src/profiler.h
@@ -14,7 +14,6 @@
 
 #include "flint.h"
 
-#undef ulong
 #define ulong ulongxx /* interferes with system includes */
 #include <time.h>
 #if defined( _MSC_VER )
@@ -47,7 +46,6 @@ FLINT_DLL int gettimeofday(struct timeval * p, void * tz);
 #elif !defined(_MSC_VER)
 #include <sys/resource.h>
 #endif
-#undef ulong
 #define ulong mp_limb_t
 
 #ifdef __cplusplus

--- a/src/profiler.h
+++ b/src/profiler.h
@@ -14,7 +14,6 @@
 
 #include "flint.h"
 
-#define ulong ulongxx /* interferes with system includes */
 #include <time.h>
 #if defined( _MSC_VER )
 #include <intrin.h>

--- a/src/qadic.h
+++ b/src/qadic.h
@@ -18,7 +18,6 @@
 #define QADIC_INLINE static __inline__
 #endif
 
-#define ulong ulongxx /* interferes with system includes */
 #include <stdlib.h>
 #include <stdio.h>
 

--- a/src/qadic.h
+++ b/src/qadic.h
@@ -22,7 +22,6 @@
 #include <stdio.h>
 
 #include <gmp.h>
-#define ulong mp_limb_t
 
 #include "flint.h"
 #include "fmpz.h"

--- a/src/qadic.h
+++ b/src/qadic.h
@@ -18,11 +18,9 @@
 #define QADIC_INLINE static __inline__
 #endif
 
-#undef ulong
 #define ulong ulongxx /* interferes with system includes */
 #include <stdlib.h>
 #include <stdio.h>
-#undef ulong
 
 #include <gmp.h>
 #define ulong mp_limb_t

--- a/src/qadic/inlines.c
+++ b/src/qadic/inlines.c
@@ -11,7 +11,6 @@
 
 #define QADIC_INLINES_C
 
-#define ulong ulongxx /* interferes with system includes */
 #include <stdlib.h>
 #include <gmp.h>
 #include "flint.h"

--- a/src/qadic/inlines.c
+++ b/src/qadic/inlines.c
@@ -13,7 +13,6 @@
 
 #define ulong ulongxx /* interferes with system includes */
 #include <stdlib.h>
-#undef ulong
 #include <gmp.h>
 #include "flint.h"
 #include "qadic.h"

--- a/src/ulong_extras/CRT.c
+++ b/src/ulong_extras/CRT.c
@@ -12,7 +12,6 @@
 #include <gmp.h>
 #define ulong ulongxx /* interferes with system includes */
 #include <math.h>
-#undef ulong
 #include "flint.h"
 #include "ulong_extras.h"
 #include "fmpz.h"

--- a/src/ulong_extras/CRT.c
+++ b/src/ulong_extras/CRT.c
@@ -10,7 +10,6 @@
 */
 
 #include <gmp.h>
-#define ulong ulongxx /* interferes with system includes */
 #include <math.h>
 #include "flint.h"
 #include "ulong_extras.h"

--- a/src/ulong_extras/cbrt.c
+++ b/src/ulong_extras/cbrt.c
@@ -14,7 +14,6 @@
 #include <gmp.h>
 #define ulong ulongxx /* interferes with system includes */
 #include <math.h>
-#undef ulong
 #include "flint.h"
 #include "ulong_extras.h"
 

--- a/src/ulong_extras/cbrt.c
+++ b/src/ulong_extras/cbrt.c
@@ -12,7 +12,6 @@
 */
 
 #include <gmp.h>
-#define ulong ulongxx /* interferes with system includes */
 #include <math.h>
 #include "flint.h"
 #include "ulong_extras.h"

--- a/src/ulong_extras/cbrt_binary_search.c
+++ b/src/ulong_extras/cbrt_binary_search.c
@@ -14,7 +14,6 @@
 #include <gmp.h>
 #define ulong ulongxx /* interferes with system includes */
 #include <math.h>
-#undef ulong
 #include "flint.h"
 #include "ulong_extras.h"
 

--- a/src/ulong_extras/cbrt_binary_search.c
+++ b/src/ulong_extras/cbrt_binary_search.c
@@ -12,7 +12,6 @@
 */
 
 #include <gmp.h>
-#define ulong ulongxx /* interferes with system includes */
 #include <math.h>
 #include "flint.h"
 #include "ulong_extras.h"

--- a/src/ulong_extras/cbrt_chebyshev_approximation.c
+++ b/src/ulong_extras/cbrt_chebyshev_approximation.c
@@ -14,7 +14,6 @@
 #include <gmp.h>
 #define ulong ulongxx /* interferes with system includes */
 #include <math.h>
-#undef ulong
 #include "flint.h"
 #include "ulong_extras.h"
 

--- a/src/ulong_extras/cbrt_chebyshev_approximation.c
+++ b/src/ulong_extras/cbrt_chebyshev_approximation.c
@@ -12,7 +12,6 @@
 */
 
 #include <gmp.h>
-#define ulong ulongxx /* interferes with system includes */
 #include <math.h>
 #include "flint.h"
 #include "ulong_extras.h"

--- a/src/ulong_extras/cbrt_estimate.c
+++ b/src/ulong_extras/cbrt_estimate.c
@@ -15,7 +15,6 @@
 #define ulong ulongxx /* interferes with system includes */
 #include <math.h>
 #include <float.h>
-#undef ulong
 #include "flint.h"
 #include "ulong_extras.h"
 #include "longlong.h"

--- a/src/ulong_extras/cbrt_estimate.c
+++ b/src/ulong_extras/cbrt_estimate.c
@@ -12,7 +12,6 @@
 */
 
 #include <gmp.h>
-#define ulong ulongxx /* interferes with system includes */
 #include <math.h>
 #include <float.h>
 #include "flint.h"

--- a/src/ulong_extras/cbrt_newton_iteration.c
+++ b/src/ulong_extras/cbrt_newton_iteration.c
@@ -14,7 +14,6 @@
 #include <gmp.h>
 #define ulong ulongxx /* interferes with system includes */
 #include <math.h>
-#undef ulong
 #include "flint.h"
 #include "ulong_extras.h"
 

--- a/src/ulong_extras/cbrt_newton_iteration.c
+++ b/src/ulong_extras/cbrt_newton_iteration.c
@@ -12,7 +12,6 @@
 */
 
 #include <gmp.h>
-#define ulong ulongxx /* interferes with system includes */
 #include <math.h>
 #include "flint.h"
 #include "ulong_extras.h"

--- a/src/ulong_extras/cbrtrem.c
+++ b/src/ulong_extras/cbrtrem.c
@@ -14,7 +14,6 @@
 #include <gmp.h>
 #define ulong ulongxx /* interferes with system includes */
 #include <math.h>
-#undef ulong
 #include "flint.h"
 #include "ulong_extras.h"
 

--- a/src/ulong_extras/cbrtrem.c
+++ b/src/ulong_extras/cbrtrem.c
@@ -12,7 +12,6 @@
 */
 
 #include <gmp.h>
-#define ulong ulongxx /* interferes with system includes */
 #include <math.h>
 #include "flint.h"
 #include "ulong_extras.h"

--- a/src/ulong_extras/compute_primes.c
+++ b/src/ulong_extras/compute_primes.c
@@ -15,7 +15,6 @@
 #include <string.h>
 #include <stdio.h>
 #include <gmp.h>
-#define ulong mp_limb_t
 
 #include "flint.h"
 #include "ulong_extras.h"

--- a/src/ulong_extras/compute_primes.c
+++ b/src/ulong_extras/compute_primes.c
@@ -15,7 +15,6 @@
 #include <stdlib.h>
 #include <string.h>
 #include <stdio.h>
-#undef ulong
 #include <gmp.h>
 #define ulong mp_limb_t
 

--- a/src/ulong_extras/compute_primes.c
+++ b/src/ulong_extras/compute_primes.c
@@ -11,7 +11,6 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
-#define ulong ulongxx /* interferes with system includes */
 #include <stdlib.h>
 #include <string.h>
 #include <stdio.h>

--- a/src/ulong_extras/factor.c
+++ b/src/ulong_extras/factor.c
@@ -12,7 +12,6 @@
 #define ulong ulongxx /* interferes with system includes */
 #include <stdlib.h>
 #include <stdio.h>
-#undef ulong
 #define ulong mp_limb_t
 #include <gmp.h>
 #include "flint.h"

--- a/src/ulong_extras/factor.c
+++ b/src/ulong_extras/factor.c
@@ -9,7 +9,6 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
-#define ulong ulongxx /* interferes with system includes */
 #include <stdlib.h>
 #include <stdio.h>
 #define ulong mp_limb_t

--- a/src/ulong_extras/factor.c
+++ b/src/ulong_extras/factor.c
@@ -11,7 +11,6 @@
 
 #include <stdlib.h>
 #include <stdio.h>
-#define ulong mp_limb_t
 #include <gmp.h>
 #include "flint.h"
 #include "ulong_extras.h"

--- a/src/ulong_extras/factor_lehman.c
+++ b/src/ulong_extras/factor_lehman.c
@@ -11,7 +11,6 @@
 
 #define ulong ulongxx /* interferes with system includes */
 #include <math.h>
-#undef ulong
 #include <gmp.h>
 #include "flint.h"
 #include "ulong_extras.h"

--- a/src/ulong_extras/factor_lehman.c
+++ b/src/ulong_extras/factor_lehman.c
@@ -9,7 +9,6 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
-#define ulong ulongxx /* interferes with system includes */
 #include <math.h>
 #include <gmp.h>
 #include "flint.h"

--- a/src/ulong_extras/factor_partial.c
+++ b/src/ulong_extras/factor_partial.c
@@ -9,7 +9,6 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
-#define ulong ulongxx /* prevent clash with standard library */
 #include <stdlib.h>
 #include <stdio.h>
 #include <gmp.h>

--- a/src/ulong_extras/factor_partial.c
+++ b/src/ulong_extras/factor_partial.c
@@ -12,7 +12,6 @@
 #define ulong ulongxx /* prevent clash with standard library */
 #include <stdlib.h>
 #include <stdio.h>
-#undef ulong
 #include <gmp.h>
 #include "flint.h"
 #include "ulong_extras.h"

--- a/src/ulong_extras/factor_power235.c
+++ b/src/ulong_extras/factor_power235.c
@@ -12,7 +12,6 @@
 
 #define ulong ulongxx /* interferes with standard libraries */
 #include <math.h>
-#undef ulong
 #include <gmp.h>
 #include "flint.h"
 #include "ulong_extras.h"

--- a/src/ulong_extras/factor_power235.c
+++ b/src/ulong_extras/factor_power235.c
@@ -10,7 +10,6 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
-#define ulong ulongxx /* interferes with standard libraries */
 #include <math.h>
 #include <gmp.h>
 #include "flint.h"

--- a/src/ulong_extras/factor_pp1.c
+++ b/src/ulong_extras/factor_pp1.c
@@ -11,7 +11,6 @@
 
 #define ulong ulongxx /* prevent clash with stdlib */
 #include <stdio.h>
-#undef ulong
 #include <gmp.h>
 #include "flint.h"
 #include "ulong_extras.h"

--- a/src/ulong_extras/factor_pp1.c
+++ b/src/ulong_extras/factor_pp1.c
@@ -9,7 +9,6 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
-#define ulong ulongxx /* prevent clash with stdlib */
 #include <stdio.h>
 #include <gmp.h>
 #include "flint.h"

--- a/src/ulong_extras/inlines.c
+++ b/src/ulong_extras/inlines.c
@@ -11,7 +11,6 @@
 
 #define ULONG_EXTRAS_INLINES_C
 
-#define ulong ulongxx /* interferes with system includes */
 #include <stdlib.h>
 #include <gmp.h>
 #include "flint.h"

--- a/src/ulong_extras/inlines.c
+++ b/src/ulong_extras/inlines.c
@@ -13,7 +13,6 @@
 
 #define ulong ulongxx /* interferes with system includes */
 #include <stdlib.h>
-#undef ulong
 #include <gmp.h>
 #include "flint.h"
 #include "ulong_extras.h"

--- a/src/ulong_extras/is_perfect_power.c
+++ b/src/ulong_extras/is_perfect_power.c
@@ -11,7 +11,6 @@
 */
 
 #include <gmp.h>
-#define ulong ulongxx /* interferes with system includes */
 #include <math.h>
 #include "flint.h"
 #include "ulong_extras.h"

--- a/src/ulong_extras/is_perfect_power.c
+++ b/src/ulong_extras/is_perfect_power.c
@@ -13,7 +13,6 @@
 #include <gmp.h>
 #define ulong ulongxx /* interferes with system includes */
 #include <math.h>
-#undef ulong
 #include "flint.h"
 #include "ulong_extras.h"
 

--- a/src/ulong_extras/is_perfect_power235.c
+++ b/src/ulong_extras/is_perfect_power235.c
@@ -11,7 +11,6 @@
 */
 
 #include <gmp.h>
-#define ulong ulongxx /* interferes with system includes */
 #include <math.h>
 #include "flint.h"
 #include "ulong_extras.h"

--- a/src/ulong_extras/is_perfect_power235.c
+++ b/src/ulong_extras/is_perfect_power235.c
@@ -13,7 +13,6 @@
 #include <gmp.h>
 #define ulong ulongxx /* interferes with system includes */
 #include <math.h>
-#undef ulong
 #include "flint.h"
 #include "ulong_extras.h"
 

--- a/src/ulong_extras/is_prime_pocklington.c
+++ b/src/ulong_extras/is_prime_pocklington.c
@@ -14,7 +14,6 @@
 #include <gmp.h>
 #include <math.h>
 #include <stdlib.h>
-#define ulong mp_limb_t
 #include "flint.h"
 #include "ulong_extras.h"
 

--- a/src/ulong_extras/is_prime_pocklington.c
+++ b/src/ulong_extras/is_prime_pocklington.c
@@ -12,7 +12,6 @@
 */
 
 #include <gmp.h>
-#define ulong ulongxx /* interferes with system includes */
 #include <math.h>
 #include <stdlib.h>
 #define ulong mp_limb_t

--- a/src/ulong_extras/is_prime_pocklington.c
+++ b/src/ulong_extras/is_prime_pocklington.c
@@ -15,7 +15,6 @@
 #define ulong ulongxx /* interferes with system includes */
 #include <math.h>
 #include <stdlib.h>
-#undef ulong
 #define ulong mp_limb_t
 #include "flint.h"
 #include "ulong_extras.h"

--- a/src/ulong_extras/is_prime_pseudosquare.c
+++ b/src/ulong_extras/is_prime_pseudosquare.c
@@ -9,7 +9,6 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
-#define ulong ulongxx /* interferes with system includes */
 #include <stdlib.h>
 #include <stdio.h>
 #include <gmp.h>

--- a/src/ulong_extras/is_prime_pseudosquare.c
+++ b/src/ulong_extras/is_prime_pseudosquare.c
@@ -12,7 +12,6 @@
 #define ulong ulongxx /* interferes with system includes */
 #include <stdlib.h>
 #include <stdio.h>
-#undef ulong
 #include <gmp.h>
 #include "flint.h"
 #include "ulong_extras.h"

--- a/src/ulong_extras/is_square.c
+++ b/src/ulong_extras/is_square.c
@@ -9,7 +9,6 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
-#define ulong ulongxx /* interferes with system includes */
 #include <math.h>
 #define ulong mp_limb_t
 #include <gmp.h>

--- a/src/ulong_extras/is_square.c
+++ b/src/ulong_extras/is_square.c
@@ -11,7 +11,6 @@
 
 #define ulong ulongxx /* interferes with system includes */
 #include <math.h>
-#undef ulong
 #define ulong mp_limb_t
 #include <gmp.h>
 #include "flint.h"

--- a/src/ulong_extras/is_square.c
+++ b/src/ulong_extras/is_square.c
@@ -10,7 +10,6 @@
 */
 
 #include <math.h>
-#define ulong mp_limb_t
 #include <gmp.h>
 #include "flint.h"
 #include "ulong_extras.h"

--- a/src/ulong_extras/nextprime.c
+++ b/src/ulong_extras/nextprime.c
@@ -12,7 +12,6 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
-#define ulong ulongxx /* interferes with system includes */
 #include <stdio.h>
 #include <stdlib.h>
 #define ulong mp_limb_t

--- a/src/ulong_extras/nextprime.c
+++ b/src/ulong_extras/nextprime.c
@@ -14,7 +14,6 @@
 
 #include <stdio.h>
 #include <stdlib.h>
-#define ulong mp_limb_t
 #include <gmp.h>
 #include "flint.h"
 #include "ulong_extras.h"

--- a/src/ulong_extras/nextprime.c
+++ b/src/ulong_extras/nextprime.c
@@ -15,7 +15,6 @@
 #define ulong ulongxx /* interferes with system includes */
 #include <stdio.h>
 #include <stdlib.h>
-#undef ulong
 #define ulong mp_limb_t
 #include <gmp.h>
 #include "flint.h"

--- a/src/ulong_extras/nth_prime.c
+++ b/src/ulong_extras/nth_prime.c
@@ -9,7 +9,6 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
-#define ulong ulongxx /* interferes with system includes */
 #include <stdlib.h>
 #include <stdio.h>
 #define ulong mp_limb_t

--- a/src/ulong_extras/nth_prime.c
+++ b/src/ulong_extras/nth_prime.c
@@ -12,7 +12,6 @@
 #define ulong ulongxx /* interferes with system includes */
 #include <stdlib.h>
 #include <stdio.h>
-#undef ulong
 #define ulong mp_limb_t
 #include "flint.h"
 #include "ulong_extras.h"

--- a/src/ulong_extras/nth_prime.c
+++ b/src/ulong_extras/nth_prime.c
@@ -11,7 +11,6 @@
 
 #include <stdlib.h>
 #include <stdio.h>
-#define ulong mp_limb_t
 #include "flint.h"
 #include "ulong_extras.h"
 

--- a/src/ulong_extras/randprime.c
+++ b/src/ulong_extras/randprime.c
@@ -13,7 +13,6 @@
 
 #include <stdlib.h>
 #include <stdio.h>
-#define ulong mp_limb_t
 #include "flint.h"
 #include "ulong_extras.h"
 

--- a/src/ulong_extras/randprime.c
+++ b/src/ulong_extras/randprime.c
@@ -11,7 +11,6 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
-#define ulong ulongxx /* interferes with system includes */
 #include <stdlib.h>
 #include <stdio.h>
 #define ulong mp_limb_t

--- a/src/ulong_extras/randprime.c
+++ b/src/ulong_extras/randprime.c
@@ -14,7 +14,6 @@
 #define ulong ulongxx /* interferes with system includes */
 #include <stdlib.h>
 #include <stdio.h>
-#undef ulong
 #define ulong mp_limb_t
 #include "flint.h"
 #include "ulong_extras.h"

--- a/src/ulong_extras/root.c
+++ b/src/ulong_extras/root.c
@@ -13,7 +13,6 @@
 
 #include <gmp.h>
 #include <math.h>
-#define ulong mp_limb_t
 #include "flint.h"
 #include "ulong_extras.h"
     

--- a/src/ulong_extras/root.c
+++ b/src/ulong_extras/root.c
@@ -12,7 +12,6 @@
 */
 
 #include <gmp.h>
-#define ulong ulongxx /* interferes with system includes */
 #include <math.h>
 #define ulong mp_limb_t
 #include "flint.h"

--- a/src/ulong_extras/root.c
+++ b/src/ulong_extras/root.c
@@ -14,7 +14,6 @@
 #include <gmp.h>
 #define ulong ulongxx /* interferes with system includes */
 #include <math.h>
-#undef ulong
 #define ulong mp_limb_t
 #include "flint.h"
 #include "ulong_extras.h"

--- a/src/ulong_extras/root_estimate.c
+++ b/src/ulong_extras/root_estimate.c
@@ -12,7 +12,6 @@
 */
 
 #include <gmp.h>
-#define ulong ulongxx /* interferes with system includes */
 #include <math.h>
 #define ulong mp_limb_t
 #include "flint.h"

--- a/src/ulong_extras/root_estimate.c
+++ b/src/ulong_extras/root_estimate.c
@@ -14,7 +14,6 @@
 #include <gmp.h>
 #define ulong ulongxx /* interferes with system includes */
 #include <math.h>
-#undef ulong
 #define ulong mp_limb_t
 #include "flint.h"
 #include "ulong_extras.h"

--- a/src/ulong_extras/root_estimate.c
+++ b/src/ulong_extras/root_estimate.c
@@ -13,7 +13,6 @@
 
 #include <gmp.h>
 #include <math.h>
-#define ulong mp_limb_t
 #include "flint.h"
 #include "ulong_extras.h"
 #include "longlong.h"

--- a/src/ulong_extras/rootrem.c
+++ b/src/ulong_extras/rootrem.c
@@ -13,7 +13,6 @@
 
 #include <gmp.h>
 #include <math.h>
-#define ulong mp_limb_t
 #include "flint.h"
 #include "ulong_extras.h"
 #include "fmpz.h"

--- a/src/ulong_extras/rootrem.c
+++ b/src/ulong_extras/rootrem.c
@@ -12,7 +12,6 @@
 */
 
 #include <gmp.h>
-#define ulong ulongxx /* interferes with system includes */
 #include <math.h>
 #define ulong mp_limb_t
 #include "flint.h"

--- a/src/ulong_extras/rootrem.c
+++ b/src/ulong_extras/rootrem.c
@@ -14,7 +14,6 @@
 #include <gmp.h>
 #define ulong ulongxx /* interferes with system includes */
 #include <math.h>
-#undef ulong
 #define ulong mp_limb_t
 #include "flint.h"
 #include "ulong_extras.h"

--- a/src/ulong_extras/sizeinbase.c
+++ b/src/ulong_extras/sizeinbase.c
@@ -11,7 +11,6 @@
 
 #include <gmp.h>
 #include <math.h>
-#define ulong mp_limb_t
 #include "flint.h"
 #include "ulong_extras.h"
 

--- a/src/ulong_extras/sizeinbase.c
+++ b/src/ulong_extras/sizeinbase.c
@@ -10,7 +10,6 @@
 */
 
 #include <gmp.h>
-#define ulong ulongxx /* interferes with system includes */
 #include <math.h>
 #define ulong mp_limb_t
 #include "flint.h"

--- a/src/ulong_extras/sizeinbase.c
+++ b/src/ulong_extras/sizeinbase.c
@@ -12,7 +12,6 @@
 #include <gmp.h>
 #define ulong ulongxx /* interferes with system includes */
 #include <math.h>
-#undef ulong
 #define ulong mp_limb_t
 #include "flint.h"
 #include "ulong_extras.h"

--- a/src/ulong_extras/sqrt.c
+++ b/src/ulong_extras/sqrt.c
@@ -12,7 +12,6 @@
 #include <gmp.h>
 #define ulong ulongxx /* interferes with system includes */
 #include <math.h>
-#undef ulong
 #include "flint.h"
 #include "ulong_extras.h"
 

--- a/src/ulong_extras/sqrt.c
+++ b/src/ulong_extras/sqrt.c
@@ -10,7 +10,6 @@
 */
 
 #include <gmp.h>
-#define ulong ulongxx /* interferes with system includes */
 #include <math.h>
 #include "flint.h"
 #include "ulong_extras.h"

--- a/src/ulong_extras/sqrtmod_primepow.c
+++ b/src/ulong_extras/sqrtmod_primepow.c
@@ -9,7 +9,6 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
-#define ulong ulongxx /* interferes with system includes */
 #include <stdio.h>
 #include <stdlib.h>
 #define ulong mp_limb_t

--- a/src/ulong_extras/sqrtmod_primepow.c
+++ b/src/ulong_extras/sqrtmod_primepow.c
@@ -12,7 +12,6 @@
 #define ulong ulongxx /* interferes with system includes */
 #include <stdio.h>
 #include <stdlib.h>
-#undef ulong
 #define ulong mp_limb_t
 #include <gmp.h>
 #include "flint.h"

--- a/src/ulong_extras/sqrtmod_primepow.c
+++ b/src/ulong_extras/sqrtmod_primepow.c
@@ -11,7 +11,6 @@
 
 #include <stdio.h>
 #include <stdlib.h>
-#define ulong mp_limb_t
 #include <gmp.h>
 #include "flint.h"
 #include "ulong_extras.h"

--- a/src/ulong_extras/sqrtmodn.c
+++ b/src/ulong_extras/sqrtmodn.c
@@ -12,7 +12,6 @@
 #define ulong ulongxx /* interferes with system includes */
 #include <stdio.h>
 #include <stdlib.h>
-#undef ulong
 #include <gmp.h>
 #include "flint.h"
 #include "ulong_extras.h"

--- a/src/ulong_extras/sqrtmodn.c
+++ b/src/ulong_extras/sqrtmodn.c
@@ -9,7 +9,6 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
-#define ulong ulongxx /* interferes with system includes */
 #include <stdio.h>
 #include <stdlib.h>
 #include <gmp.h>


### PR DESCRIPTION
Perhaps some change is necessary for some systems, but let's see what happens. I think problems has happened for BSD systems. In case of this, I will append a commit which only fixes this in `flint.h`.