### PR TITLE
Fix configuration file

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -73,6 +73,7 @@ CFLAGS:=@CFLAGS@
 TESTCFLAGS:=@TESTCFLAGS@
 CPPFLAGS:=@CPPFLAGS@
 CPPFLAGS2:=-L$(FLINT_DIR) $(CPPFLAGS)
+LIB_CPPFLAGS:=@LIB_CPPFLAGS@
 CXXFLAGS:=@CXXFLAGS@
 LIBS:=@LIBS@
 LIBS2:=$(LIBS) -lflint
@@ -505,7 +506,7 @@ ifneq ($(STATIC), 0)
 define xxx_OBJS_rule
 $(BUILD_DIR)/$(1)/%.o: $(SRC_DIR)/$(1)/%.c | $(BUILD_DIR)/$(1)
 	@echo "  CC  $$(@:$(BUILD_DIR)/%=%)"
-	@$(CC) $(CFLAGS) $(CPPFLAGS) -c $$< -o $$@ -MMD -MF $$(@:%=%.d)
+	@$(CC) $(CFLAGS) $(CPPFLAGS) $(LIB_CPPFLAGS) -c $$< -o $$@ -MMD -MF $$(@:%=%.d)
 endef
 
 $(foreach dir, $(DIRS), $(eval $(call xxx_OBJS_rule,$(dir))))
@@ -513,7 +514,7 @@ $(foreach dir, $(DIRS), $(eval $(call xxx_OBJS_rule,$(dir))))
 ifneq ($(WANT_NTL), 0)
 $(BUILD_DIR)/interfaces/NTL-interface.o: $(SRC_DIR)/interfaces/test/t-NTL-interface.cpp | $(BUILD_DIR)/interfaces
 	@echo "  CXX $(@:$(BUILD_DIR)/%=%)"
-	@$(CXX) $(CXXFLAGS) $(CPPFLAGS) -c $< -o $@ -MMD -MF $(@:%=%.d)
+	@$(CXX) $(CXXFLAGS) $(CPPFLAGS) $(LIB_CPPFLAGS) -c $< -o $@ -MMD -MF $(@:%=%.d)
 endif
 endif
 
@@ -525,7 +526,7 @@ ifneq ($(SHARED), 0)
 define xxx_LOBJS_rule
 $(BUILD_DIR)/$(1)/%.lo: $(SRC_DIR)/$(1)/%.c | $(BUILD_DIR)/$(1)
 	@echo "  CC  $$(@:$(BUILD_DIR)/%=%)"
-	@$(CC) $(PIC_FLAG) $(CFLAGS) $(CPPFLAGS) -c $$< -o $$@ -MMD -MF $$(@:%=%.d)
+	@$(CC) $(PIC_FLAG) $(CFLAGS) $(CPPFLAGS) $(LIB_CPPFLAGS) -c $$< -o $$@ -MMD -MF $$(@:%=%.d)
 endef
 
 $(foreach dir, $(DIRS), $(eval $(call xxx_LOBJS_rule,$(dir))))
@@ -533,7 +534,7 @@ $(foreach dir, $(DIRS), $(eval $(call xxx_LOBJS_rule,$(dir))))
 ifneq ($(WANT_NTL), 0)
 $(BUILD_DIR)/interfaces/NTL-interface.lo: $(SRC_DIR)/interfaces/test/t-NTL-interface.cpp | $(BUILD_DIR)/interfaces
 	@echo "  CXX $(@:$(BUILD_DIR)/%=%)"
-	@$(CXX) $(PIC_FLAG) $(CXXFLAGS) $(CPPFLAGS) -c $< -o $@ -MMD -MF $(@:%=.d)
+	@$(CXX) $(PIC_FLAG) $(CXXFLAGS) $(CPPFLAGS) $(LIB_CPPFLAGS) -c $< -o $@ -MMD -MF $(@:%=.d)
 endif
 endif
 

--- a/Makefile.in
+++ b/Makefile.in
@@ -70,6 +70,7 @@ GC_LIB_PATH:=@GC_LIB_PATH@
 NTL_LIB_PATH:=@NTL_LIB_PATH@
 
 CFLAGS:=@CFLAGS@
+TESTCFLAGS:=@TESTCFLAGS@
 CPPFLAGS:=@CPPFLAGS@
 CPPFLAGS2:=-L$(FLINT_DIR) $(CPPFLAGS)
 CXXFLAGS:=@CXXFLAGS@
