### PR TITLE
Fix some compiler warning

### DIFF
--- a/src/acb/log.c
+++ b/src/acb/log.c
@@ -84,7 +84,7 @@ acb_log(acb_t r, const acb_t z, slong prec)
 }
 
 void
-acb_log_analytic(acb_ptr res, const acb_t z, int analytic, slong prec)
+acb_log_analytic(acb_t res, const acb_t z, int analytic, slong prec)
 {
     if (analytic && arb_contains_zero(acb_imagref(z)) &&
         !arb_is_positive(acb_realref(z)))

--- a/src/acb/pow.c
+++ b/src/acb/pow.c
@@ -234,7 +234,7 @@ acb_pow(acb_t z, const acb_t x, const acb_t y, slong prec)
 }
 
 void
-acb_pow_analytic(acb_ptr res, const acb_t z, const acb_t w, int analytic, slong prec)
+acb_pow_analytic(acb_t res, const acb_t z, const acb_t w, int analytic, slong prec)
 {
     if (analytic && !acb_is_int(w) && arb_contains_zero(acb_imagref(z)) &&
         !arb_is_positive(acb_realref(z)))

--- a/src/acb/rsqrt.c
+++ b/src/acb/rsqrt.c
@@ -469,7 +469,7 @@ acb_rsqrt(acb_t y, const acb_t x, slong prec)
 }
 
 void
-acb_rsqrt_analytic(acb_ptr res, const acb_t z, int analytic, slong prec)
+acb_rsqrt_analytic(acb_t res, const acb_t z, int analytic, slong prec)
 {
     if (analytic && arb_contains_zero(acb_imagref(z)) &&
         !arb_is_positive(acb_realref(z)))

--- a/src/acb/sqrt.c
+++ b/src/acb/sqrt.c
@@ -159,7 +159,7 @@ acb_sqrt(acb_t y, const acb_t x, slong prec)
 }
 
 void
-acb_sqrt_analytic(acb_ptr res, const acb_t z, int analytic, slong prec)
+acb_sqrt_analytic(acb_t res, const acb_t z, int analytic, slong prec)
 {
     if (analytic && arb_contains_zero(acb_imagref(z)) &&
         !arb_is_positive(acb_realref(z)))

--- a/src/acb_dirichlet/powsum_smooth.c
+++ b/src/acb_dirichlet/powsum_smooth.c
@@ -33,7 +33,7 @@ static ulong smul(ulong x, ulong y)
         return lo;
 }
 
-static slong index(const ulong * v, ulong c)
+static slong _index(const ulong * v, ulong c)
 {
     slong i;
     for (i = 0; ; i++)
@@ -131,15 +131,15 @@ acb_dirichlet_powsum_smooth(acb_ptr res, const acb_t s, ulong N, slong d, slong 
             }
             else if (n % 3 == 0)
             {
-                i3 = index(smooth, 3);
-                iu = index(smooth, n / 3);
+                i3 = _index(smooth, 3);
+                iu = _index(smooth, n / 3);
                 _acb_poly_mullow(powers + i * d,
                     powers + i3 * d, d, powers + iu * d, d, d, prec);
             }
             else
             {
-                i5 = index(smooth, 5);
-                iu = index(smooth, n / 5);
+                i5 = _index(smooth, 5);
+                iu = _index(smooth, n / 5);
                 _acb_poly_mullow(powers + i * d,
                     powers + i5 * d, d, powers + iu * d, d, d, prec);
             }
@@ -163,8 +163,8 @@ acb_dirichlet_powsum_smooth(acb_ptr res, const acb_t s, ulong N, slong d, slong 
 
         if ((UWORD(1) << v) != m)
         {
-            j = index(smooth, UWORD(1) << v);
-            iu = index(smooth, u);
+            j = _index(smooth, UWORD(1) << v);
+            iu = _index(smooth, u);
 
             if (u == 1)
             {
@@ -180,7 +180,7 @@ acb_dirichlet_powsum_smooth(acb_ptr res, const acb_t s, ulong N, slong d, slong 
 
     /* finally evaluate with respect to powers of 2 using horner */
     _acb_vec_zero(res, d);
-    i2 = index(smooth, 2);
+    i2 = _index(smooth, 2);
 
     for (i = num_smooth - 1; i >= 0; i--)
     {

--- a/src/arb/log_arf.c
+++ b/src/arb/log_arf.c
@@ -16,6 +16,7 @@ int _arb_log_ui_smooth(arb_t res, ulong n, slong prec);
 
 #define TMP_ALLOC_LIMBS(size) TMP_ALLOC((size) * sizeof(mp_limb_t))
 
+#if 0
 /* requires x != 1 */
 static void
 arf_log_via_mpfr(arf_t z, const arf_t x, slong prec, arf_rnd_t rnd)
@@ -60,6 +61,7 @@ arf_log_via_mpfr(arf_t z, const arf_t x, slong prec, arf_rnd_t rnd)
 
     TMP_END;
 }
+#endif
 
 void
 arb_log_arf_huge(arb_t z, const arf_t x, slong prec)

--- a/src/arf.h
+++ b/src/arf.h
@@ -1028,7 +1028,7 @@ int arf_sqrt_fmpz(arf_t z, const fmpz_t x, slong prec, arf_rnd_t rnd);
 
 int arf_rsqrt(arf_ptr z, arf_srcptr x, slong prec, arf_rnd_t rnd);
 
-int arf_root(arf_t z, const arf_t x, ulong k, slong prec, arf_rnd_t rnd);
+int arf_root(arf_ptr z, arf_srcptr x, ulong k, slong prec, arf_rnd_t rnd);
 
 /* Magnitude bounds */
 


### PR DESCRIPTION
This should fix all compiler warnings when compiling with `CFLAGS=-Wall`.