### PR TITLE
Move fmpq_[num/den]ref to flint.h and remove fmpq.h inclusion in arf.h

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -760,6 +760,7 @@ esac
 AX_CHECK_COMPILE_FLAG([-Wall],[DEFAULT_CFLAGS="-Wall $DEFAULT_CFLAGS"])
 AX_CHECK_COMPILE_FLAG([-Wno-stringop-overread],[DEFAULT_CFLAGS="-Wno-stringop-overread $DEFAULT_CFLAGS"])
 AX_CHECK_COMPILE_FLAG([-Wno-stringop-overflow],[DEFAULT_CFLAGS="-Wno-stringop-overflow $DEFAULT_CFLAGS"])
+AX_CHECK_COMPILE_FLAG([-Werror=implicit-function-declaration],[DEFAULT_CFLAGS="-Werror=implicit-function-declaration $DEFAULT_CFLAGS"])
 AX_CHECK_COMPILE_FLAG([-O2],[DEFAULT_CFLAGS="-O2 $DEFAULT_CFLAGS"])
 AX_CHECK_COMPILE_FLAG([-std=c99],[DEFAULT_CFLAGS="-std=c99 $DEFAULT_CFLAGS"])
 AX_CHECK_COMPILE_FLAG([-pedantic],[DEFAULT_CFLAGS="-pedantic $DEFAULT_CFLAGS"])

--- a/src/acb/lambertw_asymp.c
+++ b/src/acb/lambertw_asymp.c
@@ -9,6 +9,7 @@
     (at your option) any later version.  See <http://www.gnu.org/licenses/>.
 */
 
+#include "fmpz_vec.h"
 #include "acb.h"
 
 void

--- a/src/acb/test/t-dot_fmpz.c
+++ b/src/acb/test/t-dot_fmpz.c
@@ -9,6 +9,7 @@
     (at your option) any later version.  See <http://www.gnu.org/licenses/>.
 */
 
+#include "fmpz_vec.h"
 #include "acb.h"
 
 int main()

--- a/src/acb/test/t-rising2_ui.c
+++ b/src/acb/test/t-rising2_ui.c
@@ -9,6 +9,7 @@
     (at your option) any later version.  See <http://www.gnu.org/licenses/>.
 */
 
+#include "fmpz_vec.h"
 #include "arith.h"
 #include "acb_poly.h"
 

--- a/src/acb/test/t-vec_unit_roots.c
+++ b/src/acb/test/t-vec_unit_roots.c
@@ -9,6 +9,7 @@
     (at your option) any later version.  See <http://www.gnu.org/licenses/>.
 */
 
+#include "fmpq.h"
 #include "acb.h"
 
 int main()

--- a/src/acb/unit_root.c
+++ b/src/acb/unit_root.c
@@ -9,6 +9,7 @@
     (at your option) any later version.  See <http://www.gnu.org/licenses/>.
 */
 
+#include "fmpq.h"
 #include "acb.h"
 
 static void

--- a/src/acb_dirichlet/chi.c
+++ b/src/acb_dirichlet/chi.c
@@ -11,6 +11,7 @@
     (at your option) any later version.  See <http://www.gnu.org/licenses/>.
 */
 
+#include "fmpq.h"
 #include "acb_dirichlet.h"
 
 void

--- a/src/acb_dirichlet/l_fmpq.c
+++ b/src/acb_dirichlet/l_fmpq.c
@@ -9,6 +9,7 @@
     (at your option) any later version.  See <http://www.gnu.org/licenses/>.
 */
 
+#include "fmpq.h"
 #include "arb_mat.h"
 #include "arb_hypgeom.h"
 #include "acb_dirichlet.h"

--- a/src/acb_dirichlet/l_fmpq_afe.c
+++ b/src/acb_dirichlet/l_fmpq_afe.c
@@ -9,6 +9,7 @@
     (at your option) any later version.  See <http://www.gnu.org/licenses/>.
 */
 
+#include "fmpq.h"
 #include "arb_mat.h"
 #include "arb_hypgeom.h"
 #include "acb_dirichlet.h"

--- a/src/acb_dirichlet/pairing.c
+++ b/src/acb_dirichlet/pairing.c
@@ -9,6 +9,7 @@
     (at your option) any later version.  See <http://www.gnu.org/licenses/>.
 */
 
+#include "fmpq.h"
 #include "acb_dirichlet.h"
 
 void

--- a/src/acb_dirichlet/pairing_conrey.c
+++ b/src/acb_dirichlet/pairing_conrey.c
@@ -9,6 +9,7 @@
     (at your option) any later version.  See <http://www.gnu.org/licenses/>.
 */
 
+#include "fmpq.h"
 #include "acb_dirichlet.h"
 
 void

--- a/src/acb_dirichlet/platt_multieval.c
+++ b/src/acb_dirichlet/platt_multieval.c
@@ -9,6 +9,7 @@
     (at your option) any later version.  See <http://www.gnu.org/licenses/>.
 */
 
+#include "fmpz_vec.h"
 #include "acb_dirichlet.h"
 #include "arb_hypgeom.h"
 #include "acb_dft.h"

--- a/src/acb_dirichlet/platt_multieval_threaded.c
+++ b/src/acb_dirichlet/platt_multieval_threaded.c
@@ -10,6 +10,7 @@
     (at your option) any later version.  See <http://www.gnu.org/licenses/>.
 */
 
+#include "fmpz_vec.h"
 #include "acb_dirichlet.h"
 #include "pthread.h"
 

--- a/src/acb_dirichlet/root.c
+++ b/src/acb_dirichlet/root.c
@@ -10,6 +10,7 @@
     (at your option) any later version.  See <http://www.gnu.org/licenses/>.
 */
 
+#include "fmpq.h"
 #include "acb_dirichlet.h"
 
 void

--- a/src/acb_dirichlet/test/t-l_fmpq.c
+++ b/src/acb_dirichlet/test/t-l_fmpq.c
@@ -9,6 +9,7 @@
     (at your option) any later version.  See <http://www.gnu.org/licenses/>.
 */
 
+#include "fmpq.h"
 #include "acb_dirichlet.h"
 
 int main()

--- a/src/acb_dirichlet/test/t-l_fmpq_afe.c
+++ b/src/acb_dirichlet/test/t-l_fmpq_afe.c
@@ -9,6 +9,7 @@
     (at your option) any later version.  See <http://www.gnu.org/licenses/>.
 */
 
+#include "fmpq.h"
 #include "acb_dirichlet.h"
 
 int main()