@@ -543,24 +544,24 @@ endif
 ifeq ($(SHARED), 0)
 $(BUILD_DIR)/profile/%$(EXEEXT): $(SRC_DIR)/profile/%.c $(FLINT_DIR)/$(FLINT_LIB_STATIC) | $(BUILD_DIR)/profile
 	@echo "  CC  $(@:$(BUILD_DIR)/%=%)"
-	@$(CC) $(CFLAGS) $(CPPFLAGS2) $< -o $@ $(EXE_LDFLAGS) $(LIBS2) -MMD -MF $(@:%=%.d)
+	@$(CC) $(TESTCFLAGS) $(CPPFLAGS2) $< -o $@ $(EXE_LDFLAGS) $(LIBS2) -MMD -MF $(@:%=%.d)
 else
 $(BUILD_DIR)/profile/%$(EXEEXT): $(SRC_DIR)/profile/%.c | $(FLINT_DIR)/$(FLINT_LIB) $(BUILD_DIR)/profile
 	@echo "  CC  $(@:$(BUILD_DIR)/%=%)"
-	@$(CC) $(CFLAGS) $(CPPFLAGS2) $< -o $@ $(EXE_LDFLAGS) $(LIBS2) -MMD -MF $(@:%=%.d)
+	@$(CC) $(TESTCFLAGS) $(CPPFLAGS2) $< -o $@ $(EXE_LDFLAGS) $(LIBS2) -MMD -MF $(@:%=%.d)
 endif
 
 ifeq ($(SHARED), 0)
 define xxx_PROFS_rule
 $(BUILD_DIR)/$(1)/profile/%$(EXEEXT): $(SRC_DIR)/$(1)/profile/%.c $(FLINT_DIR)/$(FLINT_LIB_STATIC) | $(BUILD_DIR)/$(1)/profile
 	@echo "  CC  $$(@:$(BUILD_DIR)/%=%)"
-	@$(CC) $(CFLAGS) $(CPPFLAGS2) $$< -o $$@ $(EXE_LDFLAGS) $(LIBS2) -MMD -MF $$(@:%=%.d)
+	@$(CC) $(TESTCFLAGS) $(CPPFLAGS2) $$< -o $$@ $(EXE_LDFLAGS) $(LIBS2) -MMD -MF $$(@:%=%.d)
 endef
 else
 define xxx_PROFS_rule
 $(BUILD_DIR)/$(1)/profile/%$(EXEEXT): $(SRC_DIR)/$(1)/profile/%.c | $(FLINT_DIR)/$(FLINT_LIB) $(BUILD_DIR)/$(1)/profile
 	@echo "  CC  $$(@:$(BUILD_DIR)/%=%)"
-	@$(CC) $(CFLAGS) $(CPPFLAGS2) $$< -o $$@ $(EXE_LDFLAGS) $(LIBS2) -MMD -MF $$(@:%=%.d)
+	@$(CC) $(TESTCFLAGS) $(CPPFLAGS2) $$< -o $$@ $(EXE_LDFLAGS) $(LIBS2) -MMD -MF $$(@:%=%.d)
 endef
 endif
 
@@ -569,24 +570,24 @@ $(foreach dir, $(DIRS), $(eval $(call xxx_PROFS_rule,$(dir))))
 ifeq ($(SHARED), 0)
 $(BUILD_DIR)/test/%$(EXEEXT): $(SRC_DIR)/test/%.c $(FLINT_DIR)/$(FLINT_LIB_STATIC) | $(BUILD_DIR)/test
 	@echo "  CC  $(@:$(BUILD_DIR)/%=%)"
-	@$(CC) $(CFLAGS) $(CPPFLAGS2) $< -o $@ $(EXE_LDFLAGS) $(LIBS2) -MMD -MF $(@:%=%.d)
+	@$(CC) $(TESTCFLAGS) $(CPPFLAGS2) $< -o $@ $(EXE_LDFLAGS) $(LIBS2) -MMD -MF $(@:%=%.d)
 else
 $(BUILD_DIR)/test/%$(EXEEXT): $(SRC_DIR)/test/%.c | $(FLINT_DIR)/$(FLINT_LIB) $(BUILD_DIR)/test
 	@echo "  CC  $(@:$(BUILD_DIR)/%=%)"
