### PR TITLE
Automatize documentation push

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,64 @@
+name: Deploy
+
+on:
+  push:
+    branches: [trunk]
+
+jobs:
+  ##############################################################################
+  # build documentation
+  ##############################################################################
+  build-doc:
+    name: Push documentation to website
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: "Check for changes in documentation"
+        id: check_doc_changes
+        run: |
+          if test -z "$(git diff --name-only HEAD~1..HEAD -- doc/)";
+          then
+            echo "No changes in doc/"
+            echo "diff=false" >> $GITHUB_OUTPUT
+          else
+            echo "Changes in doc/ detected"
+            echo "diff=true" >> $GITHUB_OUTPUT
+          fi
+
+      - name: "Setup"
+        if: success() && steps.check_doc_changes.outputs.diff == 'true'
+        run: |
+          sudo apt install -y python3-sphinx
+          sphinx-build --version
+
+      - name: "Build documentation"
+        if: success() && steps.check_doc_changes.outputs.diff == 'true'
+        run: |
+          cd doc
+          make html SPHINXOPTS="-W -j auto"
+
+      - name: "Create a tarball of the documentation"
+        if: success() && steps.check_doc_changes.outputs.diff == 'true'
+        run: |
+          cd doc/build
+          mv html doc
+          tar -czvf doc.tar.gz doc
+
+      - name: "Setup SSH key"
+        if: success() && steps.check_doc_changes.outputs.diff == 'true'
+        uses: shimataro/ssh-key-action@v2.5.0
+        with:
+          key: ${{ secrets.SSH_KEY }}
+          name: id_ed25519
+          known_hosts: ${{ secrets.KNOWN_HOSTS }}
+
+      - name: "Push documentation to server"
+        if: success() && steps.check_doc_changes.outputs.diff == 'true'
+        run: |
+          cd doc/build
+          ssh -t wbhart@opal6.opalstack.com 'mkdir ~/tmp'
+          scp doc.tar.gz wbhart@opal6.opalstack.com:~/tmp
+          ssh -t wbhart@opal6.opalstack.com 'cd ~/tmp && tar -xf doc.tar.gz && rm -rf ~/apps/flintlib_org/doc && mv doc ~/apps/flintlib_org && cd ~ && rm -rf ~/tmp'

--- a/doc/source/python_flint.rst
+++ b/doc/source/python_flint.rst
@@ -57,17 +57,24 @@ API documentation
 -------------------------------------------------------------------------------
 
 ..
-    automodsumm:: flint_ctypes
+   automodsumm:: flint_ctypes
 
-.. autoclass:: flint_ctypes.FlintDomainError
+..
+   autoclass:: flint_ctypes.FlintDomainError
 
-.. autoclass:: flint_ctypes.FlintUnableError
+..
+   autoclass:: flint_ctypes.FlintUnableError
 
-.. automodule:: flint_ctypes
-  :members:
-  :undoc-members:
-  :special-members: __init__ , __bool__
-  :member-order: bysource
+..
+   automodule:: flint_ctypes
+..
+   :members:
+..
+   :undoc-members:
+..
+   :special-members: __init__ , __bool__
+..
+   :member-order: bysource
 
 
 


### PR DESCRIPTION
This will PR will automatize the uploading of documentation to the server. It is done as the following:

1. Only performs this action if it is pushed to the `trunk` branch.
2. Checks if there is any change in the documentation directory between `HEAD` and `HEAD~1`. If there is no difference, do not perform the following steps.
3. Install requirements for building the documentation.
4. Build the HTML-documentation with the options to error on warning (so if there is any warnings at all, it will not proceed) and to build multithreaded.
5. Creates a tarball of the HTML.
6. Setups the SSH key (@fredrik-johansson see my comment in the end).
7. Pushes the documentation to the server. This is done by (1) creating a temporary directory `~/tmp`, (2) pushing the tarball to the temporary directory, (3) extracting the tarball in the temporary, (4) removing the current current documentation, (5) moving the new documentation's directory to its proper location, and (6) removing the temporary directory.

For this to work, @fredrik-johansson have to create a new SSH-key. I think no passphrase should be set, so on your computer, execute:
```
ssh-keygen -t ed25519
```
but **do not replace your own!** You may change the last word inside the file `path/to/id_ed25519.pub` from `user@computer` or `my-email@address.com` to `flint2@flintlib` to be make a distinction between possible ssh keys.

Then push this to the server via:
```
ssh-copy-id -i path/to/id_ed25519.pub username@remoteHost
```

Now you have to set some secrets for the repository (as I do not have access to this):
1. Go to *Settings* > *Security* > *Secrets and variables* and click on the green button "New repository secret".
2. Create the variable `SSH_KEY` with its content set to the non-public key, that is, the content of `path/to/id_ed25519` (**Important:** without the suffix `.pub`).
3. Create the variable `KNOWN_HOSTS`, with the content set to the public key of the server. You can find this out by connecting to the server via
```
ssh -o "IdentitiesOnly=yes" -i path/to/id_ed25519 username@remoteHost
```
exit, then search for the line starting with
```
remoteHost ssh-ed25519
```
in `~/.ssh/known_hosts`. The content of the variable should be set to this line.

Note that I have not tried the last line in `.github/workflows/docs.yml`. However, I have tried everything else, and it appears to work. I have checked pushing with changes on non-intended branch, with changes on the intended branch, and without changes on the intended branch. So it should work.