--- a/src/acb_hypgeom/airy_direct.c
+++ b/src/acb_hypgeom/airy_direct.c
@@ -10,6 +10,7 @@
 */
 
 #include "ulong_extras.h"
+#include "fmpq.h"
 #include "acb.h"
 #include "acb_hypgeom.h"
 

--- a/src/acb_hypgeom/rising_ui_jet_powsum.c
+++ b/src/acb_hypgeom/rising_ui_jet_powsum.c
@@ -10,6 +10,7 @@
 */
 
 #include "nmod_vec.h"
+#include "fmpz_vec.h"
 #include "acb.h"
 #include "acb_hypgeom.h"
 

--- a/src/acb_hypgeom/rising_ui_jet_rs.c
+++ b/src/acb_hypgeom/rising_ui_jet_rs.c
@@ -10,6 +10,7 @@
 */
 
 #include "ulong_extras.h"
+#include "fmpz_vec.h"
 #include "acb_poly.h"
 #include "arb_hypgeom.h"
 #include "acb_hypgeom.h"

--- a/src/acb_modular/eta.c
+++ b/src/acb_modular/eta.c
@@ -9,6 +9,7 @@
     (at your option) any later version.  See <http://www.gnu.org/licenses/>.
 */
 
+#include "fmpq.h"
 #include "acb.h"
 #include "acb_modular.h"
 

--- a/src/acb_modular/test/t-epsilon_arg.c
+++ b/src/acb_modular/test/t-epsilon_arg.c
@@ -9,6 +9,7 @@
     (at your option) any later version.  See <http://www.gnu.org/licenses/>.
 */
 
+#include "fmpq.h"
 #include "acb.h"
 #include "acb_modular.h"
 #include "arith.h"

--- a/src/acb_modular/test/t-eta.c
+++ b/src/acb_modular/test/t-eta.c
@@ -9,6 +9,7 @@
     (at your option) any later version.  See <http://www.gnu.org/licenses/>.
 */
 
+#include "fmpq.h"
 #include "acb.h"
 #include "acb_modular.h"
 

--- a/src/acb_modular/test/t-fundamental_domain_approx.c
+++ b/src/acb_modular/test/t-fundamental_domain_approx.c
@@ -9,6 +9,7 @@
     (at your option) any later version.  See <http://www.gnu.org/licenses/>.
 */
 
+#include "fmpq.h"
 #include "acb.h"
 #include "acb_modular.h"
 

--- a/src/acb_modular/theta.c
+++ b/src/acb_modular/theta.c
@@ -9,6 +9,7 @@
     (at your option) any later version.  See <http://www.gnu.org/licenses/>.
 */
 
+#include "fmpq.h"
 #include "acb.h"
 #include "acb_modular.h"
 

--- a/src/acb_modular/theta_jet.c
+++ b/src/acb_modular/theta_jet.c
@@ -9,6 +9,7 @@
     (at your option) any later version.  See <http://www.gnu.org/licenses/>.
 */
 
+#include "fmpq.h"
 #include "acb_modular.h"
 #include "acb_poly.h"
 

--- a/src/acb_poly/contains_fmpq_poly.c
+++ b/src/acb_poly/contains_fmpq_poly.c
@@ -9,6 +9,7 @@
     (at your option) any later version.  See <http://www.gnu.org/licenses/>.
 */
 
+#include "fmpq.h"
 #include "fmpq_poly.h"
 #include "acb_poly.h"
 

--- a/src/acb_poly/find_roots.c
+++ b/src/acb_poly/find_roots.c
@@ -10,6 +10,7 @@
 */
 
 #include "ulong_extras.h"
+#include "fmpq.h"
 #include "acb_poly.h"
 
 slong

--- a/src/acb_poly/test/t-evaluate.c
+++ b/src/acb_poly/test/t-evaluate.c
@@ -9,6 +9,7 @@
     (at your option) any later version.  See <http://www.gnu.org/licenses/>.
 */
 
+#include "fmpq.h"
 #include "fmpq_poly.h"
 #include "acb_poly.h"
 

--- a/src/acb_poly/test/t-evaluate_horner.c
+++ b/src/acb_poly/test/t-evaluate_horner.c
@@ -9,6 +9,7 @@
     (at your option) any later version.  See <http://www.gnu.org/licenses/>.
 */
 
+#include "fmpq.h"
 #include "fmpq_poly.h"
 #include "acb_poly.h"
 

--- a/src/acb_poly/test/t-evaluate_vec_fast.c
+++ b/src/acb_poly/test/t-evaluate_vec_fast.c
@@ -9,6 +9,7 @@
     (at your option) any later version.  See <http://www.gnu.org/licenses/>.
 */
 
+#include "fmpq.h"
 #include "fmpq_poly.h"
 #include "acb_poly.h"
 

--- a/src/acb_poly/test/t-evaluate_vec_iter.c
+++ b/src/acb_poly/test/t-evaluate_vec_iter.c
@@ -9,6 +9,7 @@
     (at your option) any later version.  See <http://www.gnu.org/licenses/>.
 */
 
+#include "fmpq.h"
 #include "fmpq_poly.h"
 #include "acb_poly.h"
 

--- a/src/acb_poly/test/t-interpolate_barycentric.c
+++ b/src/acb_poly/test/t-interpolate_barycentric.c
@@ -9,6 +9,7 @@
     (at your option) any later version.  See <http://www.gnu.org/licenses/>.
 */
 
+#include "fmpq.h"
 #include "fmpq_poly.h"
 #include "acb_poly.h"
 

--- a/src/acb_poly/test/t-interpolate_fast.c
+++ b/src/acb_poly/test/t-interpolate_fast.c
@@ -9,6 +9,7 @@
     (at your option) any later version.  See <http://www.gnu.org/licenses/>.
 */
 
+#include "fmpq.h"
 #include "fmpq_poly.h"
 #include "acb_poly.h"
 

--- a/src/acb_poly/test/t-interpolate_newton.c
+++ b/src/acb_poly/test/t-interpolate_newton.c
@@ -9,6 +9,7 @@
     (at your option) any later version.  See <http://www.gnu.org/licenses/>.
 */
 
+#include "fmpq.h"
 #include "fmpq_poly.h"
 #include "acb_poly.h"
 

--- a/src/arb/atan_arf_bb.c
+++ b/src/arb/atan_arf_bb.c
@@ -10,6 +10,7 @@
 */
 
 #include "thread_support.h"