-	@$(CC) $(CFLAGS) $(CPPFLAGS2) $< -o $@ $(EXE_LDFLAGS) $(LIBS2) -MMD -MF $(@:%=%.d)
+	@$(CC) $(TESTCFLAGS) $(CPPFLAGS2) $< -o $@ $(EXE_LDFLAGS) $(LIBS2) -MMD -MF $(@:%=%.d)
 endif
 
 ifeq ($(SHARED), 0)
 define xxx_TESTS_rule
 $(BUILD_DIR)/$(1)/test/%$(EXEEXT): $(SRC_DIR)/$(1)/test/%.c $(FLINT_DIR)/libflint.a | $(BUILD_DIR)/$(1)/test
 	@echo "  CC  $$(@:$(BUILD_DIR)/%=%)"
-	@$(CC) $(CFLAGS) $(CPPFLAGS2) $$< -o $$@ $(EXE_LDFLAGS) $(LIBS2) -MMD -MF $$(@:%=%.d)
+	@$(CC) $(TESTCFLAGS) $(CPPFLAGS2) $$< -o $$@ $(EXE_LDFLAGS) $(LIBS2) -MMD -MF $$(@:%=%.d)
 endef
 else
 define xxx_TESTS_rule
 $(BUILD_DIR)/$(1)/test/%$(EXEEXT): $(SRC_DIR)/$(1)/test/%.c | $(FLINT_DIR)/$(FLINT_LIB) $(BUILD_DIR)/$(1)/test
 	@echo "  CC  $$(@:$(BUILD_DIR)/%=%)"
-	@$(CC) $(CFLAGS) $(CPPFLAGS2) $$< -o $$@ $(EXE_LDFLAGS) $(LIBS2) -MMD -MF $$(@:%=%.d)
+	@$(CC) $(TESTCFLAGS) $(CPPFLAGS2) $$< -o $$@ $(EXE_LDFLAGS) $(LIBS2) -MMD -MF $$(@:%=%.d)
 endef
 endif
 
@@ -607,24 +608,24 @@ endif
 ifeq ($(SHARED), 0)
 $(BUILD_DIR)/tune/%$(EXEEXT): $(SRC_DIR)/tune/%.c $(FLINT_DIR)/$(FLINT_LIB_STATIC) | $(BUILD_DIR)/tune
 	@echo "  CC  $(@:$(BUILD_DIR)/%=%)"
-	@$(CC) $(CFLAGS) $(CPPFLAGS2) $< -o $@ $(EXE_LDFLAGS) $(LIBS2) -MMD -MF $(@:%=%.d)
+	@$(CC) $(TESTCFLAGS) $(CPPFLAGS2) $< -o $@ $(EXE_LDFLAGS) $(LIBS2) -MMD -MF $(@:%=%.d)
 else
 $(BUILD_DIR)/tune/%$(EXEEXT): $(SRC_DIR)/tune/%.c | $(FLINT_DIR)/$(FLINT_LIB) $(BUILD_DIR)/tune
 	@echo "  CC  $(@:$(BUILD_DIR)/%=%)"
-	@$(CC) $(CFLAGS) $(CPPFLAGS2) $< -o $@ $(EXE_LDFLAGS) $(LIBS2) -MMD -MF $(@:%=%.d)
+	@$(CC) $(TESTCFLAGS) $(CPPFLAGS2) $< -o $@ $(EXE_LDFLAGS) $(LIBS2) -MMD -MF $(@:%=%.d)
 endif
 
 ifeq ($(SHARED), 0)
 define xxx_TUNES_rule
 $(BUILD_DIR)/$(1)/tune/%$(EXEEXT): $(SRC_DIR)/$(1)/tune/%.c $(FLINT_DIR)/$(FLINT_LIB_STATIC) | $(BUILD_DIR)/$(1)/tune
 	@echo "  CC  $$(@:$(BUILD_DIR)/%=%)"
