### PR TITLE
Fix #1264

### DIFF
--- a/src/fq_default/ctx_init_modulus_nmod.c
+++ b/src/fq_default/ctx_init_modulus_nmod.c
@@ -43,15 +43,24 @@ void fq_default_ctx_init_modulus_nmod_type(fq_default_ctx_t ctx,
     }
     else if (type == FQ_DEFAULT_NMOD || (type == 0 && d == 1))
     {
+        mp_limb_t c0, c1;
         ctx->type = FQ_DEFAULT_NMOD;
         nmod_init(&ctx->ctx.nmod.mod, p);
-        ctx->ctx.nmod.a = 0;
+        c0 = modulus->coeffs[0];
+        c1 = modulus->coeffs[1];
+        c0 = nmod_neg(c0, ctx->ctx.nmod.mod);
+        ctx->ctx.nmod.a = nmod_div(c0, c1, ctx->ctx.nmod.mod);
     }
     else if (type == FQ_DEFAULT_FMPZ_MOD || (type == 0 && d == 1))
     {
+        mp_limb_t c0, c1;
         ctx->type = FQ_DEFAULT_FMPZ_MOD;
         fmpz_mod_ctx_init_ui(ctx->ctx.fmpz_mod.mod, p);
         fmpz_init_set_ui(ctx->ctx.fmpz_mod.a, 0);
+        c0 = modulus->coeffs[0];
+        c1 = modulus->coeffs[1];
+        c0 = nmod_neg(c0, modulus->mod);
+        fmpz_set_ui(ctx->ctx.fmpz_mod.a, nmod_div(c0, c1, modulus->mod));
     }
     else
     {

--- a/src/fq_default/test/t-ctx_init_modulus_nmod.c
+++ b/src/fq_default/test/t-ctx_init_modulus_nmod.c
@@ -75,7 +75,105 @@ main(void)
 
         fq_default_ctx_clear(ctx);
     }
-    
+
+    {
+        fq_default_ctx_t ctx;
+        fq_default_t fq;
+        ulong p;
+        int result;
+        nmod_poly_t mod;
+        fmpz_mod_ctx_t mod_ctx;
+        fmpz_mod_poly_t mod2, mod3;
+        fmpz_t pp;
+
+        p = 3;
+
+        nmod_poly_init(mod, p);
+
+        nmod_poly_fit_length(mod, 2);
+
+        nmod_poly_set_coeff_ui(mod, 0, 2);
+        nmod_poly_set_coeff_ui(mod, 1, 1);
+
+        fq_default_ctx_init_modulus_nmod(ctx, mod, "x");
+
+        fmpz_init(pp);
+        fmpz_set_ui(pp, 3);
+        fmpz_mod_ctx_init(mod_ctx, pp);
+        fmpz_mod_poly_init(mod2, mod_ctx);
+        fmpz_mod_poly_init(mod3, mod_ctx);
+        fmpz_mod_poly_set_coeff_ui(mod3, 0, 2, mod_ctx);
+        fmpz_mod_poly_set_coeff_ui(mod3, 1, 1, mod_ctx);
+        fq_default_ctx_modulus(mod2, ctx);
+        result = fmpz_mod_poly_equal(mod2, mod3, mod_ctx);
+
+        if (!result)
+        {
+            flint_printf("FAIL:\n");
+            fmpz_mod_poly_print(mod2, mod_ctx); flint_printf("\n");
+            fmpz_mod_poly_print(mod3, mod_ctx); flint_printf("\n\n");
+            fflush(stdout);
+            flint_abort();
+        }
+
+        fq_default_clear(fq, ctx);
+        fq_default_ctx_clear(ctx);
+        fmpz_mod_poly_clear(mod2, mod_ctx);
+        fmpz_mod_poly_clear(mod3, mod_ctx);
+        fmpz_mod_ctx_clear(mod_ctx);
+        fmpz_clear(pp);
+        nmod_poly_clear(mod);
+    }
+
+    {
+        fq_default_ctx_t ctx;
+        fq_default_t fq;
+        ulong p;
+        int result;
+        nmod_poly_t mod;
+        fmpz_mod_ctx_t mod_ctx;
+        fmpz_mod_poly_t mod2, mod3;
+        fmpz_t pp;
+
+        p = 3;
+
+        nmod_poly_init(mod, p);
+
+        nmod_poly_fit_length(mod, 2);
+
+        nmod_poly_set_coeff_ui(mod, 0, 2);
+        nmod_poly_set_coeff_ui(mod, 1, 1);
+
+        fq_default_ctx_init_modulus_nmod_type(ctx, mod, "x", FQ_DEFAULT_FMPZ_MOD);
+
+        fmpz_init(pp);
+        fmpz_set_ui(pp, 3);
+        fmpz_mod_ctx_init(mod_ctx, pp);
+        fmpz_mod_poly_init(mod2, mod_ctx);
+        fmpz_mod_poly_init(mod3, mod_ctx);
+        fmpz_mod_poly_set_coeff_ui(mod3, 0, 2, mod_ctx);
+        fmpz_mod_poly_set_coeff_ui(mod3, 1, 1, mod_ctx);
+        fq_default_ctx_modulus(mod2, ctx);
+        result = fmpz_mod_poly_equal(mod2, mod3, mod_ctx);
+
+        if (!result)
+        {
+            flint_printf("FAIL:\n");
+            fmpz_mod_poly_print(mod2, mod_ctx); flint_printf("\n");
+            fmpz_mod_poly_print(mod3, mod_ctx); flint_printf("\n\n");
+            fflush(stdout);
+            flint_abort();
+        }
+
+        fq_default_clear(fq, ctx);
+        fq_default_ctx_clear(ctx);
+        fmpz_mod_poly_clear(mod2, mod_ctx);
+        fmpz_mod_poly_clear(mod3, mod_ctx);
+        fmpz_mod_ctx_clear(mod_ctx);
+        fmpz_clear(pp);
+        nmod_poly_clear(mod);
+    }
+
     FLINT_TEST_CLEANUP(state);
 
     flint_printf("PASS\n");


### PR DESCRIPTION
Initialize the fq_default_ctx properly if the input is a
linear nmod_poly.