+#include "fmpz_vec.h"
 #include "arb.h"
 
 /*

--- a/src/arb/atan_sum_bs_powtab.c
+++ b/src/arb/atan_sum_bs_powtab.c
@@ -10,6 +10,7 @@
 */
 
 #include "thread_support.h"
+#include "fmpz_vec.h"
 #include "arb.h"
 
 slong _arb_compute_bs_exponents(slong * tab, slong n);

--- a/src/arb/bernoulli_ui.c
+++ b/src/arb/bernoulli_ui.c
@@ -9,6 +9,7 @@
     (at your option) any later version.  See <http://www.gnu.org/licenses/>.
 */
 
+#include "fmpq.h"
 #include "arb.h"
 #include "bernoulli.h"
 

--- a/src/arb/digamma.c
+++ b/src/arb/digamma.c
@@ -9,6 +9,7 @@
     (at your option) any later version.  See <http://www.gnu.org/licenses/>.
 */
 
+#include "fmpq.h"
 #include "arith.h"
 #include "arb.h"
 

--- a/src/arb/exp_arf_bb.c
+++ b/src/arb/exp_arf_bb.c
@@ -10,6 +10,7 @@
 */
 
 #include "thread_support.h"
+#include "fmpz_vec.h"
 #include "arb.h"
 
 /*

--- a/src/arb/exp_sum_bs_powtab.c
+++ b/src/arb/exp_sum_bs_powtab.c
@@ -10,6 +10,7 @@
 */
 
 #include "thread_support.h"
+#include "fmpz_vec.h"
 #include "arb.h"
 
 /* When splitting [a,b) into [a,m), [m,b), we need the power x^(m-a).

--- a/src/arb/get_rand_fmpq.c
+++ b/src/arb/get_rand_fmpq.c
@@ -9,6 +9,7 @@
     (at your option) any later version.  See <http://www.gnu.org/licenses/>.
 */
 
+#include "fmpq.h"
 #include "arb.h"
 
 void

--- a/src/arb/log_reduce.c
+++ b/src/arb/log_reduce.c
@@ -9,6 +9,7 @@
     (at your option) any later version.  See <http://www.gnu.org/licenses/>.
 */
 
+#include "fmpz_vec.h"
 #include "arb.h"
 
 #ifdef __GNUC__

--- a/src/arb/sin_cos_arf_bb.c
+++ b/src/arb/sin_cos_arf_bb.c
@@ -10,6 +10,7 @@
 */
 
 #include "thread_support.h"
+#include "fmpz_vec.h"
 #include "arb.h"
 #include "acb.h"
 

--- a/src/arb/test/t-acos.c
+++ b/src/arb/test/t-acos.c
@@ -10,6 +10,7 @@
 */
 
 #include <mpfr.h>
+#include "fmpq.h"
 #include "arb.h"
 
 int main()

--- a/src/arb/test/t-add.c
+++ b/src/arb/test/t-add.c
@@ -9,6 +9,7 @@
     (at your option) any later version.  See <http://www.gnu.org/licenses/>.
 */
 
+#include "fmpq.h"
 #include "arb.h"
 
 int main()

--- a/src/arb/test/t-addmul.c
+++ b/src/arb/test/t-addmul.c
@@ -9,6 +9,7 @@
     (at your option) any later version.  See <http://www.gnu.org/licenses/>.
 */
 
+#include "fmpq.h"
 #include "arb.h"
 
 int

--- a/src/arb/test/t-agm.c
+++ b/src/arb/test/t-agm.c
@@ -10,6 +10,7 @@
 */
 
 #include <mpfr.h>
+#include "fmpq.h"
 #include "arb.h"
 
 int main()

--- a/src/arb/test/t-asin.c
+++ b/src/arb/test/t-asin.c
@@ -10,6 +10,7 @@
 */
 
 #include <mpfr.h>
+#include "fmpq.h"
 #include "arb.h"
 
 int main()

--- a/src/arb/test/t-atan.c
+++ b/src/arb/test/t-atan.c
@@ -10,6 +10,7 @@
 */
 
 #include <mpfr.h>
+#include "fmpq.h"
 #include "arb.h"
 
 int main()

--- a/src/arb/test/t-atan2.c
+++ b/src/arb/test/t-atan2.c
@@ -10,6 +10,7 @@
 */
 
 #include <mpfr.h>
+#include "fmpq.h"
 #include "arb.h"
 
 int main()

--- a/src/arb/test/t-atan_sum_bs_powtab.c
+++ b/src/arb/test/t-atan_sum_bs_powtab.c
@@ -9,6 +9,7 @@
     (at your option) any later version.  See <http://www.gnu.org/licenses/>.
 */
 
+#include "fmpq.h"
 #include "arb.h"
 
 int main()

--- a/src/arb/test/t-ceil.c
+++ b/src/arb/test/t-ceil.c
@@ -9,6 +9,7 @@
     (at your option) any later version.  See <http://www.gnu.org/licenses/>.
 */
 
+#include "fmpq.h"
 #include "arb.h"
 
 int main()

--- a/src/arb/test/t-contains.c
+++ b/src/arb/test/t-contains.c
@@ -9,6 +9,7 @@
     (at your option) any later version.  See <http://www.gnu.org/licenses/>.
 */
 
+#include "fmpq.h"
 #include "arb.h"
 
 int main()

--- a/src/arb/test/t-contains_arf.c
+++ b/src/arb/test/t-contains_arf.c
@@ -9,6 +9,7 @@
     (at your option) any later version.  See <http://www.gnu.org/licenses/>.
 */
 
+#include "fmpq.h"
 #include "arb.h"
 
 int main()

--- a/src/arb/test/t-contains_fmpq.c
+++ b/src/arb/test/t-contains_fmpq.c
@@ -9,6 +9,7 @@
     (at your option) any later version.  See <http://www.gnu.org/licenses/>.
 */
 
+#include "fmpq.h"
 #include "arb.h"
 
 int main()

--- a/src/arb/test/t-contains_interior.c
+++ b/src/arb/test/t-contains_interior.c
@@ -9,6 +9,7 @@
     (at your option) any later version.  See <http://www.gnu.org/licenses/>.
 */
 
+#include "fmpq.h"
 #include "arb.h"
 
 int main()

--- a/src/arb/test/t-cos.c
+++ b/src/arb/test/t-cos.c
@@ -10,6 +10,7 @@
 */
 
 #include <mpfr.h>
+#include "fmpq.h"
 #include "arb.h"
 
 int main()

--- a/src/arb/test/t-cos_pi_fmpq.c
+++ b/src/arb/test/t-cos_pi_fmpq.c
@@ -9,7 +9,7 @@
     (at your option) any later version.  See <http://www.gnu.org/licenses/>.
 */
 