-	@$(CC) $(CFLAGS) $(CPPFLAGS2) $$< -o $$@ $(EXE_LDFLAGS) $(LIBS2) -MMD -MF $$(@:%=%.d)
+	@$(CC) $(TESTCFLAGS) $(CPPFLAGS2) $$< -o $$@ $(EXE_LDFLAGS) $(LIBS2) -MMD -MF $$(@:%=%.d)
 endef
 else
 define xxx_TUNES_rule
 $(BUILD_DIR)/$(1)/tune/%$(EXEEXT): $(SRC_DIR)/$(1)/tune/%.c | $(FLINT_DIR)/$(FLINT_LIB) $(BUILD_DIR)/$(1)/tune
 	@echo "  CC  $$(@:$(BUILD_DIR)/%=%)"
-	@$(CC) $(CFLAGS) $(CPPFLAGS2) $$< -o $$@ $(EXE_LDFLAGS) $(LIBS2) -MMD -MF $$(@:%=%.d)
+	@$(CC) $(TESTCFLAGS) $(CPPFLAGS2) $$< -o $$@ $(EXE_LDFLAGS) $(LIBS2) -MMD -MF $$(@:%=%.d)
 endef
 endif
 
@@ -633,11 +634,11 @@ $(foreach dir, $(DIRS), $(eval $(call xxx_TUNES_rule,$(dir))))
 ifeq ($(SHARED), 0)
 $(BUILD_DIR)/examples/%$(EXEEXT): $(FLINT_DIR)/examples/%.c $(FLINT_DIR)/$(FLINT_LIB_STATIC) | $(BUILD_DIR)/examples
 	@echo "  CC  $(@:$(BUILD_DIR)/%=%)"
-	@$(CC) $(CFLAGS) $(CPPFLAGS2) $< -o $@ $(EXE_LDFLAGS) $(LIBS2) -MMD -MF $(@:%=%.d)
+	@$(CC) $(TESTCFLAGS) $(CPPFLAGS2) $< -o $@ $(EXE_LDFLAGS) $(LIBS2) -MMD -MF $(@:%=%.d)
 else
 $(BUILD_DIR)/examples/%$(EXEEXT): $(FLINT_DIR)/examples/%.c | $(FLINT_DIR)/$(FLINT_LIB) $(BUILD_DIR)/examples
 	@echo "  CC  $(@:$(BUILD_DIR)/%=%)"
-	@$(CC) $(CFLAGS) $(CPPFLAGS2) $< -o $@ $(EXE_LDFLAGS) $(LIBS2) -MMD -MF $(@:%=%.d)
+	@$(CC) $(TESTCFLAGS) $(CPPFLAGS2) $< -o $@ $(EXE_LDFLAGS) $(LIBS2) -MMD -MF $(@:%=%.d)
 endif
 
 ################################################################################

--- a/configure.ac
+++ b/configure.ac
@@ -89,6 +89,13 @@ else
     cflags_set="no"
 fi
 
+if test -n "${TESTCFLAGS+x}";
+then
+    testcflags_set="yes"
+else
+    testcflags_set="no"
+fi
+
 LT_INIT
 
 if test "$cflags_set" = "no";
@@ -414,7 +421,7 @@ AC_PROG_MKDIR_P
 # environment variables
 ################################################################################ 
 
-AC_ARG_VAR(TESTCFLAGS, [Choose different C compiler flags for tests [default=CFLAGS]. Can be useful to compile library at a specific optimization level while compiling tests fast.])
+AC_ARG_VAR([TESTCFLAGS], [Choose different C compiler flags for tests [default=CFLAGS]. Can be useful to compile library at a specific optimization level while compiling tests fast.])
 
 AC_ARG_VAR(ABI, [Desired ABI])
 
