### PR TITLE
Add option to specify directory for temporary files

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -386,7 +386,9 @@ jobs:
       - name: "Configure"
         run: |
           ./bootstrap.sh
-          ./configure CC=${CC} CFLAGS="${CFLAGS}" ${EXTRA_OPTIONS}
+          # We need to specify TMPPATH as we do not have write access to the
+          # CI's /tmp directory.
+          ./configure CC=${CC} CFLAGS="${CFLAGS}" TMPPATH="." ${EXTRA_OPTIONS}
 
       - name: "Compile"
         run: |

--- a/CMake/cmake_config.h.in
+++ b/CMake/cmake_config.h.in
@@ -18,6 +18,8 @@
 
 #cmakedefine01 FLINT_USES_FENV
 
+#define FLINT_TMPPATH "@FLINT_TMPPATH@"
+
 #ifdef _MSC_VER
 #define access _access
 #define strcasecmp _stricmp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,6 +43,13 @@ if(CMAKE_BUILD_TYPE STREQUAL Debug)
   set(FLINT_WANT_ASSERT ON)
 endif()
 
+# temporary directory
+if(NOT DEFINED TMPPATH)
+    set(FLINT_TMPPATH "/tmp" CACHE STRING "Path to a directory meant for temporary files for host system (NOTE: Will probably become redundant in the future). Only relevant if host do not have read and write access to /tmp [default=/tmp].")
+else()
+    set(FLINT_TMPPATH "${TMPPATH}" CACHE STRING "Path to a directory meant for temporary files for host system (NOTE: Will probably become redundant in the future). Only relevant if host do not have read and write access to /tmp [default=/tmp].")
+endif()
+
 # pthread configuration
 
 if(MSVC)

--- a/configure.ac
+++ b/configure.ac
@@ -425,6 +425,15 @@ AC_SUBST(ABI_FLAG)
 
 AC_ARG_VAR(LDCONFIG, [ldconfig tool])
 
+AC_ARG_VAR(TMPPATH, [Path to a directory meant for temporary files for host system (NOTE: Will probably become redundant in the future). Only relevant if host do not have read and write access to /tmp [default=/tmp].])
+
+if test -z "$TMPPATH";
+then
+    TMPPATH="/tmp"
+fi
+
+AC_DEFINE_UNQUOTED([FLINT_TMPPATH], ["$TMPPATH"], [Define to set the default directory for temporary files])
+
 ################################################################################ 
 # check programs and system
 ################################################################################ 

--- a/src/qsieve/factor.c
+++ b/src/qsieve/factor.c
@@ -24,7 +24,7 @@
 
 #define _STDC_FORMAT_MACROS
 
-#if (defined(__WIN32) && !defined(__CYGWIN__)) || defined(__MINGW32__) || defined(__MINGW64__) || defined(_MSC_VER)
+#if (defined(__WIN32) && !defined(__CYGWIN__) && !defined(__MINGW32__) && !defined(__MINGW64__)) || defined(_MSC_VER)
 # include <windows.h>
 #endif
 
@@ -60,7 +60,7 @@ void qsieve_factor(fmpz_factor_t factors, const fmpz_t n)
     fmpz_t temp, temp2, X, Y;
     slong num_facs;
     fmpz * facs;
-#if (defined(__WIN32) && !defined(__CYGWIN__)) || defined(__MINGW32__) || defined(__MINGW64__) || defined(_MSC_VER)
+#if (defined(__WIN32) && !defined(__CYGWIN__) && !defined(__MINGW32__) && !defined(__MINGW64__)) || defined(_MSC_VER)
     char temp_path[MAX_PATH];
 #else
     int fd;
@@ -211,7 +211,7 @@ void qsieve_factor(fmpz_factor_t factors, const fmpz_t n)
     pthread_mutex_init(&qs_inf->mutex, NULL);
 #endif
 
-#if (defined(__WIN32) && !defined(__CYGWIN__)) || defined(__MINGW32__) || defined(__MINGW64__) || defined(_MSC_VER)
+#if (defined(__WIN32) && !defined(__CYGWIN__) && !defined(__MINGW32__) && !defined(__MINGW64__)) || defined(_MSC_VER)
     if (GetTempPathA(MAX_PATH, temp_path) == 0)
         flint_throw(FLINT_ERROR, "GetTempPathA failed\n");
 
@@ -222,7 +222,7 @@ void qsieve_factor(fmpz_factor_t factors, const fmpz_t n)
     if (qs_inf->siqs == NULL)
         flint_throw(FLINT_ERROR, "fopen failed\n");
 #else
-    strcpy(qs_inf->fname, "/tmp/siqsXXXXXX"); /* must be shorter than fname_alloc_size in init.c */
+    strcpy(qs_inf->fname, FLINT_TMPPATH "/siqsXXXXXX");
     fd = mkstemp(qs_inf->fname);
     if (fd == -1)
         flint_throw(FLINT_ERROR, "mkstemp failed\n");

--- a/src/qsieve/init.c
+++ b/src/qsieve/init.c
@@ -10,7 +10,7 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
-#if (defined(__WIN32) && !defined(__CYGWIN__)) || defined(__MINGW32__) || defined(__MINGW64__) || defined(_MSC_VER)
+#if (defined(__WIN32) && !defined(__CYGWIN__) && !defined(__MINGW32__) && !defined(__MINGW64__)) || defined(_MSC_VER)
 # include <windows.h>
 #endif
 
@@ -22,10 +22,10 @@ void qsieve_init(qs_t qs_inf, const fmpz_t n)
     size_t fname_alloc_size;
     slong i;
 
-#if (defined(__WIN32) && !defined(__CYGWIN__)) || defined(__MINGW32__) || defined(__MINGW64__) || defined(_MSC_VER)
+#if (defined(__WIN32) && !defined(__CYGWIN__) && !defined(__MINGW32__) && !defined(__MINGW64__)) || defined(_MSC_VER)
     fname_alloc_size = MAX_PATH;
 #else
-    fname_alloc_size = 20;
+    fname_alloc_size = sizeof(FLINT_TMPPATH "/siqsXXXXXX");
 #endif
     qs_inf->fname = (char *) flint_malloc(fname_alloc_size); /* space for filename */
 


### PR DESCRIPTION
Reason is that the MinGW CI fails due to no write access to `/tmp`.

Hopefully solves #1206