-#include "ulong_extras.h"
+#include "fmpq.h"
 #include "arb.h"
 
 int main()

--- a/src/arb/test/t-cosh.c
+++ b/src/arb/test/t-cosh.c
@@ -10,6 +10,7 @@
 */
 
 #include <mpfr.h>
+#include "fmpq.h"
 #include "arb.h"
 
 int main()

--- a/src/arb/test/t-div.c
+++ b/src/arb/test/t-div.c
@@ -9,6 +9,7 @@
     (at your option) any later version.  See <http://www.gnu.org/licenses/>.
 */
 
+#include "fmpq.h"
 #include "arb.h"
 
 int main()

--- a/src/arb/test/t-dot_fmpz.c
+++ b/src/arb/test/t-dot_fmpz.c
@@ -9,6 +9,7 @@
     (at your option) any later version.  See <http://www.gnu.org/licenses/>.
 */
 
+#include "fmpz_vec.h"
 #include "arb.h"
 
 int main()

--- a/src/arb/test/t-euler_number_ui.c
+++ b/src/arb/test/t-euler_number_ui.c
@@ -9,6 +9,7 @@
     (at your option) any later version.  See <http://www.gnu.org/licenses/>.
 */
 
+#include "fmpz_vec.h"
 #include "ulong_extras.h"
 #include "arith.h"
 #include "arb.h"

--- a/src/arb/test/t-exp.c
+++ b/src/arb/test/t-exp.c
@@ -10,6 +10,7 @@
 */
 
 #include <mpfr.h>
+#include "fmpq.h"
 #include "arb.h"
 
 /* check accuracy compared to reference algorithm */

--- a/src/arb/test/t-exp_sum_bs_powtab.c
+++ b/src/arb/test/t-exp_sum_bs_powtab.c
@@ -9,6 +9,7 @@
     (at your option) any later version.  See <http://www.gnu.org/licenses/>.
 */
 
+#include "fmpq.h"
 #include "arb.h"
 
 int main()

--- a/src/arb/test/t-expm1.c
+++ b/src/arb/test/t-expm1.c
@@ -10,6 +10,7 @@
 */
 
 #include <mpfr.h>
+#include "fmpq.h"
 #include "arb.h"
 
 int main()

--- a/src/arb/test/t-floor.c
+++ b/src/arb/test/t-floor.c
@@ -9,6 +9,7 @@
     (at your option) any later version.  See <http://www.gnu.org/licenses/>.
 */
 
+#include "fmpq.h"
 #include "arb.h"
 
 int main()

--- a/src/arb/test/t-gamma_fmpq.c
+++ b/src/arb/test/t-gamma_fmpq.c
@@ -10,6 +10,7 @@
 */
 
 #include "ulong_extras.h"
+#include "fmpq.h"
 #include "arb.h"
 
 #ifdef __GNUC__

--- a/src/arb/test/t-get_abs_lbound_arf.c
+++ b/src/arb/test/t-get_abs_lbound_arf.c
@@ -9,6 +9,7 @@
     (at your option) any later version.  See <http://www.gnu.org/licenses/>.
 */
 
+#include "fmpq.h"
 #include "arb.h"
 
 int main()

--- a/src/arb/test/t-get_lbound_arf.c
+++ b/src/arb/test/t-get_lbound_arf.c
@@ -9,6 +9,7 @@
     (at your option) any later version.  See <http://www.gnu.org/licenses/>.
 */
 
+#include "fmpq.h"
 #include "arb.h"
 
 int main()

--- a/src/arb/test/t-get_rand_fmpq.c
+++ b/src/arb/test/t-get_rand_fmpq.c
@@ -9,6 +9,7 @@
     (at your option) any later version.  See <http://www.gnu.org/licenses/>.
 */
 
+#include "fmpq.h"
 #include "arb.h"
 
 int main()

--- a/src/arb/test/t-intersection.c
+++ b/src/arb/test/t-intersection.c
@@ -9,6 +9,7 @@
     (at your option) any later version.  See <http://www.gnu.org/licenses/>.
 */
 
+#include "fmpq.h"
 #include "arb.h"
 
 int main()

--- a/src/arb/test/t-log.c
+++ b/src/arb/test/t-log.c
@@ -10,6 +10,7 @@
 */
 
 #include <mpfr.h>
+#include "fmpq.h"
 #include "arb.h"
 
 int main()

--- a/src/arb/test/t-log_newton.c
+++ b/src/arb/test/t-log_newton.c
@@ -10,6 +10,7 @@
 */
 
 #include <mpfr.h>
+#include "fmpq.h"
 #include "arb.h"
 
 int main()

--- a/src/arb/test/t-mul.c
+++ b/src/arb/test/t-mul.c
@@ -9,6 +9,7 @@
     (at your option) any later version.  See <http://www.gnu.org/licenses/>.
 */
 
+#include "fmpq.h"
 #include "arb.h"
 
 int

--- a/src/arb/test/t-mul_more.c
+++ b/src/arb/test/t-mul_more.c
@@ -9,6 +9,7 @@
     (at your option) any later version.  See <http://www.gnu.org/licenses/>.
 */
 
+#include "fmpq.h"
 #include "arb.h"
 
 int main()

--- a/src/arb/test/t-overlaps.c
+++ b/src/arb/test/t-overlaps.c
@@ -9,6 +9,7 @@
     (at your option) any later version.  See <http://www.gnu.org/licenses/>.
 */
 
+#include "fmpq.h"
 #include "arb.h"
 
 int main()

--- a/src/arb/test/t-pow_fmpq.c
+++ b/src/arb/test/t-pow_fmpq.c
@@ -9,6 +9,7 @@
     (at your option) any later version.  See <http://www.gnu.org/licenses/>.
 */
 
+#include "fmpq.h"
 #include "arb.h"
 
 int main()

--- a/src/arb/test/t-rising2_ui.c
+++ b/src/arb/test/t-rising2_ui.c
@@ -9,6 +9,7 @@
     (at your option) any later version.  See <http://www.gnu.org/licenses/>.
 */
 
+#include "fmpz_vec.h"
 #include "arith.h"
 #include "arb_poly.h"
 

--- a/src/arb/test/t-rising_ui.c
+++ b/src/arb/test/t-rising_ui.c
@@ -9,6 +9,7 @@
     (at your option) any later version.  See <http://www.gnu.org/licenses/>.
 */
 
+#include "fmpq.h"
 #include "arb.h"
 
 int main()