@@ -769,11 +776,12 @@ else
     AX_CHECK_COMPILE_FLAG([$CFLAGS],[],AC_MSG_ERROR([Couldn't compile with given CFLAGS!]))
 fi
 
-if test -n "${TESTCFLAGS+x}";
+if test "$testcflags_set" = "no";
 then
-    TESTCFLAGS=$CFLAGS
+    TESTCFLAGS="$CFLAGS"
+else
+    TESTCFLAGS="$TESTCFLAGS $save_CFLAGS"
 fi
-AC_SUBST(TESTCFLAGS)
 
 CPPFLAGS="-I./src $CPPFLAGS"
 

--- a/configure.ac
+++ b/configure.ac
@@ -767,7 +767,6 @@ dnl NOTE: The following flags shouldn't be default. They are leftovers from
 dnl previous configure script
 AX_CHECK_COMPILE_FLAG([-g],[DEFAULT_CFLAGS="-g $DEFAULT_CFLAGS"])
 AX_CHECK_COMPILE_FLAG([-funroll-loops],[DEFAULT_CFLAGS="-funroll-loops $DEFAULT_CFLAGS"])
-AX_CHECK_COMPILE_FLAG([-mpopcnt],[DEFAULT_CFLAGS="-mpopcnt $DEFAULT_CFLAGS"])
 
 if test "$cflags_set" = "no";
 then

--- a/configure.ac
+++ b/configure.ac
@@ -414,6 +414,8 @@ AC_PROG_MKDIR_P
 # environment variables
 ################################################################################ 
 
+AC_ARG_VAR(TESTCFLAGS, [Choose different C compiler flags for tests [default=CFLAGS]. Can be useful to compile library at a specific optimization level while compiling tests fast.])
+
 AC_ARG_VAR(ABI, [Desired ABI],
 if test -n "$ABI";
 then
@@ -757,6 +759,12 @@ then
     dnl FIXME: -g -funroll-loops shouldn't be activated by default
     CFLAGS="$CFLAGS $DEFAULT_CFLAGS $FLINT_CFLAGS -g -funroll-loops"
 fi
+
+if test -n "${TESTCFLAGS+x}";
+then
+    TESTCFLAGS=$CFLAGS
+fi
+AC_SUBST(TESTCFLAGS)
 
 AX_CHECK_COMPILE_FLAG($CFLAGS,[],AC_MSG_ERROR([Couldn't compile with CFLAGS!]))
 

--- a/configure.ac
+++ b/configure.ac
@@ -416,14 +416,7 @@ AC_PROG_MKDIR_P
 
 AC_ARG_VAR(TESTCFLAGS, [Choose different C compiler flags for tests [default=CFLAGS]. Can be useful to compile library at a specific optimization level while compiling tests fast.])
 
-AC_ARG_VAR(ABI, [Desired ABI],
-if test -n "$ABI";
-then
-    AX_CHECK_COMPILE_FLAG(-m$ABI,
-    [CFLAGS="-m$ABI $CFLAGS"],
-    [AC_MSG_ERROR([$CC does not support the ABI flag -m$ABI])])
-fi)
-AC_SUBST(ABI_FLAG)
+AC_ARG_VAR(ABI, [Desired ABI])
 
 AC_ARG_VAR(LDCONFIG, [ldconfig tool])
 
@@ -448,14 +441,6 @@ then
 fi
 
 AC_C_BIGENDIAN(flint_big_endian=yes)
-
-case $host_cpu in
-    sparc*)
-        AX_CHECK_COMPILE_FLAG(-mno-relax,[FLINT_CFLAGS="-mno-relax $FLINT_CFLAGS"])
-        ;;
-    *)
-        ;;
-esac
 
 case "$host_os" in
     darwin*)
@@ -718,46 +703,70 @@ AC_MSG_ERROR([Couldn't find alloca, which is required for FLINT. Please submit a
 report to <https://github.com/flintlib/flint2/issues/> and specify your
 operating system.])])
 
-if test "$enable_coverage" = "yes";
-then
-    AX_CHECK_COMPILE_FLAG([-fprofile-arcs -ftest-coverage],
-    [CFLAGS="-fprofile-arcs -ftest-coverage $CFLAGS"],
-    [AC_MSG_ERROR([$CC does not seem to support test coverage flags.])])
-fi
-
 AC_MSG_CHECKING([if $CC has popcount intrinsics])
 AC_COMPILE_IFELSE(
     [AC_LANG_PROGRAM([],[long int x = __builtin_popcountl(3);])],
     [AC_COMPILE_IFELSE(
         [AC_LANG_PROGRAM([],[long long int x = __builtin_popcountll(3);])],
         [AC_MSG_RESULT([yes])
-         AC_DEFINE(FLINT_USES_POPCNT,1,[Define if system has popcount intrinsics])
-         AX_CHECK_COMPILE_FLAG(-mpopcnt,[FLINT_CFLAGS="-mpopcnt $FLINT_CFLAGS"])],
+         has_popcount="yes"
+         AC_DEFINE(FLINT_USES_POPCNT,1,[Define if system has popcount intrinsics])],
         [AC_MSG_RESULT([no])]
     )],
     [AC_MSG_RESULT([no])]
 )
 
+################################################################################ 
+# CFLAGS
+################################################################################ 
+
+save_CFLAGS="$CFLAGS"
+CFLAGS=""
+
+# The following is needed for Clang to check for unknown options.
+AX_CHECK_COMPILE_FLAG([-Werror=unknown-warning-option], [CFLAGS="-Werror=unknown-warning-option"])
+
+if test "$enable_coverage" = "yes";
+then
+    AX_CHECK_COMPILE_FLAG([-fprofile-arcs -ftest-coverage],
+    [save_CFLAGS="-fprofile-arcs -ftest-coverage $save_CFLAGS"],
+    [AC_MSG_ERROR([$CC does not seem to support test coverage flags.])])
+fi
+
+if test -n "$ABI";
+then
+    AX_CHECK_COMPILE_FLAG([-m$ABI],
+    [save_CFLAGS="-m$ABI $save_CFLAGS"],
+    [AC_MSG_ERROR([$CC does not support the ABI flag -m$ABI])])
+fi
+AC_SUBST(ABI_FLAG)
+
+case $host_cpu in
+    sparc*)
+        AX_CHECK_COMPILE_FLAG(-mno-relax,[DEFAULT_CFLAGS="-mno-relax $DEFAULT_CFLAGS"])
+        ;;
+    *)
+        ;;
+esac
+
+AX_CHECK_COMPILE_FLAG([-Wall],[DEFAULT_CFLAGS="-Wall $DEFAULT_CFLAGS"])
+AX_CHECK_COMPILE_FLAG([-Wno-stringop-overread],[DEFAULT_CFLAGS="-Wno-stringop-overread $DEFAULT_CFLAGS"])
+AX_CHECK_COMPILE_FLAG([-Wno-stringop-overflow],[DEFAULT_CFLAGS="-Wno-stringop-overflow $DEFAULT_CFLAGS"])
+AX_CHECK_COMPILE_FLAG([-O2],[DEFAULT_CFLAGS="-O2 $DEFAULT_CFLAGS"])
+AX_CHECK_COMPILE_FLAG([-std=c99],[DEFAULT_CFLAGS="-std=c99 $DEFAULT_CFLAGS"])
+
+dnl NOTE: The following flags shouldn't be default. They are leftovers from
+dnl previous configure script
+AX_CHECK_COMPILE_FLAG([-g],[DEFAULT_CFLAGS="-g $DEFAULT_CFLAGS"])
+AX_CHECK_COMPILE_FLAG([-funroll-loops],[DEFAULT_CFLAGS="-funroll-loops $DEFAULT_CFLAGS"])
+AX_CHECK_COMPILE_FLAG([-mpopcnt],[DEFAULT_CFLAGS="-mpopcnt $DEFAULT_CFLAGS"])
+
 if test "$cflags_set" = "no";
 then