--- a/src/arb/test/t-sin.c
+++ b/src/arb/test/t-sin.c
@@ -10,6 +10,7 @@
 */
 
 #include <mpfr.h>
+#include "fmpq.h"
 #include "arb.h"
 
 int main()

--- a/src/arb/test/t-sin_cos.c
+++ b/src/arb/test/t-sin_cos.c
@@ -10,6 +10,7 @@
 */
 
 #include <mpfr.h>
+#include "fmpq.h"
 #include "arb.h"
 
 int main()

--- a/src/arb/test/t-sin_cos_generic.c
+++ b/src/arb/test/t-sin_cos_generic.c
@@ -10,6 +10,7 @@
 */
 
 #include <mpfr.h>
+#include "fmpq.h"
 #include "arb.h"
 
 int main()

--- a/src/arb/test/t-sin_cos_pi_fmpq.c
+++ b/src/arb/test/t-sin_cos_pi_fmpq.c
@@ -9,6 +9,7 @@
     (at your option) any later version.  See <http://www.gnu.org/licenses/>.
 */
 
+#include "fmpq.h"
 #include "arb.h"
 
 int main()

--- a/src/arb/test/t-sin_pi_fmpq.c
+++ b/src/arb/test/t-sin_pi_fmpq.c
@@ -9,6 +9,7 @@
     (at your option) any later version.  See <http://www.gnu.org/licenses/>.
 */
 
+#include "fmpq.h"
 #include "arb.h"
 
 int main()

--- a/src/arb/test/t-sinh.c
+++ b/src/arb/test/t-sinh.c
@@ -10,6 +10,7 @@
 */
 
 #include <mpfr.h>
+#include "fmpq.h"
 #include "arb.h"
 
 int main()

--- a/src/arb/test/t-sinh_cosh.c
+++ b/src/arb/test/t-sinh_cosh.c
@@ -10,6 +10,7 @@
 */
 
 #include <mpfr.h>
+#include "fmpq.h"
 #include "arb.h"
 
 int main()

--- a/src/arb/test/t-sub.c
+++ b/src/arb/test/t-sub.c
@@ -9,6 +9,7 @@
     (at your option) any later version.  See <http://www.gnu.org/licenses/>.
 */
 
+#include "fmpq.h"
 #include "arb.h"
 
 int main()

--- a/src/arb/test/t-submul.c
+++ b/src/arb/test/t-submul.c
@@ -9,6 +9,7 @@
     (at your option) any later version.  See <http://www.gnu.org/licenses/>.
 */
 
+#include "fmpq.h"
 #include "arb.h"
 
 int

--- a/src/arb/zeta_ui_bernoulli.c
+++ b/src/arb/zeta_ui_bernoulli.c
@@ -9,6 +9,7 @@
     (at your option) any later version.  See <http://www.gnu.org/licenses/>.
 */
 
+#include "fmpq.h"
 #include "arb.h"
 #include "bernoulli.h"
 

--- a/src/arb/zeta_ui_vec_borwein.c
+++ b/src/arb/zeta_ui_vec_borwein.c
@@ -9,6 +9,7 @@
     (at your option) any later version.  See <http://www.gnu.org/licenses/>.
 */
 
+#include "fmpz_vec.h"
 #include "arb.h"
 
 /* With parameter n, the error is bounded by 3/(3+sqrt(8))^n */

--- a/src/arb_hypgeom/erf.c
+++ b/src/arb_hypgeom/erf.c
@@ -10,6 +10,7 @@
 */
 
 #include "double_extras.h"
+#include "fmpq.h"
 #include "arb_hypgeom.h"
 
 #define LOG2 0.69314718055994530942

--- a/src/arb_hypgeom/gamma.c
+++ b/src/arb_hypgeom/gamma.c
@@ -9,6 +9,7 @@
     (at your option) any later version.  See <http://www.gnu.org/licenses/>.
 */
 
+#include "fmpq.h"
 #include "acb.h"
 #include "arb_hypgeom.h"
 #include "bernoulli.h"

--- a/src/arb_hypgeom/gamma_fmpq.c
+++ b/src/arb_hypgeom/gamma_fmpq.c
@@ -11,6 +11,7 @@
 
 #include "double_extras.h"
 #include "fmpz_poly.h"
+#include "fmpq.h"
 #include "arb_hypgeom.h"
 #include "hypgeom.h"
 

--- a/src/arb_hypgeom/gamma_upper_fmpq.c
+++ b/src/arb_hypgeom/gamma_upper_fmpq.c
@@ -9,6 +9,7 @@
     (at your option) any later version.  See <http://www.gnu.org/licenses/>.
 */
 
+#include "fmpq.h"
 #include "arb_hypgeom.h"
 
 static void

--- a/src/arb_hypgeom/gamma_upper_fmpq_step_bsplit.c
+++ b/src/arb_hypgeom/gamma_upper_fmpq_step_bsplit.c
@@ -10,6 +10,7 @@
 */
 
 #include <stdio.h>
+#include "fmpq.h"
 #include "arb_mat.h"
 #include "arb_hypgeom.h"
 

--- a/src/arb_hypgeom/legendre_p_ui_asymp.c
+++ b/src/arb_hypgeom/legendre_p_ui_asymp.c
@@ -10,6 +10,7 @@
 */
 
 #include "ulong_extras.h"
+#include "fmpz_vec.h"
 #include "acb.h"
 #include "arb_hypgeom.h"
 

--- a/src/arb_hypgeom/legendre_p_ui_one.c
+++ b/src/arb_hypgeom/legendre_p_ui_one.c
@@ -10,6 +10,7 @@
 */
 
 #include "ulong_extras.h"
+#include "fmpz_vec.h"
 #include "arb_hypgeom.h"
 
 #define UNROLL 4

--- a/src/arb_hypgeom/legendre_p_ui_zero.c
+++ b/src/arb_hypgeom/legendre_p_ui_zero.c
@@ -10,6 +10,7 @@
 */
 
 #include "ulong_extras.h"
+#include "fmpz_vec.h"
 #include "arb_hypgeom.h"
 
 #define UNROLL 4

--- a/src/arb_hypgeom/rising_ui_jet_powsum.c
+++ b/src/arb_hypgeom/rising_ui_jet_powsum.c
@@ -10,6 +10,7 @@
 */
 
 #include "nmod_vec.h"
+#include "fmpz_vec.h"
 #include "arb_hypgeom.h"
 
 void