-    AC_MSG_CHECKING([default CFLAGS])
-    case $host_os in
-        mingw*|msys)
-            DEFAULT_CFLAGS="-std=c99 -O2 -Wall"
-            ;;
-        cygwin)
-            DEFAULT_CFLAGS="-O2 -Wall"
-            ;;
-        freebsd*|openbsd*)
-            DEFAULT_CFLAGS="-std=c99 -O2 -Wall"
-            ;;
-        *)
-            DEFAULT_CFLAGS="-ansi -O2 -Wall"
-            ;;
-    esac
-    AC_MSG_RESULT([$DEFAULT_CFLAGS])
-    dnl FIXME: -g -funroll-loops shouldn't be activated by default
-    CFLAGS="$CFLAGS $DEFAULT_CFLAGS $FLINT_CFLAGS -g -funroll-loops"
+    CFLAGS="$save_CFLAGS $DEFAULT_CFLAGS"
+else
+    CFLAGS="$save_CFLAGS"
+    AX_CHECK_COMPILE_FLAG([$CFLAGS],[],AC_MSG_ERROR([Couldn't compile with given CFLAGS!]))
 fi
 
 if test -n "${TESTCFLAGS+x}";
@@ -765,8 +774,6 @@ then
     TESTCFLAGS=$CFLAGS
 fi
 AC_SUBST(TESTCFLAGS)
-
-AX_CHECK_COMPILE_FLAG($CFLAGS,[],AC_MSG_ERROR([Couldn't compile with CFLAGS!]))
 
 CPPFLAGS="-I./src $CPPFLAGS"
 

--- a/configure.ac
+++ b/configure.ac
@@ -761,6 +761,7 @@ AX_CHECK_COMPILE_FLAG([-Wno-stringop-overread],[DEFAULT_CFLAGS="-Wno-stringop-ov
 AX_CHECK_COMPILE_FLAG([-Wno-stringop-overflow],[DEFAULT_CFLAGS="-Wno-stringop-overflow $DEFAULT_CFLAGS"])
 AX_CHECK_COMPILE_FLAG([-O2],[DEFAULT_CFLAGS="-O2 $DEFAULT_CFLAGS"])
 AX_CHECK_COMPILE_FLAG([-std=c99],[DEFAULT_CFLAGS="-std=c99 $DEFAULT_CFLAGS"])
+AX_CHECK_COMPILE_FLAG([-pedantic],[DEFAULT_CFLAGS="-pedantic $DEFAULT_CFLAGS"])
 
 dnl NOTE: The following flags shouldn't be default. They are leftovers from
 dnl previous configure script

--- a/configure.ac
+++ b/configure.ac
@@ -787,6 +787,8 @@ AC_SUBST(BLAS_LIB_PATH,$blas_lib_path)
 AC_SUBST(GC_LIB_PATH,$gc_lib_path)
 AC_SUBST(NTL_LIB_PATH,$ntl_lib_path)
 
+AC_SUBST(LIB_CPPFLAGS,[-DFLINT_NOSTDIO -DFLINT_NOSTDARG])
+
 # Configure fmpz's memory manager
 if test "$with_gc" = "yes";
 then

--- a/configure.ac
+++ b/configure.ac
@@ -749,10 +749,10 @@ then
             DEFAULT_CFLAGS="-O2 -Wall"
             ;;
         freebsd*|openbsd*)
-            DEFAULT_CFLAGS="-std=c99 -pedantic -O2 -Wall"
+            DEFAULT_CFLAGS="-std=c99 -O2 -Wall"
             ;;
         *)
-            DEFAULT_CFLAGS="-ansi -pedantic -O2 -Wall"
+            DEFAULT_CFLAGS="-ansi -O2 -Wall"
             ;;
     esac
     AC_MSG_RESULT([$DEFAULT_CFLAGS])
@@ -787,7 +787,7 @@ AC_SUBST(BLAS_LIB_PATH,$blas_lib_path)
 AC_SUBST(GC_LIB_PATH,$gc_lib_path)
 AC_SUBST(NTL_LIB_PATH,$ntl_lib_path)
 
-AC_SUBST(LIB_CPPFLAGS,[-DFLINT_NOSTDIO -DFLINT_NOSTDARG])
+AC_SUBST(LIB_CPPFLAGS,["-DFLINT_NOSTDIO -DFLINT_NOSTDARG"])
 
 # Configure fmpz's memory manager
 if test "$with_gc" = "yes";

--- a/src/fmpz/io.c
+++ b/src/fmpz/io.c
@@ -11,6 +11,7 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
+#include <stdio.h>
 #include "fmpz.h"
 
 /* printing *******************************************************************/

--- a/src/qfb/io.c
+++ b/src/qfb/io.c
@@ -9,6 +9,7 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
+#include <stdio.h>
 #include "qfb.h"
 
 /* printing *******************************************************************/


### PR DESCRIPTION
- Always compile the *library* without `stdio.h` and `stdarg.h`. This feature is not transferred into tests (so one does not have to include anything there to do `fflush(stdout)`). Neither is the feature transferred once installed -- it is only pushed as a preprocessor C flags for object files when compiling the library.
-  Give option to users to specify other CFLAGS for tests, named `TEST_CFLAGS`. Perhaps it's the best if this option is invisible, as it is mainly for maintainers. It's currently visible. For now this feature applies for all executables, which may change in the future.
- Include `stdio.h` in files according to the removal of `stdio.h` in library source files.
- Solve #1292 by testing `-mpopcnt` properly. Moreover, extend these tests for all CFLAGS. (Apparently Clang only gives warnings for some unknown options.)
- Include `-Wno-stringop-overread` and `-Wno-stringop-overflow` by default in CFLAGS to get rid of unwanted warnings (only if compiler supports it, which only seems to be GCC as of writing this).