--- a/src/arb_hypgeom/rising_ui_jet_rs.c
+++ b/src/arb_hypgeom/rising_ui_jet_rs.c
@@ -10,6 +10,7 @@
 */
 
 #include "ulong_extras.h"
+#include "fmpz_vec.h"
 #include "arb_poly.h"
 #include "arb_hypgeom.h"
 

--- a/src/arb_hypgeom/sum_fmpq_arb_rs.c
+++ b/src/arb_hypgeom/sum_fmpq_arb_rs.c
@@ -10,6 +10,7 @@
 */
 
 #include "ulong_extras.h"
+#include "fmpz_vec.h"
 #include "arb_hypgeom.h"
 
 #ifdef __GNUC__

--- a/src/arb_hypgeom/sum_fmpq_imag_arb_rs.c
+++ b/src/arb_hypgeom/sum_fmpq_imag_arb_rs.c
@@ -10,6 +10,7 @@
 */
 
 #include "ulong_extras.h"
+#include "fmpz_vec.h"
 #include "arb_hypgeom.h"
 
 #ifdef __GNUC__

--- a/src/arb_hypgeom/test/t-gamma_fmpq.c
+++ b/src/arb_hypgeom/test/t-gamma_fmpq.c
@@ -9,6 +9,7 @@
     (at your option) any later version.  See <http://www.gnu.org/licenses/>.
 */
 
+#include "fmpq.h"
 #include "ulong_extras.h"
 #include "arb_hypgeom.h"
 

--- a/src/arb_hypgeom/test/t-gamma_lower_sum_rs.c
+++ b/src/arb_hypgeom/test/t-gamma_lower_sum_rs.c
@@ -9,6 +9,7 @@
     (at your option) any later version.  See <http://www.gnu.org/licenses/>.
 */
 
+#include "fmpq.h"
 #include "arb_hypgeom.h"
 
 int main()

--- a/src/arb_hypgeom/test/t-gamma_upper_fmpq.c
+++ b/src/arb_hypgeom/test/t-gamma_upper_fmpq.c
@@ -9,6 +9,7 @@
     (at your option) any later version.  See <http://www.gnu.org/licenses/>.
 */
 
+#include "fmpq.h"
 #include "arb_hypgeom.h"
 
 int main()

--- a/src/arb_hypgeom/test/t-gamma_upper_sum_rs.c
+++ b/src/arb_hypgeom/test/t-gamma_upper_sum_rs.c
@@ -9,6 +9,7 @@
     (at your option) any later version.  See <http://www.gnu.org/licenses/>.
 */
 
+#include "fmpq.h"
 #include "arb_hypgeom.h"
 
 int main()

--- a/src/arb_hypgeom/test/t-sum_fmpq_arb.c
+++ b/src/arb_hypgeom/test/t-sum_fmpq_arb.c
@@ -9,6 +9,7 @@
     (at your option) any later version.  See <http://www.gnu.org/licenses/>.
 */
 
+#include "fmpq.h"
 #include "fmpq_vec.h"
 #include "arb_hypgeom.h"
 

--- a/src/arb_hypgeom/test/t-sum_fmpq_imag_arb.c
+++ b/src/arb_hypgeom/test/t-sum_fmpq_imag_arb.c
@@ -9,6 +9,7 @@
     (at your option) any later version.  See <http://www.gnu.org/licenses/>.
 */
 
+#include "fmpq.h"
 #include "fmpq_vec.h"
 #include "arb_hypgeom.h"
 

--- a/src/arb_poly/contains_fmpq_poly.c
+++ b/src/arb_poly/contains_fmpq_poly.c
@@ -9,6 +9,7 @@
     (at your option) any later version.  See <http://www.gnu.org/licenses/>.
 */
 
+#include "fmpq.h"
 #include "fmpq_poly.h"
 #include "arb_poly.h"
 

--- a/src/arb_poly/test/t-evaluate.c
+++ b/src/arb_poly/test/t-evaluate.c
@@ -9,6 +9,7 @@
     (at your option) any later version.  See <http://www.gnu.org/licenses/>.
 */
 
+#include "fmpq.h"
 #include "fmpq_poly.h"
 #include "arb_poly.h"
 

--- a/src/arb_poly/test/t-evaluate_horner.c
+++ b/src/arb_poly/test/t-evaluate_horner.c
@@ -9,6 +9,7 @@
     (at your option) any later version.  See <http://www.gnu.org/licenses/>.
 */
 
+#include "fmpq.h"
 #include "fmpq_poly.h"
 #include "arb_poly.h"
 

--- a/src/arb_poly/test/t-evaluate_vec_fast.c
+++ b/src/arb_poly/test/t-evaluate_vec_fast.c
@@ -9,6 +9,7 @@
     (at your option) any later version.  See <http://www.gnu.org/licenses/>.
 */
 
+#include "fmpq.h"
 #include "fmpq_poly.h"
 #include "arb_poly.h"
 

--- a/src/arb_poly/test/t-evaluate_vec_iter.c
+++ b/src/arb_poly/test/t-evaluate_vec_iter.c
@@ -9,6 +9,7 @@
     (at your option) any later version.  See <http://www.gnu.org/licenses/>.
 */
 
+#include "fmpq.h"
 #include "fmpq_poly.h"
 #include "arb_poly.h"
 

--- a/src/arb_poly/test/t-interpolate_barycentric.c
+++ b/src/arb_poly/test/t-interpolate_barycentric.c
@@ -9,6 +9,7 @@
     (at your option) any later version.  See <http://www.gnu.org/licenses/>.
 */
 
+#include "fmpq.h"
 #include "fmpq_poly.h"
 #include "arb_poly.h"
 

--- a/src/arb_poly/test/t-interpolate_fast.c
+++ b/src/arb_poly/test/t-interpolate_fast.c
@@ -9,6 +9,7 @@
     (at your option) any later version.  See <http://www.gnu.org/licenses/>.
 */
 
+#include "fmpq.h"
 #include "fmpq_poly.h"
 #include "arb_poly.h"
 

--- a/src/arb_poly/test/t-interpolate_newton.c
+++ b/src/arb_poly/test/t-interpolate_newton.c
@@ -9,6 +9,7 @@
     (at your option) any later version.  See <http://www.gnu.org/licenses/>.
 */
 
+#include "fmpq.h"
 #include "fmpq_poly.h"
 #include "arb_poly.h"
 

--- a/src/arf.h
+++ b/src/arf.h
@@ -18,7 +18,6 @@
 #define ARF_INLINE static __inline__
 #endif
 
-#include "fmpq.h"
 #include "mag.h"
 #include "arf_types.h"
 

--- a/src/arf/get_fmpq.c
+++ b/src/arf/get_fmpq.c
@@ -9,6 +9,7 @@
     (at your option) any later version.  See <http://www.gnu.org/licenses/>.
 */
 
+#include "fmpq.h"
 #include "arf.h"
 
 void

--- a/src/arf/test/t-set_fmpq.c
+++ b/src/arf/test/t-set_fmpq.c
@@ -9,8 +9,8 @@
     (at your option) any later version.  See <http://www.gnu.org/licenses/>.
 */
 
+#include "fmpq.h"
 #include "arf.h"
-
 
 int main()
 {

--- a/src/bernoulli/rev_clear.c
+++ b/src/bernoulli/rev_clear.c
@@ -9,6 +9,8 @@
     (at your option) any later version.  See <http://www.gnu.org/licenses/>.
 */
 
+#include "fmpz.h"
+#include "fmpz_vec.h"
 #include "arb.h"
 #include "bernoulli.h"
 

--- a/src/bernoulli/rev_init.c
+++ b/src/bernoulli/rev_init.c
@@ -9,6 +9,7 @@
     (at your option) any later version.  See <http://www.gnu.org/licenses/>.
 */
 
+#include "fmpz_vec.h"
 #include "arb.h"
 #include "bernoulli.h"
 

--- a/src/bernoulli/test/t-bound_2exp_si.c
+++ b/src/bernoulli/test/t-bound_2exp_si.c
@@ -9,6 +9,7 @@
     (at your option) any later version.  See <http://www.gnu.org/licenses/>.
 */
 
+#include "fmpq.h"
 #include "arf.h"
 #include "bernoulli.h"
 

--- a/src/flint.h
+++ b/src/flint.h
@@ -509,6 +509,9 @@ fmpq;
 
 typedef fmpq fmpq_t[1];
 
+#define fmpq_numref(__x) (&(__x)->num)
+#define fmpq_denref(__y) (&(__y)->den)
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/fmpq.h
+++ b/src/fmpq.h
@@ -26,9 +26,6 @@
 extern "C" {
 #endif
 
-#define fmpq_numref(__x) (&(__x)->num)
-#define fmpq_denref(__y) (&(__y)->den)
-
 FMPQ_INLINE void fmpq_init(fmpq_t x)
 {
     x->num = WORD(0);

--- a/src/gr/arb.c
+++ b/src/gr/arb.c
@@ -9,6 +9,7 @@
     (at your option) any later version.  See <http://www.gnu.org/licenses/>.
 */
 
+#include "fmpq.h"
 #include "arb_poly.h"
 #include "acb_poly.h"
 #include "arb_mat.h"

--- a/src/gr/fmpz.c
+++ b/src/gr/fmpz.c
@@ -14,6 +14,7 @@
 #include "fmpz_factor.h"
 #include "fmpz_poly.h"
 #include "fmpz_mat.h"
+#include "fmpq.h"
 #include "gr.h"
 #include "gr_vec.h"
 #include "gr_special.h"

--- a/src/gr/fmpzi.c
+++ b/src/gr/fmpzi.c
@@ -10,6 +10,7 @@
 */
 
 #include <math.h>
+#include "fmpq.h"
 #include "qqbar.h"
 #include "fmpzi.h"
 #include "gr.h"

--- a/src/gr/qqbar.c
+++ b/src/gr/qqbar.c
@@ -10,6 +10,7 @@
 */
 
 #include "fmpz_poly.h"
+#include "fmpq.h"
 #include "fmpzi.h"
 #include "qqbar.h"
 #include "fexpr.h"

--- a/src/gr_special/fac.c
+++ b/src/gr_special/fac.c
@@ -10,6 +10,7 @@
 */
 
 #include "ulong_extras.h"
+#include "fmpq.h"
 #include "arith.h"
 #include "arb.h"
 #include "gr_special.h"

--- a/src/qqbar/affine_transform.c
+++ b/src/qqbar/affine_transform.c
@@ -9,6 +9,7 @@
     (at your option) any later version.  See <http://www.gnu.org/licenses/>.
 */
 
+#include "fmpq.h"
 #include "fmpq_poly.h"
 #include "arb_fmpz_poly.h"
 #include "qqbar.h"

--- a/src/qqbar/cmp_re.c
+++ b/src/qqbar/cmp_re.c
@@ -9,6 +9,7 @@
     (at your option) any later version.  See <http://www.gnu.org/licenses/>.
 */
 
+#include "fmpq.h"
 #include "fmpz_poly.h"
 #include "qqbar.h"
 

--- a/src/qqbar/div.c
+++ b/src/qqbar/div.c
@@ -10,6 +10,7 @@
 */
 
 #include "ulong_extras.h"
+#include "fmpq.h"
 #include "qqbar.h"
 
 void

--- a/src/qqbar/express_in_field.c
+++ b/src/qqbar/express_in_field.c
@@ -9,6 +9,7 @@
     (at your option) any later version.  See <http://www.gnu.org/licenses/>.
 */
 
+#include "fmpq.h"
 #include "fmpq_poly.h"
 #include "qqbar.h"
 

--- a/src/qqbar/fmpq_pow_si_ui.c
+++ b/src/qqbar/fmpq_pow_si_ui.c
@@ -9,6 +9,7 @@
     (at your option) any later version.  See <http://www.gnu.org/licenses/>.
 */
 
+#include "fmpq.h"
 #include "qqbar.h"
 
 void

--- a/src/qqbar/fmpq_root_ui.c
+++ b/src/qqbar/fmpq_root_ui.c
@@ -9,6 +9,7 @@
     (at your option) any later version.  See <http://www.gnu.org/licenses/>.
 */
 
+#include "fmpq.h"
 #include "fmpz_poly.h"
 #include "qqbar.h"
 

--- a/src/qqbar/get_fexpr.c
+++ b/src/qqbar/get_fexpr.c
@@ -10,6 +10,7 @@
 */
 
 #include <stdio.h>
+#include "fmpq.h"
 #include "fmpq_poly.h"
 #include "arb_fmpz_poly.h"
 #include "acb_poly.h"

--- a/src/qqbar/mul.c
+++ b/src/qqbar/mul.c
@@ -10,6 +10,7 @@
 */
 
 #include "ulong_extras.h"
+#include "fmpq.h"
 #include "qqbar.h"
 
 void

--- a/src/qqbar/pow.c
+++ b/src/qqbar/pow.c
@@ -10,6 +10,7 @@
 */
 
 #include "ulong_extras.h"
+#include "fmpq.h"
 #include "fmpz_poly_factor.h"
 #include "arb_fmpz_poly.h"
 #include "qqbar.h"

--- a/src/qqbar/randtest.c
+++ b/src/qqbar/randtest.c
@@ -10,6 +10,7 @@
     (at your option) any later version.  See <http://www.gnu.org/licenses/>.
 */
 
+#include "fmpq.h"
 #include "fmpz_mod_poly.h"
 #include "fmpz_poly_factor.h"
 #include "arb_fmpz_poly.h"

--- a/src/qqbar/root_of_unity.c
+++ b/src/qqbar/root_of_unity.c
@@ -10,6 +10,7 @@
 */
 
 #include "fmpz_poly.h"
+#include "fmpq.h"
 #include "qqbar.h"
 
 int

--- a/src/qqbar/root_ui.c
+++ b/src/qqbar/root_ui.c
@@ -9,6 +9,7 @@
     (at your option) any later version.  See <http://www.gnu.org/licenses/>.
 */
 
+#include "fmpq.h"
 #include "fmpz_poly_factor.h"
 #include "arb_fmpz_poly.h"
 #include "qqbar.h"

--- a/src/qqbar/roots_fmpz_poly.c
+++ b/src/qqbar/roots_fmpz_poly.c
@@ -10,6 +10,7 @@
 */
 
 #include <stdlib.h>
+#include "fmpq.h"
 #include "fmpz_poly_factor.h"
 #include "arb_fmpz_poly.h"
 #include "qqbar.h"

--- a/src/qqbar/set_d.c
+++ b/src/qqbar/set_d.c
@@ -9,6 +9,7 @@
     (at your option) any later version.  See <http://www.gnu.org/licenses/>.
 */
 
+#include "fmpq.h"
 #include "qqbar.h"
 
 int

--- a/src/qqbar/set_fexpr.c
+++ b/src/qqbar/set_fexpr.c
@@ -9,6 +9,7 @@
     (at your option) any later version.  See <http://www.gnu.org/licenses/>.
 */
 
+#include "fmpq.h"
 #include "fmpz_poly.h"
 #include "qqbar.h"
 #include "fexpr.h"

--- a/src/qqbar/test/t-ceil.c
+++ b/src/qqbar/test/t-ceil.c
@@ -9,6 +9,7 @@
     (at your option) any later version.  See <http://www.gnu.org/licenses/>.
 */
 
+#include "fmpq.h"
 #include "qqbar.h"
 
 int main()

--- a/src/qqbar/test/t-conjugates.c
+++ b/src/qqbar/test/t-conjugates.c
@@ -9,6 +9,7 @@
     (at your option) any later version.  See <http://www.gnu.org/licenses/>.
 */
 
+#include "fmpq.h"
 #include "qqbar.h"
 
 int main()

--- a/src/qqbar/test/t-cos_pi.c
+++ b/src/qqbar/test/t-cos_pi.c
@@ -9,6 +9,7 @@
     (at your option) any later version.  See <http://www.gnu.org/licenses/>.
 */
 
+#include "fmpq.h"
 #include "qqbar.h"
 
 int main()

--- a/src/qqbar/test/t-cot_pi.c
+++ b/src/qqbar/test/t-cot_pi.c
@@ -9,6 +9,7 @@
     (at your option) any later version.  See <http://www.gnu.org/licenses/>.
 */
 
+#include "fmpq.h"
 #include "qqbar.h"
 
 int main()

--- a/src/qqbar/test/t-csc_pi.c
+++ b/src/qqbar/test/t-csc_pi.c
@@ -9,6 +9,7 @@
     (at your option) any later version.  See <http://www.gnu.org/licenses/>.
 */
 
+#include "fmpq.h"
 #include "qqbar.h"
 
 int main()

--- a/src/qqbar/test/t-exp_pi_i.c
+++ b/src/qqbar/test/t-exp_pi_i.c
@@ -9,6 +9,7 @@
     (at your option) any later version.  See <http://www.gnu.org/licenses/>.
 */
 
+#include "fmpq.h"
 #include "qqbar.h"
 
 int main()

--- a/src/qqbar/test/t-floor.c
+++ b/src/qqbar/test/t-floor.c
@@ -9,6 +9,7 @@
     (at your option) any later version.  See <http://www.gnu.org/licenses/>.
 */
 
+#include "fmpq.h"
 #include "qqbar.h"
 
 int main()

--- a/src/qqbar/test/t-fmpz_poly_composed_op.c
+++ b/src/qqbar/test/t-fmpz_poly_composed_op.c
@@ -9,6 +9,7 @@
     (at your option) any later version.  See <http://www.gnu.org/licenses/>.
 */
 
+#include "fmpq.h"
 #include "fmpq_poly.h"
 #include "qqbar.h"
 

--- a/src/qqbar/test/t-get_fexpr_formula.c
+++ b/src/qqbar/test/t-get_fexpr_formula.c
@@ -10,6 +10,7 @@
 */
 
 #include "ulong_extras.h"
+#include "fmpq.h"
 #include "fexpr.h"
 #include "qqbar.h"
 

--- a/src/qqbar/test/t-pow_fmpq.c
+++ b/src/qqbar/test/t-pow_fmpq.c
@@ -9,6 +9,7 @@
     (at your option) any later version.  See <http://www.gnu.org/licenses/>.
 */
 
+#include "fmpq.h"
 #include "qqbar.h"
 
 int main()

--- a/src/qqbar/test/t-sec_pi.c
+++ b/src/qqbar/test/t-sec_pi.c
@@ -9,6 +9,7 @@
     (at your option) any later version.  See <http://www.gnu.org/licenses/>.
 */
 
+#include "fmpq.h"
 #include "qqbar.h"
 
 int main()

--- a/src/qqbar/test/t-sin_pi.c
+++ b/src/qqbar/test/t-sin_pi.c
@@ -9,6 +9,7 @@
     (at your option) any later version.  See <http://www.gnu.org/licenses/>.
 */
 
+#include "fmpq.h"
 #include "qqbar.h"
 
 int main()

--- a/src/qqbar/test/t-tan_pi.c
+++ b/src/qqbar/test/t-tan_pi.c
@@ -9,6 +9,7 @@
     (at your option) any later version.  See <http://www.gnu.org/licenses/>.
 */
 
+#include "fmpq.h"
 #include "qqbar.h"
 
 int main()


### PR DESCRIPTION
Personally I think it is suitable to have it these macros along with the definition of `fmpq_t` as it is a trivial getter. Let me know what you think.