### PR TITLE
Declude fmpz_mat

### DIFF
--- a/doc/source/fmpz_mat.rst
+++ b/doc/source/fmpz_mat.rst
@@ -308,12 +308,12 @@ Comparison
 
     Returns a non-zero value if row `i` of ``mat`` is zero.
 
-.. function:: int fmpz_mat_col_equal(fmpz_mat_t M, slong m, slong n)
+.. function:: int fmpz_mat_equal_col(fmpz_mat_t M, slong m, slong n)
 
     Returns `1` if columns `m` and `n` of the matrix `M` are equal, otherwise
     returns `0`.
 
-.. function:: int fmpz_mat_row_equal(fmpz_mat_t M, slong m, slong n)
+.. function:: int fmpz_mat_equal_row(fmpz_mat_t M, slong m, slong n)
 
     Returns `1` if rows `m` and `n` of the matrix `M` are equal, otherwise
     returns `0`.
@@ -375,9 +375,12 @@ Modular reduction and reconstruction
 
 .. function:: void fmpz_mat_multi_mod_ui_precomp(nmod_mat_t * residues, slong nres, const fmpz_mat_t mat, fmpz_comb_t comb, fmpz_comb_temp_t temp)
 
-    Sets each of the ``nres`` matrices in ``residues`` to ``mat``
-    reduced modulo the modulus of the respective matrix, given
-    precomputed ``comb`` and ``comb_temp`` structures.
+    Sets each of the ``nres`` matrices in ``residues`` to ``mat`` reduced modulo
+    the modulus of the respective matrix, given precomputed ``comb`` and
+    ``comb_temp`` structures.
+
+    Note: ``fmpz.h`` must be included **before** ``fmpz_mat.h`` in order for
+    this function to be declared.
 
 .. function:: void fmpz_mat_multi_mod_ui(nmod_mat_t * residues, slong nres, const fmpz_mat_t mat)
 
@@ -390,9 +393,11 @@ Modular reduction and reconstruction
 
 .. function:: void fmpz_mat_multi_CRT_ui_precomp(fmpz_mat_t mat, nmod_mat_t * const residues, slong nres, fmpz_comb_t comb, fmpz_comb_temp_t temp, int sign)
 
-    Reconstructs ``mat`` from its images modulo the ``nres`` matrices
-    in ``residues``, given precomputed ``comb`` and ``comb_temp``
-    structures.
+    Reconstructs ``mat`` from its images modulo the ``nres`` matrices in
+    ``residues``, given precomputed ``comb`` and ``comb_temp`` structures.
+
+    Note: ``fmpz.h`` must be included **before** ``fmpz_mat.h`` in order for
+    this function to be declared.
 
 .. function:: void fmpz_mat_multi_CRT_ui(fmpz_mat_t mat, nmod_mat_t * const residues, slong nres, int sign)
 

--- a/src/arith/stirlingmat.c
+++ b/src/arith/stirlingmat.c
@@ -9,6 +9,7 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
+#include "fmpz.h"
 #include "fmpz_mat.h"
 #include "arith.h"
 

--- a/src/arith/test/t-stirling.c
+++ b/src/arith/test/t-stirling.c
@@ -9,6 +9,7 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
+#include "fmpz.h"
 #include "fmpz_mat.h"
 #include "arith.h"
 

--- a/src/bool_mat/all_pairs_longest_walk.c
+++ b/src/bool_mat/all_pairs_longest_walk.c
@@ -9,6 +9,7 @@
     (at your option) any later version.  See <http://www.gnu.org/licenses/>.
 */
 
+#include "fmpz.h"
 #include "fmpz_mat.h"
 #include "bool_mat.h"
 

--- a/src/bool_mat/nilpotency_degree.c
+++ b/src/bool_mat/nilpotency_degree.c
@@ -9,6 +9,7 @@
     (at your option) any later version.  See <http://www.gnu.org/licenses/>.
 */
 
+#include "fmpz.h"
 #include "fmpz_mat.h"
 #include "bool_mat.h"
 

--- a/src/bool_mat/test/t-all_pairs_longest_walk.c
+++ b/src/bool_mat/test/t-all_pairs_longest_walk.c
@@ -10,6 +10,7 @@
 */
 
 #include "perm.h"
+#include "fmpz.h"
 #include "fmpz_mat.h"
 #include "bool_mat.h"
 

--- a/src/fmpq.h
+++ b/src/fmpq.h
@@ -101,35 +101,27 @@ FMPQ_INLINE void fmpq_abs(fmpq_t dest, const fmpq_t src)
 }
 
 int _fmpq_cmp(const fmpz_t p, const fmpz_t q, const fmpz_t r, const fmpz_t s);
-
 int fmpq_cmp(const fmpq_t x, const fmpq_t y);
 
 int _fmpq_cmp_fmpz(const fmpz_t p, const fmpz_t q, const fmpz_t r);
-
 int fmpq_cmp_fmpz(const fmpq_t x, const fmpz_t y);
 
 int _fmpq_cmp_ui(const fmpz_t p, const fmpz_t q, ulong c);
-
 int fmpq_cmp_ui(const fmpq_t x, ulong c);
 
 int _fmpq_cmp_si(const fmpz_t p, const fmpz_t q, slong c);
-
 int fmpq_cmp_si(const fmpq_t x, slong c);
 
 void _fmpq_canonicalise(fmpz_t num, fmpz_t den);
-
 void fmpq_canonicalise(fmpq_t res);
 
 int _fmpq_is_canonical(const fmpz_t num, const fmpz_t den);
-
 int fmpq_is_canonical(const fmpq_t x);
 
 void _fmpq_set_ui(fmpz_t rnum, fmpz_t rden, ulong p, ulong q);
-
 void fmpq_set_ui(fmpq_t res, ulong p, ulong q);
 
 void _fmpq_set_si(fmpz_t rnum, fmpz_t rden, slong p, ulong q);
-
 void fmpq_set_si(fmpq_t res, slong p, ulong q);
 
 FMPQ_INLINE int fmpq_equal_ui(fmpq_t q, slong n)
@@ -194,113 +186,75 @@ int _fmpq_print(const fmpz_t num, const fmpz_t den);
 int fmpq_print(const fmpq_t x);
 
 void _fmpq_randtest(fmpz_t num, fmpz_t den, flint_rand_t state, flint_bitcnt_t bits);
-
 void fmpq_randtest(fmpq_t res, flint_rand_t state, flint_bitcnt_t bits);
 
 void fmpq_randtest_not_zero(fmpq_t res, flint_rand_t state, flint_bitcnt_t bits);
 
 void _fmpq_randbits(fmpz_t num, fmpz_t den, flint_rand_t state, flint_bitcnt_t bits);
-
 void fmpq_randbits(fmpq_t res, flint_rand_t state, flint_bitcnt_t bits);
 
 void _fmpq_add_small(fmpz_t rnum, fmpz_t rden, slong p1, ulong q1, slong p2, ulong q2);
 
 void _fmpq_mul_small(fmpz_t rnum, fmpz_t rden, slong p1, ulong q1, slong p2, ulong q2);
 
-void _fmpq_add(fmpz_t rnum, fmpz_t rden, const fmpz_t op1num,
-    const fmpz_t op1den, const fmpz_t op2num, const fmpz_t op2den);
-
+void _fmpq_add(fmpz_t rnum, fmpz_t rden, const fmpz_t op1num, const fmpz_t op1den, const fmpz_t op2num, const fmpz_t op2den);
 void fmpq_add(fmpq_t res, const fmpq_t op1, const fmpq_t op2);
 
-void _fmpq_add_si(fmpz_t rnum, fmpz_t rden, const fmpz_t p,
-                                                      const fmpz_t q, slong r);
-
+void _fmpq_add_si(fmpz_t rnum, fmpz_t rden, const fmpz_t p, const fmpz_t q, slong r);
 void fmpq_add_si(fmpq_t res, const fmpq_t op1, slong c);
 
-void _fmpq_add_ui(fmpz_t rnum, fmpz_t rden, const fmpz_t p,
-		                                      const fmpz_t q, ulong r);
-
+void _fmpq_add_ui(fmpz_t rnum, fmpz_t rden, const fmpz_t p, const fmpz_t q, ulong r);
 void fmpq_add_ui(fmpq_t res, const fmpq_t op1, ulong c);
 
-void _fmpq_add_fmpz(fmpz_t rnum, fmpz_t rden, const fmpz_t p,
-                                               const fmpz_t q, const fmpz_t r);
-
+void _fmpq_add_fmpz(fmpz_t rnum, fmpz_t rden, const fmpz_t p, const fmpz_t q, const fmpz_t r);
 void fmpq_add_fmpz(fmpq_t res, const fmpq_t op1, const fmpz_t c);
 
-void _fmpq_sub(fmpz_t rnum, fmpz_t rden, const fmpz_t op1num,
-    const fmpz_t op1den, const fmpz_t op2num, const fmpz_t op2den);
-
+void _fmpq_sub(fmpz_t rnum, fmpz_t rden, const fmpz_t op1num, const fmpz_t op1den, const fmpz_t op2num, const fmpz_t op2den);
 void fmpq_sub(fmpq_t res, const fmpq_t op1, const fmpq_t op2);
 
-void _fmpq_sub_si(fmpz_t rnum, fmpz_t rden, const fmpz_t p,
-                                                      const fmpz_t q, slong r);
-
+void _fmpq_sub_si(fmpz_t rnum, fmpz_t rden, const fmpz_t p, const fmpz_t q, slong r);
 void fmpq_sub_si(fmpq_t res, const fmpq_t op1, slong c);
 
-void _fmpq_sub_ui(fmpz_t rnum, fmpz_t rden, const fmpz_t p,
-		                                      const fmpz_t q, ulong r);
-
+void _fmpq_sub_ui(fmpz_t rnum, fmpz_t rden, const fmpz_t p, const fmpz_t q, ulong r);
 void fmpq_sub_ui(fmpq_t res, const fmpq_t op1, ulong c);
 
-void _fmpq_sub_fmpz(fmpz_t rnum, fmpz_t rden, const fmpz_t p,
-                                               const fmpz_t q, const fmpz_t r);
-
+void _fmpq_sub_fmpz(fmpz_t rnum, fmpz_t rden, const fmpz_t p, const fmpz_t q, const fmpz_t r);
 void fmpq_sub_fmpz(fmpq_t res, const fmpq_t op1, const fmpz_t c);
 
-void _fmpq_mul_si(fmpz_t rnum, fmpz_t rden, const fmpz_t p,
-                                                      const fmpz_t q, slong r);
-
+void _fmpq_mul_si(fmpz_t rnum, fmpz_t rden, const fmpz_t p, const fmpz_t q, slong r);
 void fmpq_mul_si(fmpq_t res, const fmpq_t op1, slong c);
 
-void _fmpq_mul_ui(fmpz_t rnum, fmpz_t rden, const fmpz_t p,
-                                                      const fmpz_t q, ulong r);
-
+void _fmpq_mul_ui(fmpz_t rnum, fmpz_t rden, const fmpz_t p, const fmpz_t q, ulong r);
 void fmpq_mul_ui(fmpq_t res, const fmpq_t op1, ulong c);
 
-void _fmpq_mul(fmpz_t rnum, fmpz_t rden, const fmpz_t op1num,
-    const fmpz_t op1den, const fmpz_t op2num, const fmpz_t op2den);
-
+void _fmpq_mul(fmpz_t rnum, fmpz_t rden, const fmpz_t op1num, const fmpz_t op1den, const fmpz_t op2num, const fmpz_t op2den);
 void fmpq_mul(fmpq_t res, const fmpq_t op1, const fmpq_t op2);
-
 
 void fmpq_mul_fmpz(fmpq_t res, const fmpq_t op, const fmpz_t x);
 
-void _fmpq_pow_si(fmpz_t rnum, fmpz_t rden,
-                  const fmpz_t opnum, const fmpz_t opden, slong e);
-
+void _fmpq_pow_si(fmpz_t rnum, fmpz_t rden, const fmpz_t opnum, const fmpz_t opden, slong e);
 void fmpq_pow_si(fmpq_t rop, const fmpq_t op, slong e);
 
 int fmpq_pow_fmpz(fmpq_t a, const fmpq_t b, const fmpz_t e);
 
-void _fmpq_addmul(fmpz_t rnum, fmpz_t rden, const fmpz_t op1num,
-    const fmpz_t op1den, const fmpz_t op2num, const fmpz_t op2den);
-
+void _fmpq_addmul(fmpz_t rnum, fmpz_t rden, const fmpz_t op1num, const fmpz_t op1den, const fmpz_t op2num, const fmpz_t op2den);
 void fmpq_addmul(fmpq_t res, const fmpq_t op1, const fmpq_t op2);
 
-
-void _fmpq_submul(fmpz_t rnum, fmpz_t rden, const fmpz_t op1num,
-    const fmpz_t op1den, const fmpz_t op2num, const fmpz_t op2den);
-
+void _fmpq_submul(fmpz_t rnum, fmpz_t rden, const fmpz_t op1num, const fmpz_t op1den, const fmpz_t op2num, const fmpz_t op2den);
 void fmpq_submul(fmpq_t res, const fmpq_t op1, const fmpq_t op2);
-
 
 void fmpq_inv(fmpq_t dest, const fmpq_t src);
 
-void _fmpq_div(fmpz_t rnum, fmpz_t rden, const fmpz_t op1num,
-                const fmpz_t op1den, const fmpz_t op2num, const fmpz_t op2den);
-
+void _fmpq_div(fmpz_t rnum, fmpz_t rden, const fmpz_t op1num, const fmpz_t op1den, const fmpz_t op2num, const fmpz_t op2den);
 void fmpq_div(fmpq_t res, const fmpq_t op1, const fmpq_t op2);
 
 void fmpq_div_fmpz(fmpq_t res, const fmpq_t op, const fmpz_t x);
-
 
 void fmpq_mul_2exp(fmpq_t res, const fmpq_t x, flint_bitcnt_t exp);
 
 void fmpq_div_2exp(fmpq_t res, const fmpq_t x, flint_bitcnt_t exp);
 
-
 int _fmpq_mod_fmpz(fmpz_t res, const fmpz_t num, const fmpz_t den, const fmpz_t mod);
-
 int fmpq_mod_fmpz(fmpz_t res, const fmpq_t x, const fmpz_t mod);
 
 void _fmpq_gcd(fmpz_t rnum, fmpz_t rden, const fmpz_t p, const fmpz_t q, const fmpz_t r, const fmpz_t s);
@@ -310,53 +264,34 @@ void _fmpq_gcd_cofactors(fmpz_t ng, fmpz_t dg, fmpz_t A, fmpz_t B, const fmpz_t 
 void fmpq_gcd_cofactors(fmpq_t g, fmpz_t A, fmpz_t B, const fmpq_t a, const fmpq_t b);
 
 int _fmpq_reconstruct_fmpz(fmpz_t num, fmpz_t den, const fmpz_t a, const fmpz_t m);
-
 int fmpq_reconstruct_fmpz(fmpq_t res, const fmpz_t a, const fmpz_t m);
 
-int _fmpq_reconstruct_fmpz_2_naive(fmpz_t n, fmpz_t d,
-               const fmpz_t a, const fmpz_t m, const fmpz_t N, const fmpz_t D);
-
-int _fmpq_reconstruct_fmpz_2(fmpz_t n, fmpz_t d,
-               const fmpz_t a, const fmpz_t m, const fmpz_t N, const fmpz_t D);
-
-int fmpq_reconstruct_fmpz_2(fmpq_t res,
-               const fmpz_t a, const fmpz_t m, const fmpz_t N, const fmpz_t D);
+int _fmpq_reconstruct_fmpz_2_naive(fmpz_t n, fmpz_t d, const fmpz_t a, const fmpz_t m, const fmpz_t N, const fmpz_t D);
+int _fmpq_reconstruct_fmpz_2(fmpz_t n, fmpz_t d, const fmpz_t a, const fmpz_t m, const fmpz_t N, const fmpz_t D);
+int fmpq_reconstruct_fmpz_2(fmpq_t res, const fmpz_t a, const fmpz_t m, const fmpz_t N, const fmpz_t D);
 
 flint_bitcnt_t fmpq_height_bits(const fmpq_t x);
 
 void fmpq_height(fmpz_t height, const fmpq_t x);
 
-void _fmpq_next_calkin_wilf(fmpz_t rnum, fmpz_t rden,
-    const fmpz_t num, const fmpz_t den);
-
+void _fmpq_next_calkin_wilf(fmpz_t rnum, fmpz_t rden, const fmpz_t num, const fmpz_t den);
 void fmpq_next_calkin_wilf(fmpq_t res, const fmpq_t x);
 
-void _fmpq_next_signed_calkin_wilf(fmpz_t rnum, fmpz_t rden,
-    const fmpz_t num, const fmpz_t den);
-
+void _fmpq_next_signed_calkin_wilf(fmpz_t rnum, fmpz_t rden, const fmpz_t num, const fmpz_t den);
 void fmpq_next_signed_calkin_wilf(fmpq_t res, const fmpq_t x);
 
-void _fmpq_next_minimal(fmpz_t rnum, fmpz_t rden,
-    const fmpz_t num, const fmpz_t den);
-
+void _fmpq_next_minimal(fmpz_t rnum, fmpz_t rden, const fmpz_t num, const fmpz_t den);
 void fmpq_next_minimal(fmpq_t res, const fmpq_t x);
 
-void _fmpq_next_signed_minimal(fmpz_t rnum, fmpz_t rden,
-    const fmpz_t num, const fmpz_t den);
-
+void _fmpq_next_signed_minimal(fmpz_t rnum, fmpz_t rden, const fmpz_t num, const fmpz_t den);
 void fmpq_next_signed_minimal(fmpq_t res, const fmpq_t x);
 
-void fmpq_farey_neighbors(fmpq_t left, fmpq_t right,
-                                             const fmpq_t mid, const fmpz_t Q);
+void fmpq_farey_neighbors(fmpq_t left, fmpq_t right, const fmpq_t mid, const fmpz_t Q);
 
+void _fmpq_simplest_between(fmpz_t mid_num, fmpz_t mid_den, const fmpz_t l_num, const fmpz_t l_den, const fmpz_t r_num, const fmpz_t r_den);
 void fmpq_simplest_between(fmpq_t mid, const fmpq_t l, const fmpq_t r);
 
-void _fmpq_simplest_between(fmpz_t mid_num, fmpz_t mid_den,
-                                       const fmpz_t l_num, const fmpz_t l_den,
-                                       const fmpz_t r_num, const fmpz_t r_den);
-
 slong fmpq_get_cfrac_naive(fmpz * c, fmpq_t rem, const fmpq_t x, slong n);
-
 slong fmpq_get_cfrac(fmpz * c, fmpq_t rem, const fmpq_t x, slong n);
 
 void fmpq_set_cfrac(fmpq_t x, const fmpz * c, slong n);
@@ -364,11 +299,9 @@ void fmpq_set_cfrac(fmpq_t x, const fmpz * c, slong n);
 slong fmpq_cfrac_bound(const fmpq_t x);
 
 void fmpq_dedekind_sum_naive(fmpq_t s, const fmpz_t h, const fmpz_t k);
-
 void fmpq_dedekind_sum(fmpq_t s, const fmpz_t h, const fmpz_t k);
 
 void _fmpq_harmonic_ui(fmpz_t num, fmpz_t den, ulong n);
-
 void fmpq_harmonic_ui(fmpq_t x, ulong n);
 
 fmpq * _fmpq_vec_init(slong len);
@@ -478,11 +411,9 @@ FMPQ_INLINE void _fmpq_ball_swap(_fmpq_ball_t x, _fmpq_ball_t y)
 
 int _fmpq_ball_gt_one(const _fmpq_ball_t x);
 
-void _fmpq_hgcd(_fmpq_cfrac_list_t s, _fmpz_mat22_t M,
-                                                   fmpz_t x_num, fmpz_t x_den);
+void _fmpq_hgcd(_fmpq_cfrac_list_t s, _fmpz_mat22_t M, fmpz_t x_num, fmpz_t x_den);
 
-void _fmpq_ball_get_cfrac(_fmpq_cfrac_list_t s, _fmpz_mat22_t M,
-                                                    int needM, _fmpq_ball_t x);
+void _fmpq_ball_get_cfrac(_fmpq_cfrac_list_t s, _fmpz_mat22_t M, int needM, _fmpq_ball_t x);
 
 /* Inlines *******************************************************************/
 

--- a/src/fmpq.h
+++ b/src/fmpq.h
@@ -303,36 +303,11 @@ int _fmpq_mod_fmpz(fmpz_t res, const fmpz_t num, const fmpz_t den, const fmpz_t 
 
 int fmpq_mod_fmpz(fmpz_t res, const fmpq_t x, const fmpz_t mod);
 
-FMPQ_INLINE void
-_fmpq_gcd(fmpz_t rnum, fmpz_t rden, const fmpz_t p, const fmpz_t q,
-            const fmpz_t r, const fmpz_t s)
-{
-   fmpz_t a, b;
-   fmpz_init(a); fmpz_init(b);
-   fmpz_mul(a, p, s);
-   fmpz_mul(b, q, r);
-   fmpz_gcd(rnum, a, b);
-   fmpz_mul(rden, q, s);
-   _fmpq_canonicalise(rnum, rden);
-   fmpz_clear(a); fmpz_clear(b);
-}
+void _fmpq_gcd(fmpz_t rnum, fmpz_t rden, const fmpz_t p, const fmpz_t q, const fmpz_t r, const fmpz_t s);
+void fmpq_gcd(fmpq_t res, const fmpq_t op1, const fmpq_t op2);
 
-FMPQ_INLINE void
-fmpq_gcd(fmpq_t res, const fmpq_t op1, const fmpq_t op2)
-{
-    _fmpq_gcd(fmpq_numref(res), fmpq_denref(res), fmpq_numref(op1),
-              fmpq_denref(op1), fmpq_numref(op2), fmpq_denref(op2));
-}
-
-void _fmpq_gcd_cofactors(fmpz_t ng, fmpz_t dg, fmpz_t A, fmpz_t B,
-           const fmpz_t na, const fmpz_t da, const fmpz_t nb, const fmpz_t db);
-
-FMPQ_INLINE void
-fmpq_gcd_cofactors(fmpq_t g, fmpz_t A, fmpz_t B, const fmpq_t a, const fmpq_t b)
-{
-    _fmpq_gcd_cofactors(fmpq_numref(g), fmpq_denref(g), A, B,
-               fmpq_numref(a), fmpq_denref(a), fmpq_numref(b), fmpq_denref(b));
-}
+void _fmpq_gcd_cofactors(fmpz_t ng, fmpz_t dg, fmpz_t A, fmpz_t B, const fmpz_t na, const fmpz_t da, const fmpz_t nb, const fmpz_t db);
+void fmpq_gcd_cofactors(fmpq_t g, fmpz_t A, fmpz_t B, const fmpq_t a, const fmpq_t b);
 
 int _fmpq_reconstruct_fmpz(fmpz_t num, fmpz_t den, const fmpz_t a, const fmpz_t m);
 

--- a/src/fmpq/gcd.c
+++ b/src/fmpq/gcd.c
@@ -1,0 +1,33 @@
+/*
+    Copyright (C) 2023 Albin Ahlbäck
+
+    This file is part of FLINT.
+
+    FLINT is free software: you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License (LGPL) as published
+    by the Free Software Foundation; either version 2.1 of the License, or
+    (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+*/
+
+#include "fmpq.h"
+
+void
+_fmpq_gcd(fmpz_t rnum, fmpz_t rden, const fmpz_t p, const fmpz_t q,
+            const fmpz_t r, const fmpz_t s)
+{
+   fmpz_t a, b;
+   fmpz_init(a); fmpz_init(b);
+   fmpz_mul(a, p, s);
+   fmpz_mul(b, q, r);
+   fmpz_gcd(rnum, a, b);
+   fmpz_mul(rden, q, s);
+   _fmpq_canonicalise(rnum, rden);
+   fmpz_clear(a); fmpz_clear(b);
+}
+
+void
+fmpq_gcd(fmpq_t res, const fmpq_t op1, const fmpq_t op2)
+{
+    _fmpq_gcd(fmpq_numref(res), fmpq_denref(res), fmpq_numref(op1),
+              fmpq_denref(op1), fmpq_numref(op2), fmpq_denref(op2));
+}

--- a/src/fmpq/gcd_cofactors.c
+++ b/src/fmpq/gcd_cofactors.c
@@ -79,3 +79,10 @@ void _fmpq_gcd_cofactors(
     fmpz_clear(nbbar);
     fmpz_clear(dbbar);
 }
+
+void
+fmpq_gcd_cofactors(fmpq_t g, fmpz_t A, fmpz_t B, const fmpq_t a, const fmpq_t b)
+{
+    _fmpq_gcd_cofactors(fmpq_numref(g), fmpq_denref(g), A, B,
+               fmpq_numref(a), fmpq_denref(a), fmpq_numref(b), fmpq_denref(b));
+}

--- a/src/fmpz_lll/advance_check_babai.c
+++ b/src/fmpz_lll/advance_check_babai.c
@@ -13,6 +13,7 @@
 
 #include "double_extras.h"
 #include "d_vec.h"
+#include "fmpz.h"
 #include "fmpz_mat.h"
 #include "fmpz_lll.h"
 

--- a/src/fmpz_lll/advance_check_babai_heuristic_d.c
+++ b/src/fmpz_lll/advance_check_babai_heuristic_d.c
@@ -12,6 +12,7 @@
 */
 
 #include "double_extras.h"
+#include "fmpz.h"
 #include "fmpz_mat.h"
 #include "fmpz_lll.h"
 

--- a/src/fmpz_lll/check_babai.c
+++ b/src/fmpz_lll/check_babai.c
@@ -13,6 +13,7 @@
 
 #include "double_extras.h"
 #include "d_vec.h"
+#include "fmpz.h"
 #include "fmpz_mat.h"
 #include "fmpz_lll.h"
 

--- a/src/fmpz_lll/check_babai_heuristic.c
+++ b/src/fmpz_lll/check_babai_heuristic.c
@@ -13,6 +13,7 @@
 
 #include <float.h>
 #include "gmpcompat.h"
+#include "fmpz.h"
 #include "fmpz_mat.h"
 #include "fmpz_lll.h"
 #ifdef GM

--- a/src/fmpz_lll/check_babai_heuristic_d.c
+++ b/src/fmpz_lll/check_babai_heuristic_d.c
@@ -12,6 +12,7 @@
 */
 
 #include "double_extras.h"
+#include "fmpz.h"
 #include "fmpz_mat.h"
 #include "fmpz_lll.h"
 

--- a/src/fmpz_lll/is_reduced_d_with_removal.c
+++ b/src/fmpz_lll/is_reduced_d_with_removal.c
@@ -10,6 +10,7 @@
 */
 
 #include "d_vec.h"
+#include "fmpz.h"
 #include "fmpz_mat.h"
 #include "fmpz_lll.h"
 

--- a/src/fmpz_lll/is_reduced_mpfr_with_removal.c
+++ b/src/fmpz_lll/is_reduced_mpfr_with_removal.c
@@ -10,6 +10,7 @@
 */
 
 #include "mpfr.h"
+#include "fmpz.h"
 #include "fmpz_mat.h"
 #include "fmpz_lll.h"
 #include "mpfr_vec.h"

--- a/src/fmpz_lll/lll_d.c
+++ b/src/fmpz_lll/lll_d.c
@@ -13,6 +13,7 @@
 
 #include "double_extras.h"
 #include "d_vec.h"
+#include "fmpz.h"
 #include "fmpz_mat.h"
 #include "fmpz_lll.h"
 

--- a/src/fmpz_lll/lll_d_heuristic.c
+++ b/src/fmpz_lll/lll_d_heuristic.c
@@ -13,6 +13,7 @@
 
 #include "double_extras.h"
 #include "d_vec.h"
+#include "fmpz.h"
 #include "fmpz_mat.h"
 #include "fmpz_lll.h"
 

--- a/src/fmpz_lll/lll_d_heuristic_with_removal.c
+++ b/src/fmpz_lll/lll_d_heuristic_with_removal.c
@@ -13,6 +13,7 @@
 
 #include "double_extras.h"
 #include "d_vec.h"
+#include "fmpz.h"
 #include "fmpz_mat.h"
 #include "fmpz_lll.h"
 

--- a/src/fmpz_lll/lll_d_with_removal.c
+++ b/src/fmpz_lll/lll_d_with_removal.c
@@ -13,6 +13,7 @@
 
 #include "double_extras.h"
 #include "d_vec.h"
+#include "fmpz.h"
 #include "fmpz_mat.h"
 #include "fmpz_lll.h"
 

--- a/src/fmpz_lll/lll_d_with_removal_knapsack.c
+++ b/src/fmpz_lll/lll_d_with_removal_knapsack.c
@@ -13,6 +13,7 @@
 
 #include "double_extras.h"
 #include "d_vec.h"
+#include "fmpz.h"
 #include "fmpz_mat.h"
 #include "fmpz_lll.h"
 

--- a/src/fmpz_lll/lll_mpf2.c
+++ b/src/fmpz_lll/lll_mpf2.c
@@ -12,6 +12,7 @@
 */
 
 #include <float.h>
+#include "fmpz.h"
 #include "fmpz_mat.h"
 #include "fmpz_lll.h"
 

--- a/src/fmpz_lll/lll_mpf2_with_removal.c
+++ b/src/fmpz_lll/lll_mpf2_with_removal.c
@@ -12,6 +12,7 @@
 */
 
 #include <float.h>
+#include "fmpz.h"
 #include "fmpz_mat.h"
 #include "fmpz_lll.h"
 

--- a/src/fmpz_lll/lll_with_removal_ulll.c
+++ b/src/fmpz_lll/lll_with_removal_ulll.c
@@ -11,6 +11,7 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
+#include "fmpz.h"
 #include "fmpz_mat.h"
 #include "fmpz_lll.h"
 

--- a/src/fmpz_lll/shift.c
+++ b/src/fmpz_lll/shift.c
@@ -11,6 +11,7 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
+#include "fmpz.h"
 #include "fmpz_mat.h"
 #include "fmpz_lll.h"
 

--- a/src/fmpz_lll/test/t-lll.c
+++ b/src/fmpz_lll/test/t-lll.c
@@ -10,6 +10,7 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
+#include "fmpz.h"
 #include "fmpz_mat.h"
 #include "fmpz_lll.h"
 

--- a/src/fmpz_lll/test/t-lll_d_heuristic_with_removal.c
+++ b/src/fmpz_lll/test/t-lll_d_heuristic_with_removal.c
@@ -9,6 +9,7 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
+#include "fmpz.h"
 #include "fmpz_mat.h"
 #include "fmpz_lll.h"
 

--- a/src/fmpz_lll/test/t-lll_d_with_removal.c
+++ b/src/fmpz_lll/test/t-lll_d_with_removal.c
@@ -9,9 +9,9 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
+#include "fmpz.h"
 #include "fmpz_mat.h"
 #include "fmpz_lll.h"
-#include "ulong_extras.h"
 
 int
 main(void)

--- a/src/fmpz_lll/test/t-lll_d_with_removal_knapsack.c
+++ b/src/fmpz_lll/test/t-lll_d_with_removal_knapsack.c
@@ -9,6 +9,7 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
+#include "fmpz.h"
 #include "fmpz_mat.h"
 #include "fmpz_lll.h"
 

--- a/src/fmpz_lll/test/t-lll_mpf_with_removal.c
+++ b/src/fmpz_lll/test/t-lll_mpf_with_removal.c
@@ -9,6 +9,7 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
+#include "fmpz.h"
 #include "fmpz_mat.h"
 #include "fmpz_lll.h"
 

--- a/src/fmpz_lll/test/t-lll_with_removal.c
+++ b/src/fmpz_lll/test/t-lll_with_removal.c
@@ -9,6 +9,7 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
+#include "fmpz.h"
 #include "fmpz_mat.h"
 #include "fmpz_lll.h"
 

--- a/src/fmpz_lll/test/t-wrapper_with_removal.c
+++ b/src/fmpz_lll/test/t-wrapper_with_removal.c
@@ -9,6 +9,7 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
+#include "fmpz.h"
 #include "fmpz_mat.h"
 #include "fmpz_lll.h"
 

--- a/src/fmpz_lll/test/t-wrapper_with_removal_knapsack.c
+++ b/src/fmpz_lll/test/t-wrapper_with_removal_knapsack.c
@@ -9,6 +9,7 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
+#include "fmpz.h"
 #include "fmpz_mat.h"
 #include "fmpz_lll.h"
 

--- a/src/fmpz_mat.h
+++ b/src/fmpz_mat.h
@@ -430,8 +430,6 @@ void fmpz_mat_det_divisor(fmpz_t d, const fmpz_mat_t A);
 
 void fmpz_mat_similarity(fmpz_mat_t A, slong r, fmpz_t d);
 
-#include "fmpz_poly.h"
-
 /* Characteristic polynomial ************************************************/
 
 void _fmpz_mat_charpoly_berkowitz(fmpz * rop, const fmpz_mat_t op);

--- a/src/fmpz_mat/CRT_ui.c
+++ b/src/fmpz_mat/CRT_ui.c
@@ -11,6 +11,7 @@
 
 #include "ulong_extras.h"
 #include "nmod_mat.h"
+#include "fmpz.h"
 #include "fmpz_mat.h"
 
 void

--- a/src/fmpz_mat/can_solve_fflu.c
+++ b/src/fmpz_mat/can_solve_fflu.c
@@ -10,8 +10,9 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
-#include "fmpz_mat.h"
 #include "perm.h"
+#include "fmpz.h"
+#include "fmpz_mat.h"
 
 void _fmpz_mat_window_with_perm_init(fmpz_mat_t Ap, slong * perm,
 		                               const fmpz_mat_t A, slong start)

--- a/src/fmpz_mat/charpoly_berkowitz.c
+++ b/src/fmpz_mat/charpoly_berkowitz.c
@@ -9,7 +9,9 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
+#include "fmpz.h"
 #include "fmpz_mat.h"
+#include "fmpz_poly.h"
 
 /*
     Assumes that \code{mat} is an $n \times n$ matrix and sets \code{(cp,n+1)}

--- a/src/fmpz_mat/chol_d.c
+++ b/src/fmpz_mat/chol_d.c
@@ -9,6 +9,7 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
+#include "fmpz.h"
 #include "fmpz_mat.h"
 
 #ifdef __GNUC__

--- a/src/fmpz_mat/clear.c
+++ b/src/fmpz_mat/clear.c
@@ -9,6 +9,7 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
+#include "fmpz.h"
 #include "fmpz_mat.h"
 
 void

--- a/src/fmpz_mat/col_partition.c
+++ b/src/fmpz_mat/col_partition.c
@@ -109,7 +109,7 @@ fmpz_mat_col_partition(slong * part, fmpz_mat_t M, int short_circuit)
         {
             if (part[col_h[upto].col] == -WORD(1))
             {
-                if (!fmpz_mat_col_equal(M, col_h[start].col, col_h[upto].col))
+                if (!fmpz_mat_equal_col(M, col_h[start].col, col_h[upto].col))
                 {
                     if (new_start == start)
                         new_start = upto;

--- a/src/fmpz_mat/concat_horizontal.c
+++ b/src/fmpz_mat/concat_horizontal.c
@@ -9,6 +9,7 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
+#include "fmpz.h"
 #include "fmpz_mat.h"
 
 void

--- a/src/fmpz_mat/concat_vertical.c
+++ b/src/fmpz_mat/concat_vertical.c
@@ -9,6 +9,7 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
+#include "fmpz.h"
 #include "fmpz_mat.h"
 
 void

--- a/src/fmpz_mat/content.c
+++ b/src/fmpz_mat/content.c
@@ -9,8 +9,8 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
-#include "fmpz_mat.h"
 #include "fmpz.h"
+#include "fmpz_mat.h"
 
 void fmpz_mat_content(fmpz_t mat_gcd, const fmpz_mat_t A)
 {

--- a/src/fmpz_mat/det_bareiss.c
+++ b/src/fmpz_mat/det_bareiss.c
@@ -9,6 +9,7 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
+#include "fmpz.h"
 #include "fmpz_mat.h"
 #include "perm.h"
 

--- a/src/fmpz_mat/det_bound.c
+++ b/src/fmpz_mat/det_bound.c
@@ -9,6 +9,7 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
+#include "fmpz.h"
 #include "fmpz_mat.h"
 
 static void

--- a/src/fmpz_mat/det_cofactor.c
+++ b/src/fmpz_mat/det_cofactor.c
@@ -9,6 +9,7 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
+#include "fmpz.h"
 #include "fmpz_mat.h"
 
 #define E(i,j) fmpz_mat_entry(A, i, j)

--- a/src/fmpz_mat/det_modular.c
+++ b/src/fmpz_mat/det_modular.c
@@ -9,6 +9,7 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
+#include "fmpz.h"
 #include "fmpz_mat.h"
 
 void

--- a/src/fmpz_mat/det_modular_accelerated.c
+++ b/src/fmpz_mat/det_modular_accelerated.c
@@ -9,6 +9,7 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
+#include "fmpz.h"
 #include "fmpz_mat.h"
 
 void

--- a/src/fmpz_mat/det_modular_given_divisor.c
+++ b/src/fmpz_mat/det_modular_given_divisor.c
@@ -11,6 +11,7 @@
 
 #include "ulong_extras.h"
 #include "nmod_mat.h"
+#include "fmpz.h"
 #include "fmpz_mat.h"
 
 /* Enable to exercise corner cases */

--- a/src/fmpz_mat/equal.c
+++ b/src/fmpz_mat/equal.c
@@ -9,6 +9,7 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
+#include "fmpz.h"
 #include "fmpz_mat.h"
 
 int fmpz_mat_equal(const fmpz_mat_t mat1, const fmpz_mat_t mat2)
@@ -32,4 +33,30 @@ int fmpz_mat_equal(const fmpz_mat_t mat1, const fmpz_mat_t mat2)
     }
 
     return 1;
+}
+
+int fmpz_mat_equal_col(fmpz_mat_t M, slong m, slong n)
+{
+   slong i;
+
+   for (i = 0; i < M->r; i++)
+   {
+      if (!fmpz_equal(M->rows[i] + m, M->rows[i] + n))
+         return 0;
+   }
+
+   return 1;
+}
+
+int fmpz_mat_equal_row(fmpz_mat_t M, slong m, slong n)
+{
+   slong i;
+
+   for (i = 0; i < M->c; i++)
+   {
+      if (!fmpz_equal(M->rows[m] + i, M->rows[n] + i))
+         return 0;
+   }
+
+   return 1;
 }

--- a/src/fmpz_mat/fflu.c
+++ b/src/fmpz_mat/fflu.c
@@ -10,6 +10,7 @@
 */
 
 #include "ulong_extras.h"
+#include "fmpz.h"
 #include "fmpz_mat.h"
 
 #define E(j,k) fmpz_mat_entry(B,j,k)

--- a/src/fmpz_mat/find_pivot_any.c
+++ b/src/fmpz_mat/find_pivot_any.c
@@ -9,6 +9,7 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
+#include "fmpz.h"
 #include "fmpz_mat.h"
 
 slong

--- a/src/fmpz_mat/find_pivot_smallest.c
+++ b/src/fmpz_mat/find_pivot_smallest.c
@@ -9,6 +9,7 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
+#include "fmpz.h"
 #include "fmpz_mat.h"
 
 slong

--- a/src/fmpz_mat/fmpz_vec_mul.c
+++ b/src/fmpz_mat/fmpz_vec_mul.c
@@ -9,6 +9,7 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
+#include "fmpz.h"
 #include "fmpz_mat.h"
 
 void fmpz_mat_fmpz_vec_mul(

--- a/src/fmpz_mat/fmpz_vec_mul_ptr.c
+++ b/src/fmpz_mat/fmpz_vec_mul_ptr.c
@@ -9,6 +9,7 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
+#include "fmpz.h"
 #include "fmpz_mat.h"
 
 void fmpz_mat_fmpz_vec_mul_ptr(

--- a/src/fmpz_mat/get_d_mat.c
+++ b/src/fmpz_mat/get_d_mat.c
@@ -12,6 +12,7 @@
 
 #include <float.h>
 #include "d_mat.h"
+#include "fmpz.h"
 #include "fmpz_mat.h"
 
 int

--- a/src/fmpz_mat/get_d_mat_transpose.c
+++ b/src/fmpz_mat/get_d_mat_transpose.c
@@ -11,6 +11,7 @@
 */
 
 #include <float.h>
+#include "fmpz.h"
 #include "fmpz_mat.h"
 
 int

--- a/src/fmpz_mat/get_nmod_mat.c
+++ b/src/fmpz_mat/get_nmod_mat.c
@@ -9,6 +9,7 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
+#include "fmpz.h"
 #include "fmpz_mat.h"
 
 void

--- a/src/fmpz_mat/gram.c
+++ b/src/fmpz_mat/gram.c
@@ -9,6 +9,7 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
+#include "fmpz.h"
 #include "fmpz_mat.h"
 
 void fmpz_mat_gram(fmpz_mat_t B, const fmpz_mat_t A)

--- a/src/fmpz_mat/hadamard.c
+++ b/src/fmpz_mat/hadamard.c
@@ -9,6 +9,7 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
+#include "fmpz.h"
 #include "fmpz_mat.h"
 #include "fq_nmod.h"
 

--- a/src/fmpz_mat/hnf_classical.c
+++ b/src/fmpz_mat/hnf_classical.c
@@ -9,6 +9,7 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
+#include "fmpz.h"
 #include "fmpz_mat.h"
 
 void

--- a/src/fmpz_mat/hnf_minors.c
+++ b/src/fmpz_mat/hnf_minors.c
@@ -10,6 +10,7 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
+#include "fmpz.h"
 #include "fmpz_mat.h"
 
 /*

--- a/src/fmpz_mat/hnf_minors_transform.c
+++ b/src/fmpz_mat/hnf_minors_transform.c
@@ -10,6 +10,7 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
+#include "fmpz.h"
 #include "fmpz_mat.h"
 
 /*

--- a/src/fmpz_mat/hnf_modular.c
+++ b/src/fmpz_mat/hnf_modular.c
@@ -9,6 +9,7 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
+#include "fmpz.h"
 #include "fmpz_mat.h"
 
 void

--- a/src/fmpz_mat/hnf_modular_eldiv.c
+++ b/src/fmpz_mat/hnf_modular_eldiv.c
@@ -10,6 +10,7 @@
 */
 
 #include "nmod_mat.h"
+#include "fmpz.h"
 #include "fmpz_mat.h"
 
 void

--- a/src/fmpz_mat/hnf_transform.c
+++ b/src/fmpz_mat/hnf_transform.c
@@ -12,6 +12,7 @@
 
 #include "ulong_extras.h"
 #include "nmod_mat.h"
+#include "fmpz.h"
 #include "fmpz_mat.h"
 
 void

--- a/src/fmpz_mat/hnf_xgcd.c
+++ b/src/fmpz_mat/hnf_xgcd.c
@@ -9,6 +9,7 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
+#include "fmpz.h"
 #include "fmpz_mat.h"
 
 void fmpz_mat_hnf_xgcd(fmpz_mat_t H, const fmpz_mat_t A)

--- a/src/fmpz_mat/inlines.c
+++ b/src/fmpz_mat/inlines.c
@@ -11,7 +11,4 @@
 
 #define FMPZ_MAT_INLINES_C
 
-#include "flint.h"
-#include "ulong_extras.h"
-#include "fmpz.h"
 #include "fmpz_mat.h"

--- a/src/fmpz_mat/inv.c
+++ b/src/fmpz_mat/inv.c
@@ -9,6 +9,7 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
+#include "fmpz.h"
 #include "fmpz_mat.h"
 
 static void

--- a/src/fmpz_mat/invert.c
+++ b/src/fmpz_mat/invert.c
@@ -1,0 +1,50 @@
+/*
+    Copyright (C) 2023 Albin Ahlbäck
+
+    This file is part of FLINT.
+
+    FLINT is free software: you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License (LGPL) as published
+    by the Free Software Foundation; either version 2.1 of the License, or
+    (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+*/
+
+#include "fmpz.h"
+#include "fmpz_mat.h"
+
+void fmpz_mat_invert_rows(fmpz_mat_t mat, slong * perm)
+{
+    slong i;
+
+    for (i = 0; i < mat->r/2; i++)
+        fmpz_mat_swap_rows(mat, perm, i, mat->r - i - 1);
+}
+
+void fmpz_mat_invert_cols(fmpz_mat_t mat, slong * perm)
+{
+    if (!fmpz_mat_is_empty(mat))
+    {
+        slong t;
+        slong i;
+        slong c = mat->c;
+        slong k = mat->c/2;
+
+        if (perm)
+        {
+            for (i = 0; i < k; i++)
+            {
+                t = perm[i];
+                perm[i] = perm[c - i - 1];
+                perm[c - i - 1] = t;
+            }
+        }
+
+        for (t = 0; t < mat->r; t++)
+        {
+            for (i = 0; i < k; i++)
+            {
+                fmpz_swap(fmpz_mat_entry(mat, t, i), fmpz_mat_entry(mat, t, c - i - 1));
+            }
+        }
+    }
+}

--- a/src/fmpz_mat/io.c
+++ b/src/fmpz_mat/io.c
@@ -12,6 +12,7 @@
 
 #include <stdio.h>
 #include "gmpcompat.h"
+#include "fmpz.h"
 #include "fmpz_mat.h"
 
 /* printing *******************************************************************/

--- a/src/fmpz_mat/is_hadamard.c
+++ b/src/fmpz_mat/is_hadamard.c
@@ -9,6 +9,7 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
+#include "fmpz.h"
 #include "fmpz_mat.h"
 
 int

--- a/src/fmpz_mat/is_in_hnf.c
+++ b/src/fmpz_mat/is_in_hnf.c
@@ -9,6 +9,7 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
+#include "fmpz.h"
 #include "fmpz_mat.h"
 
 int fmpz_mat_is_in_hnf(const fmpz_mat_t A)

--- a/src/fmpz_mat/is_in_rref_with_rank.c
+++ b/src/fmpz_mat/is_in_rref_with_rank.c
@@ -10,6 +10,7 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
+#include "fmpz.h"
 #include "fmpz_mat.h"
 
 int fmpz_mat_is_in_rref_with_rank(const fmpz_mat_t A, const fmpz_t den, slong rank)

--- a/src/fmpz_mat/is_in_snf.c
+++ b/src/fmpz_mat/is_in_snf.c
@@ -9,6 +9,7 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
+#include "fmpz.h"
 #include "fmpz_mat.h"
 
 int fmpz_mat_is_in_snf(const fmpz_mat_t A)

--- a/src/fmpz_mat/is_one.c
+++ b/src/fmpz_mat/is_one.c
@@ -10,6 +10,7 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
+#include "fmpz.h"
 #include "fmpz_mat.h"
 
 int

--- a/src/fmpz_mat/kronecker_product.c
+++ b/src/fmpz_mat/kronecker_product.c
@@ -9,6 +9,7 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
+#include "fmpz.h"
 #include "fmpz_mat.h"
 
 void fmpz_mat_kronecker_product(fmpz_mat_t C, const fmpz_mat_t A, const fmpz_mat_t B)

--- a/src/fmpz_mat/minpoly_modular.c
+++ b/src/fmpz_mat/minpoly_modular.c
@@ -15,6 +15,8 @@
 #include "ulong_extras.h"
 #include "nmod_mat.h"
 #include "nmod_poly.h"
+#include "fmpz.h"
+#include "fmpz_poly.h"
 #include "fmpz_mat.h"
 
 #define MINPOLY_M_LOG2E  1.44269504088896340736  /* log2(e) */

--- a/src/fmpz_mat/mul.c
+++ b/src/fmpz_mat/mul.c
@@ -10,6 +10,7 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
+#include "fmpz.h"
 #include "fmpz_mat.h"
 
 void _fmpz_mat_mul_small_1(fmpz_mat_t C, const fmpz_mat_t A, const fmpz_mat_t B)

--- a/src/fmpz_mat/mul_classical.c
+++ b/src/fmpz_mat/mul_classical.c
@@ -9,6 +9,7 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
+#include "fmpz.h"
 #include "fmpz_mat.h"
 
 void

--- a/src/fmpz_mat/mul_classical_inline.c
+++ b/src/fmpz_mat/mul_classical_inline.c
@@ -9,8 +9,9 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
-#include "fmpz_mat.h"
 #include "gmpcompat.h"
+#include "fmpz.h"
+#include "fmpz_mat.h"
 
 void
 fmpz_mat_mul_classical_inline(fmpz_mat_t C, const fmpz_mat_t A,

--- a/src/fmpz_mat/mul_double_word.c
+++ b/src/fmpz_mat/mul_double_word.c
@@ -12,6 +12,7 @@
 */
 
 #include "thread_support.h"
+#include "fmpz.h"
 #include "fmpz_mat.h"
 
 /*

--- a/src/fmpz_mat/mul_fft.c
+++ b/src/fmpz_mat/mul_fft.c
@@ -12,6 +12,7 @@
 #include "gmpcompat.h"
 #include "mpn_extras.h"
 #include "ulong_extras.h"
+#include "fmpz.h"
 #include "fmpz_mat.h"
 #include "fft.h"
 

--- a/src/fmpz_mat/mul_fmpz_vec_ptr.c
+++ b/src/fmpz_mat/mul_fmpz_vec_ptr.c
@@ -9,6 +9,7 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
+#include "fmpz.h"
 #include "fmpz_mat.h"
 
 void fmpz_mat_mul_fmpz_vec_ptr(

--- a/src/fmpz_mat/mul_multi_mod.c
+++ b/src/fmpz_mat/mul_multi_mod.c
@@ -13,6 +13,7 @@
 #include "thread_support.h"
 #include "nmod.h"
 #include "nmod_mat.h"
+#include "fmpz.h"
 #include "fmpz_mat.h"
 
 typedef struct {

--- a/src/fmpz_mat/mul_small.c
+++ b/src/fmpz_mat/mul_small.c
@@ -12,6 +12,7 @@
 */
 
 #include "thread_support.h"
+#include "fmpz.h"
 #include "fmpz_mat.h"
 
 static void _dot1(fmpz_t z, fmpz * a, slong * b, slong len)

--- a/src/fmpz_mat/mul_strassen.c
+++ b/src/fmpz_mat/mul_strassen.c
@@ -10,9 +10,6 @@
 */
 
 #include "fmpz_mat.h"
-#include "fmpz.h"
-#include "fmpz_vec.h"
-#include "flint.h"
 
 void fmpz_mat_mul_strassen(fmpz_mat_t C, const fmpz_mat_t A, const fmpz_mat_t B)
 {

--- a/src/fmpz_mat/multi_CRT_ui.c
+++ b/src/fmpz_mat/multi_CRT_ui.c
@@ -11,6 +11,7 @@
 
 #include "nmod_vec.h"
 #include "nmod_mat.h"
+#include "fmpz.h"
 #include "fmpz_mat.h"
 
 void

--- a/src/fmpz_mat/multi_mod_ui.c
+++ b/src/fmpz_mat/multi_mod_ui.c
@@ -11,6 +11,7 @@
 
 #include "nmod_vec.h"
 #include "nmod_mat.h"
+#include "fmpz.h"
 #include "fmpz_mat.h"
 
 void

--- a/src/fmpz_mat/nullspace.c
+++ b/src/fmpz_mat/nullspace.c
@@ -9,6 +9,7 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
+#include "fmpz.h"
 #include "fmpz_mat.h"
 
 slong

--- a/src/fmpz_mat/one.c
+++ b/src/fmpz_mat/one.c
@@ -9,6 +9,7 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
+#include "fmpz.h"
 #include "fmpz_mat.h"
 
 void

--- a/src/fmpz_mat/pow.c
+++ b/src/fmpz_mat/pow.c
@@ -9,6 +9,7 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
+#include "fmpz.h"
 #include "fmpz_mat.h"
 
 void

--- a/src/fmpz_mat/randajtai.c
+++ b/src/fmpz_mat/randajtai.c
@@ -12,6 +12,7 @@
 */
 
 #include <math.h>
+#include "fmpz.h"
 #include "fmpz_mat.h"
 
 void

--- a/src/fmpz_mat/randbits.c
+++ b/src/fmpz_mat/randbits.c
@@ -9,6 +9,7 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
+#include "fmpz.h"
 #include "fmpz_mat.h"
 
 void

--- a/src/fmpz_mat/randdet.c
+++ b/src/fmpz_mat/randdet.c
@@ -9,8 +9,8 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
-#include "fmpz_mat.h"
 #include "fmpz.h"
+#include "fmpz_mat.h"
 
 void
 fmpz_mat_randdet(fmpz_mat_t mat, flint_rand_t state, const fmpz_t det)

--- a/src/fmpz_mat/randintrel.c
+++ b/src/fmpz_mat/randintrel.c
@@ -11,6 +11,7 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
+#include "fmpz.h"
 #include "fmpz_mat.h"
 
 void

--- a/src/fmpz_mat/randntrulike.c
+++ b/src/fmpz_mat/randntrulike.c
@@ -11,6 +11,7 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
+#include "fmpz.h"
 #include "fmpz_mat.h"
 
 void

--- a/src/fmpz_mat/randntrulike2.c
+++ b/src/fmpz_mat/randntrulike2.c
@@ -11,6 +11,7 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
+#include "fmpz.h"
 #include "fmpz_mat.h"
 
 void

--- a/src/fmpz_mat/randops.c
+++ b/src/fmpz_mat/randops.c
@@ -9,6 +9,7 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
+#include "fmpz.h"
 #include "fmpz_mat.h"
 
 void

--- a/src/fmpz_mat/randpermdiag.c
+++ b/src/fmpz_mat/randpermdiag.c
@@ -9,8 +9,9 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
-#include "fmpz_mat.h"
 #include "perm.h"
+#include "fmpz.h"
+#include "fmpz_mat.h"
 
 int
 fmpz_mat_randpermdiag(fmpz_mat_t mat, flint_rand_t state,

--- a/src/fmpz_mat/randrank.c
+++ b/src/fmpz_mat/randrank.c
@@ -9,6 +9,7 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
+#include "fmpz.h"
 #include "fmpz_mat.h"
 
 void

--- a/src/fmpz_mat/randsimdioph.c
+++ b/src/fmpz_mat/randsimdioph.c
@@ -11,6 +11,7 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
+#include "fmpz.h"
 #include "fmpz_mat.h"
 
 void

--- a/src/fmpz_mat/randtest.c
+++ b/src/fmpz_mat/randtest.c
@@ -9,6 +9,7 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
+#include "fmpz.h"
 #include "fmpz_mat.h"
 
 void

--- a/src/fmpz_mat/randtest_unsigned.c
+++ b/src/fmpz_mat/randtest_unsigned.c
@@ -9,6 +9,7 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
+#include "fmpz.h"
 #include "fmpz_mat.h"
 
 void

--- a/src/fmpz_mat/rank.c
+++ b/src/fmpz_mat/rank.c
@@ -9,6 +9,7 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
+#include "fmpz.h"
 #include "fmpz_mat.h"
 
 slong

--- a/src/fmpz_mat/rank_small_inplace.c
+++ b/src/fmpz_mat/rank_small_inplace.c
@@ -9,8 +9,9 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
-#include "fmpz_mat.h"
 #include "perm.h"
+#include "fmpz.h"
+#include "fmpz_mat.h"
 
 #define E(j,k) fmpz_mat_entry(B,j,k)
 

--- a/src/fmpz_mat/rref_fflu.c
+++ b/src/fmpz_mat/rref_fflu.c
@@ -9,6 +9,7 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
+#include "fmpz.h"
 #include "fmpz_mat.h"
 
 slong

--- a/src/fmpz_mat/rref_mod.c
+++ b/src/fmpz_mat/rref_mod.c
@@ -10,6 +10,7 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
+#include "fmpz.h"
 #include "fmpz_mat.h"
 
 #define E(j,k) fmpz_mat_entry(A,j,k)

--- a/src/fmpz_mat/rref_mul.c
+++ b/src/fmpz_mat/rref_mul.c
@@ -13,6 +13,7 @@
 #include "ulong_extras.h"
 #include "perm.h"
 #include "nmod_mat.h"
+#include "fmpz.h"
 #include "fmpz_mat.h"
 
 slong

--- a/src/fmpz_mat/scalar_addmul_fmpz.c
+++ b/src/fmpz_mat/scalar_addmul_fmpz.c
@@ -9,6 +9,7 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
+#include "fmpz.h"
 #include "fmpz_mat.h"
 
 void

--- a/src/fmpz_mat/scalar_addmul_nmod_mat_fmpz.c
+++ b/src/fmpz_mat/scalar_addmul_nmod_mat_fmpz.c
@@ -10,6 +10,7 @@
 */
 
 #include "nmod_mat.h"
+#include "fmpz.h"
 #include "fmpz_mat.h"
 
 void

--- a/src/fmpz_mat/scalar_addmul_nmod_mat_ui.c
+++ b/src/fmpz_mat/scalar_addmul_nmod_mat_ui.c
@@ -9,6 +9,7 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
+#include "fmpz.h"
 #include "fmpz_mat.h"
 
 void

--- a/src/fmpz_mat/scalar_addmul_ui.c
+++ b/src/fmpz_mat/scalar_addmul_ui.c
@@ -9,6 +9,7 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
+#include "fmpz.h"
 #include "fmpz_mat.h"
 
 void

--- a/src/fmpz_mat/scalar_divexact_fmpz.c
+++ b/src/fmpz_mat/scalar_divexact_fmpz.c
@@ -9,6 +9,7 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
+#include "fmpz.h"
 #include "fmpz_mat.h"
 
 void

--- a/src/fmpz_mat/scalar_divexact_si.c
+++ b/src/fmpz_mat/scalar_divexact_si.c
@@ -9,6 +9,7 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
+#include "fmpz.h"
 #include "fmpz_mat.h"
 
 void

--- a/src/fmpz_mat/scalar_divexact_ui.c
+++ b/src/fmpz_mat/scalar_divexact_ui.c
@@ -9,6 +9,7 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
+#include "fmpz.h"
 #include "fmpz_mat.h"
 
 void

--- a/src/fmpz_mat/scalar_mod_fmpz.c
+++ b/src/fmpz_mat/scalar_mod_fmpz.c
@@ -9,6 +9,7 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
+#include "fmpz.h"
 #include "fmpz_mat.h"
 
 void

--- a/src/fmpz_mat/scalar_mul_2exp.c
+++ b/src/fmpz_mat/scalar_mul_2exp.c
@@ -10,6 +10,7 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
+#include "fmpz.h"
 #include "fmpz_mat.h"
 
 void

--- a/src/fmpz_mat/scalar_mul_fmpz.c
+++ b/src/fmpz_mat/scalar_mul_fmpz.c
@@ -9,6 +9,7 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
+#include "fmpz.h"
 #include "fmpz_mat.h"
 
 void

--- a/src/fmpz_mat/scalar_mul_si.c
+++ b/src/fmpz_mat/scalar_mul_si.c
@@ -9,6 +9,7 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
+#include "fmpz.h"
 #include "fmpz_mat.h"
 
 void

--- a/src/fmpz_mat/scalar_mul_ui.c
+++ b/src/fmpz_mat/scalar_mul_ui.c
@@ -9,6 +9,7 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
+#include "fmpz.h"
 #include "fmpz_mat.h"
 
 void

--- a/src/fmpz_mat/scalar_submul_fmpz.c
+++ b/src/fmpz_mat/scalar_submul_fmpz.c
@@ -9,6 +9,7 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
+#include "fmpz.h"
 #include "fmpz_mat.h"
 
 void

--- a/src/fmpz_mat/scalar_submul_ui.c
+++ b/src/fmpz_mat/scalar_submul_ui.c
@@ -9,6 +9,7 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
+#include "fmpz.h"
 #include "fmpz_mat.h"
 
 void

--- a/src/fmpz_mat/scalar_tdiv_q_2exp.c
+++ b/src/fmpz_mat/scalar_tdiv_q_2exp.c
@@ -10,6 +10,7 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
+#include "fmpz.h"
 #include "fmpz_mat.h"
 
 void

--- a/src/fmpz_mat/set_nmod_mat.c
+++ b/src/fmpz_mat/set_nmod_mat.c
@@ -10,6 +10,7 @@
 */
 
 #include "nmod_mat.h"
+#include "fmpz.h"
 #include "fmpz_mat.h"
 
 void

--- a/src/fmpz_mat/set_nmod_mat_unsigned.c
+++ b/src/fmpz_mat/set_nmod_mat_unsigned.c
@@ -10,6 +10,7 @@
 */
 
 #include "nmod_mat.h"
+#include "fmpz.h"
 #include "fmpz_mat.h"
 
 void

--- a/src/fmpz_mat/similarity.c
+++ b/src/fmpz_mat/similarity.c
@@ -9,7 +9,6 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
-#include "flint.h"
 #include "fmpz.h"
 #include "fmpz_mat.h"
 

--- a/src/fmpz_mat/snf.c
+++ b/src/fmpz_mat/snf.c
@@ -9,6 +9,7 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
+#include "fmpz.h"
 #include "fmpz_mat.h"
 
 void

--- a/src/fmpz_mat/snf_diagonal.c
+++ b/src/fmpz_mat/snf_diagonal.c
@@ -9,6 +9,7 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
+#include "fmpz.h"
 #include "fmpz_mat.h"
 
 /* sets a to gcd(a,b) and b to lcm(a,b) using temporary fmpz_t t */

--- a/src/fmpz_mat/snf_iliopoulos.c
+++ b/src/fmpz_mat/snf_iliopoulos.c
@@ -9,6 +9,7 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
+#include "fmpz.h"
 #include "fmpz_mat.h"
 
 static void _eliminate_col(fmpz_mat_t S, slong i, const fmpz_t mod)

--- a/src/fmpz_mat/snf_kannan_bachem.c
+++ b/src/fmpz_mat/snf_kannan_bachem.c
@@ -9,6 +9,7 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
+#include "fmpz.h"
 #include "fmpz_mat.h"
 
 void fmpz_mat_snf_kannan_bachem(fmpz_mat_t S, const fmpz_mat_t A)

--- a/src/fmpz_mat/solve.c
+++ b/src/fmpz_mat/solve.c
@@ -9,8 +9,8 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
-#include "fmpz_mat.h"
 #include "perm.h"
+#include "fmpz_mat.h"
 
 int
 fmpz_mat_solve(fmpz_mat_t X, fmpz_t den,

--- a/src/fmpz_mat/solve_bound.c
+++ b/src/fmpz_mat/solve_bound.c
@@ -9,6 +9,7 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
+#include "fmpz.h"
 #include "fmpz_mat.h"
 
 void

--- a/src/fmpz_mat/solve_cramer.c
+++ b/src/fmpz_mat/solve_cramer.c
@@ -9,6 +9,7 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
+#include "fmpz.h"
 #include "fmpz_mat.h"
 
 #define AA(i,j) fmpz_mat_entry(A, i, j)

--- a/src/fmpz_mat/solve_dixon.c
+++ b/src/fmpz_mat/solve_dixon.c
@@ -11,6 +11,7 @@
 
 #include "ulong_extras.h"
 #include "nmod_mat.h"
+#include "fmpz.h"
 #include "fmpz_mat.h"
 
 mp_limb_t

--- a/src/fmpz_mat/solve_fflu.c
+++ b/src/fmpz_mat/solve_fflu.c
@@ -9,8 +9,9 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
-#include "fmpz_mat.h"
 #include "perm.h"
+#include "fmpz.h"
+#include "fmpz_mat.h"
 
 int
 fmpz_mat_solve_fflu(fmpz_mat_t X, fmpz_t den,

--- a/src/fmpz_mat/solve_fflu_precomp.c
+++ b/src/fmpz_mat/solve_fflu_precomp.c
@@ -11,6 +11,7 @@
 */
 
 #include "ulong_extras.h"
+#include "fmpz.h"
 #include "fmpz_mat.h"
 
 #define XX(ii,jj) fmpz_mat_entry(X,(ii),(jj))

--- a/src/fmpz_mat/sqr_bodrato.c
+++ b/src/fmpz_mat/sqr_bodrato.c
@@ -10,6 +10,7 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
+#include "fmpz.h"
 #include "fmpz_mat.h"
 
 #define E fmpz_mat_entry

--- a/src/fmpz_mat/strong_echelon_form_mod.c
+++ b/src/fmpz_mat/strong_echelon_form_mod.c
@@ -9,6 +9,7 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
+#include "fmpz.h"
 #include "fmpz_mat.h"
 
 static int

--- a/src/fmpz_mat/swap.c
+++ b/src/fmpz_mat/swap.c
@@ -23,3 +23,34 @@ fmpz_mat_swap(fmpz_mat_t mat1, fmpz_mat_t mat2)
         *mat2 = tmp;
     }
 }
+
+void
+fmpz_mat_swap_entrywise(fmpz_mat_t mat1, fmpz_mat_t mat2)
+{
+    slong i, j;
+
+    for (i = 0; i < fmpz_mat_nrows(mat1); i++)
+        for (j = 0; j < fmpz_mat_ncols(mat1); j++)
+            fmpz_swap(fmpz_mat_entry(mat2, i, j), fmpz_mat_entry(mat1, i, j));
+}
+
+void
+fmpz_mat_swap_cols(fmpz_mat_t mat, slong * perm, slong r, slong s)
+{
+    if (r != s && !fmpz_mat_is_empty(mat))
+    {
+        slong t;
+
+        if (perm)
+        {
+            t = perm[s];
+            perm[s] = perm[r];
+            perm[r] = t;
+        }
+
+       for (t = 0; t < mat->r; t++)
+       {
+           fmpz_swap(fmpz_mat_entry(mat, t, r), fmpz_mat_entry(mat, t, s));
+       }
+    }
+}

--- a/src/fmpz_mat/swap.c
+++ b/src/fmpz_mat/swap.c
@@ -9,6 +9,7 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
+#include "fmpz.h"
 #include "fmpz_mat.h"
 
 void

--- a/src/fmpz_mat/test/t-add_sub.c
+++ b/src/fmpz_mat/test/t-add_sub.c
@@ -9,10 +9,7 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
-#include "flint.h"
-#include "fmpz.h"
 #include "fmpz_mat.h"
-#include "ulong_extras.h"
 
 int
 main(void)

--- a/src/fmpz_mat/test/t-can_solve_fflu.c
+++ b/src/fmpz_mat/test/t-can_solve_fflu.c
@@ -10,12 +10,8 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
-#include "flint.h"
 #include "fmpz.h"
-#include "fmpz_vec.h"
 #include "fmpz_mat.h"
-#include "ulong_extras.h"
-
 
 int
 main(void)

--- a/src/fmpz_mat/test/t-can_solve_multi_mod_den.c
+++ b/src/fmpz_mat/test/t-can_solve_multi_mod_den.c
@@ -10,12 +10,8 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
-#include "flint.h"
 #include "fmpz.h"
-#include "fmpz_vec.h"
 #include "fmpz_mat.h"
-#include "ulong_extras.h"
-
 
 int
 main(void)

--- a/src/fmpz_mat/test/t-charpoly.c
+++ b/src/fmpz_mat/test/t-charpoly.c
@@ -10,10 +10,8 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
-#include "flint.h"
-#include "fmpz.h"
 #include "fmpz_mat.h"
-#include "ulong_extras.h"
+#include "fmpz_poly.h"
 
 int
 main(void)

--- a/src/fmpz_mat/test/t-charpoly_berkowitz.c
+++ b/src/fmpz_mat/test/t-charpoly_berkowitz.c
@@ -10,10 +10,8 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
-#include "flint.h"
-#include "fmpz.h"
+#include "fmpz_poly.h"
 #include "fmpz_mat.h"
-#include "ulong_extras.h"
 
 int
 main(void)

--- a/src/fmpz_mat/test/t-chol_d.c
+++ b/src/fmpz_mat/test/t-chol_d.c
@@ -10,7 +10,6 @@
 */
 
 #include "fmpz_mat.h"
-#include "ulong_extras.h"
 
 #define FMPZ_MAT_CHOL_EPS (1.0E-9)
 

--- a/src/fmpz_mat/test/t-col_partition.c
+++ b/src/fmpz_mat/test/t-col_partition.c
@@ -9,11 +9,8 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
-#include "flint.h"
 #include "fmpz.h"
-#include "fmpz_vec.h"
 #include "fmpz_mat.h"
-#include "ulong_extras.h"
 
 int main(void)
 {

--- a/src/fmpz_mat/test/t-concat_horizontal.c
+++ b/src/fmpz_mat/test/t-concat_horizontal.c
@@ -9,11 +9,7 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
-#include "flint.h"
-#include "fmpz.h"
-#include "fmpz_vec.h"
 #include "fmpz_mat.h"
-#include "ulong_extras.h"
 
 int main(void)
 {

--- a/src/fmpz_mat/test/t-concat_vertical.c
+++ b/src/fmpz_mat/test/t-concat_vertical.c
@@ -9,11 +9,7 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
-#include "flint.h"
-#include "fmpz.h"
-#include "fmpz_vec.h"
 #include "fmpz_mat.h"
-#include "ulong_extras.h"
 
 int main(void)
 {

--- a/src/fmpz_mat/test/t-content.c
+++ b/src/fmpz_mat/test/t-content.c
@@ -9,13 +9,8 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
-#include "flint.h"
 #include "fmpz.h"
 #include "fmpz_mat.h"
-#include "nmod_mat.h"
-#include "ulong_extras.h"
-#include "long_extras.h"
-
 
 int main()
 {

--- a/src/fmpz_mat/test/t-det.c
+++ b/src/fmpz_mat/test/t-det.c
@@ -9,12 +9,8 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
-#include "flint.h"
 #include "fmpz.h"
-#include "fmpz_vec.h"
 #include "fmpz_mat.h"
-#include "ulong_extras.h"
-
 
 int
 main(void)

--- a/src/fmpz_mat/test/t-det_bound.c
+++ b/src/fmpz_mat/test/t-det_bound.c
@@ -9,12 +9,8 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
-#include "flint.h"
 #include "fmpz.h"
-#include "fmpz_vec.h"
 #include "fmpz_mat.h"
-#include "ulong_extras.h"
-
 
 int
 main(void)

--- a/src/fmpz_mat/test/t-det_divisor.c
+++ b/src/fmpz_mat/test/t-det_divisor.c
@@ -9,12 +9,8 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
-#include "flint.h"
 #include "fmpz.h"
-#include "fmpz_vec.h"
 #include "fmpz_mat.h"
-#include "ulong_extras.h"
-
 
 int
 main(void)

--- a/src/fmpz_mat/test/t-det_modular.c
+++ b/src/fmpz_mat/test/t-det_modular.c
@@ -9,12 +9,9 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
-#include "flint.h"
-#include "fmpz.h"
-#include "fmpz_vec.h"
-#include "fmpz_mat.h"
 #include "ulong_extras.h"
-
+#include "fmpz.h"
+#include "fmpz_mat.h"
 
 int
 main(void)

--- a/src/fmpz_mat/test/t-det_modular_accelerated.c
+++ b/src/fmpz_mat/test/t-det_modular_accelerated.c
@@ -9,12 +9,9 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
-#include "flint.h"
-#include "fmpz.h"
-#include "fmpz_vec.h"
-#include "fmpz_mat.h"
 #include "ulong_extras.h"
-
+#include "fmpz.h"
+#include "fmpz_mat.h"
 
 int
 main(void)

--- a/src/fmpz_mat/test/t-entry.c
+++ b/src/fmpz_mat/test/t-entry.c
@@ -10,10 +10,8 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
-#include "flint.h"
 #include "fmpz.h"
 #include "fmpz_mat.h"
-#include "ulong_extras.h"
 
 int
 main(void)

--- a/src/fmpz_mat/test/t-equal.c
+++ b/src/fmpz_mat/test/t-equal.c
@@ -9,10 +9,8 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
-#include "flint.h"
 #include "fmpz.h"
 #include "fmpz_mat.h"
-#include "ulong_extras.h"
 
 int
 main(void)

--- a/src/fmpz_mat/test/t-fmpz_vec_mul.c
+++ b/src/fmpz_mat/test/t-fmpz_vec_mul.c
@@ -9,6 +9,7 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
+#include "fmpz.h"
 #include "fmpz_mat.h"
 
 int main(void)

--- a/src/fmpz_mat/test/t-get_d_mat.c
+++ b/src/fmpz_mat/test/t-get_d_mat.c
@@ -11,10 +11,8 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
-#include "flint.h"
 #include "fmpz.h"
 #include "fmpz_mat.h"
-#include "ulong_extras.h"
 
 int
 main(void)

--- a/src/fmpz_mat/test/t-get_d_mat_transpose.c
+++ b/src/fmpz_mat/test/t-get_d_mat_transpose.c
@@ -11,10 +11,8 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
-#include "flint.h"
 #include "fmpz.h"
 #include "fmpz_mat.h"
-#include "ulong_extras.h"
 
 int
 main(void)

--- a/src/fmpz_mat/test/t-get_nmod_mat.c
+++ b/src/fmpz_mat/test/t-get_nmod_mat.c
@@ -9,11 +9,9 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
-#include "flint.h"
-#include "fmpz.h"
-#include "fmpz_mat.h"
-#include "nmod_mat.h"
 #include "ulong_extras.h"
+#include "nmod_mat.h"
+#include "fmpz_mat.h"
 
 int
 main(void)

--- a/src/fmpz_mat/test/t-hadamard.c
+++ b/src/fmpz_mat/test/t-hadamard.c
@@ -9,10 +9,7 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
-#include "flint.h"
-#include "fmpz.h"
 #include "fmpz_mat.h"
-#include "ulong_extras.h"
 
 int should_have_hadamard(int n)
 {

--- a/src/fmpz_mat/test/t-hnf.c
+++ b/src/fmpz_mat/test/t-hnf.c
@@ -9,8 +9,6 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
-#include "flint.h"
-#include "fmpz.h"
 #include "fmpz_mat.h"
 
 int

--- a/src/fmpz_mat/test/t-hnf_classical.c
+++ b/src/fmpz_mat/test/t-hnf_classical.c
@@ -9,8 +9,6 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
-#include "flint.h"
-#include "fmpz.h"
 #include "fmpz_mat.h"
 
 int

--- a/src/fmpz_mat/test/t-hnf_minors.c
+++ b/src/fmpz_mat/test/t-hnf_minors.c
@@ -9,8 +9,6 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
-#include "flint.h"
-#include "fmpz.h"
 #include "fmpz_mat.h"
 
 int

--- a/src/fmpz_mat/test/t-hnf_minors_transform.c
+++ b/src/fmpz_mat/test/t-hnf_minors_transform.c
@@ -9,8 +9,6 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
-#include "flint.h"
-#include "fmpz.h"
 #include "fmpz_mat.h"
 
 int

--- a/src/fmpz_mat/test/t-hnf_modular.c
+++ b/src/fmpz_mat/test/t-hnf_modular.c
@@ -9,7 +9,6 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
-#include "flint.h"
 #include "fmpz.h"
 #include "fmpz_mat.h"
 

--- a/src/fmpz_mat/test/t-hnf_modular_eldiv.c
+++ b/src/fmpz_mat/test/t-hnf_modular_eldiv.c
@@ -9,7 +9,6 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
-#include "flint.h"
 #include "fmpz.h"
 #include "fmpz_mat.h"
 

--- a/src/fmpz_mat/test/t-hnf_pernet_stein.c
+++ b/src/fmpz_mat/test/t-hnf_pernet_stein.c
@@ -9,7 +9,6 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
-#include "flint.h"
 #include "fmpz.h"
 #include "fmpz_mat.h"
 

--- a/src/fmpz_mat/test/t-hnf_transform.c
+++ b/src/fmpz_mat/test/t-hnf_transform.c
@@ -9,7 +9,6 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
-#include "flint.h"
 #include "fmpz.h"
 #include "fmpz_mat.h"
 

--- a/src/fmpz_mat/test/t-hnf_xgcd.c
+++ b/src/fmpz_mat/test/t-hnf_xgcd.c
@@ -9,8 +9,6 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
-#include "flint.h"
-#include "fmpz.h"
 #include "fmpz_mat.h"
 
 int

--- a/src/fmpz_mat/test/t-howell_form_mod.c
+++ b/src/fmpz_mat/test/t-howell_form_mod.c
@@ -9,9 +9,9 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
-#include "flint.h"
-#include "fmpz_mat.h"
 #include "perm.h"
+#include "fmpz.h"
+#include "fmpz_mat.h"
 
 int
 fmpz_mat_mod_is_in_howell_form(const fmpz_mat_t A, const fmpz_t mod)

--- a/src/fmpz_mat/test/t-init_clear.c
+++ b/src/fmpz_mat/test/t-init_clear.c
@@ -9,10 +9,8 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
-#include "flint.h"
 #include "fmpz.h"
 #include "fmpz_mat.h"
-#include "ulong_extras.h"
 
 int
 main(void)

--- a/src/fmpz_mat/test/t-inv.c
+++ b/src/fmpz_mat/test/t-inv.c
@@ -9,12 +9,8 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
-#include "flint.h"
 #include "fmpz.h"
-#include "fmpz_vec.h"
 #include "fmpz_mat.h"
-#include "ulong_extras.h"
-
 
 int
 main(void)

--- a/src/fmpz_mat/test/t-invert_rows_cols.c
+++ b/src/fmpz_mat/test/t-invert_rows_cols.c
@@ -1,5 +1,5 @@
 /*
-    Copyright (C) 2019 Tommy Hofmann Johansson
+    Copyright (C) 2019 Tommy Hofmann
 
     This file is part of FLINT.
 
@@ -9,10 +9,8 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
-#include "flint.h"
 #include "fmpz.h"
 #include "fmpz_mat.h"
-#include "ulong_extras.h"
 
 int
 main(void)

--- a/src/fmpz_mat/test/t-is_empty.c
+++ b/src/fmpz_mat/test/t-is_empty.c
@@ -9,10 +9,7 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
-#include "flint.h"
-#include "fmpz.h"
 #include "fmpz_mat.h"
-#include "ulong_extras.h"
 
 int
 main(void)

--- a/src/fmpz_mat/test/t-is_one.c
+++ b/src/fmpz_mat/test/t-is_one.c
@@ -10,10 +10,7 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
-#include "flint.h"
-#include "fmpz.h"
 #include "fmpz_mat.h"
-#include "ulong_extras.h"
 
 int
 main(void)

--- a/src/fmpz_mat/test/t-is_square.c
+++ b/src/fmpz_mat/test/t-is_square.c
@@ -9,10 +9,7 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
-#include "flint.h"
-#include "fmpz.h"
 #include "fmpz_mat.h"
-#include "ulong_extras.h"
 
 int
 main(void)

--- a/src/fmpz_mat/test/t-is_zero.c
+++ b/src/fmpz_mat/test/t-is_zero.c
@@ -9,10 +9,7 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
-#include "flint.h"
-#include "fmpz.h"
 #include "fmpz_mat.h"
-#include "ulong_extras.h"
 
 int
 main(void)

--- a/src/fmpz_mat/test/t-kronecker_product.c
+++ b/src/fmpz_mat/test/t-kronecker_product.c
@@ -9,8 +9,6 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
-#include "flint.h"
-#include "fmpz.h"
 #include "fmpz_mat.h"
 
 int

--- a/src/fmpz_mat/test/t-lll_original.c
+++ b/src/fmpz_mat/test/t-lll_original.c
@@ -9,11 +9,8 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
-#include "flint.h"
 #include "fmpz_mat.h"
 #include "fmpq.h"
-#include "fmpq_mat.h"
-#include "fmpq_vec.h"
 
 int
 main(void)

--- a/src/fmpz_mat/test/t-lll_storjohann.c
+++ b/src/fmpz_mat/test/t-lll_storjohann.c
@@ -9,11 +9,8 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
-#include "flint.h"
 #include "fmpz_mat.h"
 #include "fmpq.h"
-#include "fmpq_mat.h"
-#include "fmpq_vec.h"
 
 int
 main(void)

--- a/src/fmpz_mat/test/t-max_bits.c
+++ b/src/fmpz_mat/test/t-max_bits.c
@@ -9,11 +9,7 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
-#include "flint.h"
-#include "fmpz.h"
 #include "fmpz_mat.h"
-#include "fmpz_vec.h"
-#include "ulong_extras.h"
 
 int
 main(void)

--- a/src/fmpz_mat/test/t-minpoly.c
+++ b/src/fmpz_mat/test/t-minpoly.c
@@ -10,10 +10,8 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
-#include "flint.h"
-#include "fmpz.h"
 #include "fmpz_mat.h"
-#include "ulong_extras.h"
+#include "fmpz_poly.h"
 
 int
 main(void)

--- a/src/fmpz_mat/test/t-mul.c
+++ b/src/fmpz_mat/test/t-mul.c
@@ -10,11 +10,8 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
-#include "flint.h"
 #include "fmpz.h"
-#include "fmpz_vec.h"
 #include "fmpz_mat.h"
-#include "ulong_extras.h"
 
 int main(void)
 {

--- a/src/fmpz_mat/test/t-mul_blas.c
+++ b/src/fmpz_mat/test/t-mul_blas.c
@@ -9,11 +9,7 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
-#include "flint.h"
-#include "fmpz.h"
-#include "fmpz_vec.h"
 #include "fmpz_mat.h"
-#include "ulong_extras.h"
 
 int main(void)
 {

--- a/src/fmpz_mat/test/t-mul_classical.c
+++ b/src/fmpz_mat/test/t-mul_classical.c
@@ -9,11 +9,7 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
-#include "flint.h"
-#include "fmpz.h"
-#include "fmpz_vec.h"
 #include "fmpz_mat.h"
-#include "ulong_extras.h"
 
 int main(void)
 {

--- a/src/fmpz_mat/test/t-mul_double_word.c
+++ b/src/fmpz_mat/test/t-mul_double_word.c
@@ -9,12 +9,8 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
-#include "flint.h"
 #include "fmpz.h"
-#include "fmpz_vec.h"
 #include "fmpz_mat.h"
-#include "ulong_extras.h"
-
 
 void _fmpz_mat_full(fmpz_mat_t A, flint_bitcnt_t bits)
 {

--- a/src/fmpz_mat/test/t-mul_fft.c
+++ b/src/fmpz_mat/test/t-mul_fft.c
@@ -9,11 +9,7 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
-#include "flint.h"
-#include "fmpz.h"
-#include "fmpz_vec.h"
 #include "fmpz_mat.h"
-#include "ulong_extras.h"
 
 int main(void)
 {

--- a/src/fmpz_mat/test/t-mul_fmpz_vec.c
+++ b/src/fmpz_mat/test/t-mul_fmpz_vec.c
@@ -9,6 +9,7 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
+#include "fmpz.h"
 #include "fmpz_mat.h"
 
 int main(void)

--- a/src/fmpz_mat/test/t-mul_multi_mod.c
+++ b/src/fmpz_mat/test/t-mul_multi_mod.c
@@ -9,11 +9,7 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
-#include "flint.h"
-#include "fmpz.h"
-#include "fmpz_vec.h"
 #include "fmpz_mat.h"
-#include "ulong_extras.h"
 
 int main(void)
 {

--- a/src/fmpz_mat/test/t-mul_small.c
+++ b/src/fmpz_mat/test/t-mul_small.c
@@ -9,11 +9,8 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
-#include "flint.h"
 #include "fmpz.h"
-#include "fmpz_vec.h"
 #include "fmpz_mat.h"
-#include "ulong_extras.h"
 
 int main(void)
 {

--- a/src/fmpz_mat/test/t-mul_strassen.c
+++ b/src/fmpz_mat/test/t-mul_strassen.c
@@ -9,10 +9,7 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
-#include "flint.h"
-#include "ulong_extras.h"
 #include "fmpz_mat.h"
-#include "fmpz.h"
 
 int
 main(void)

--- a/src/fmpz_mat/test/t-nullspace.c
+++ b/src/fmpz_mat/test/t-nullspace.c
@@ -9,12 +9,8 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
-#include "flint.h"
-#include "fmpz.h"
-#include "fmpz_vec.h"
-#include "fmpz_mat.h"
 #include "ulong_extras.h"
-
+#include "fmpz_mat.h"
 
 int
 main(void)

--- a/src/fmpz_mat/test/t-one.c
+++ b/src/fmpz_mat/test/t-one.c
@@ -9,10 +9,8 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
-#include "flint.h"
 #include "fmpz.h"
 #include "fmpz_mat.h"
-#include "ulong_extras.h"
 
 int
 main(void)

--- a/src/fmpz_mat/test/t-pow.c
+++ b/src/fmpz_mat/test/t-pow.c
@@ -9,11 +9,7 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
-#include "flint.h"
-#include "fmpz.h"
-#include "fmpz_vec.h"
 #include "fmpz_mat.h"
-#include "ulong_extras.h"
 
 int main(void)
 {

--- a/src/fmpz_mat/test/t-print_read.c
+++ b/src/fmpz_mat/test/t-print_read.c
@@ -19,8 +19,6 @@
 #include <unistd.h>
 #endif
 
-#include "flint.h"
-#include "fmpz.h"
 #include "fmpz_mat.h"
 
 #if (!defined (__WIN32) || defined(__CYGWIN__)) && !defined(_MSC_VER)

--- a/src/fmpz_mat/test/t-rank.c
+++ b/src/fmpz_mat/test/t-rank.c
@@ -9,12 +9,7 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
-#include "flint.h"
-#include "fmpz.h"
-#include "fmpz_vec.h"
 #include "fmpz_mat.h"
-#include "ulong_extras.h"
-
 
 int
 main(void)

--- a/src/fmpz_mat/test/t-rref.c
+++ b/src/fmpz_mat/test/t-rref.c
@@ -9,12 +9,9 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
-#include "flint.h"
-#include "fmpz.h"
-#include "fmpz_vec.h"
-#include "fmpz_mat.h"
 #include "perm.h"
-#include "ulong_extras.h"
+#include "fmpz.h"
+#include "fmpz_mat.h"
 
 int
 main(void)

--- a/src/fmpz_mat/test/t-rref_fflu.c
+++ b/src/fmpz_mat/test/t-rref_fflu.c
@@ -9,12 +9,9 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
-#include "flint.h"
-#include "fmpz.h"
-#include "fmpz_vec.h"
-#include "fmpz_mat.h"
 #include "perm.h"
-#include "ulong_extras.h"
+#include "fmpz.h"
+#include "fmpz_mat.h"
 
 int
 main(void)

--- a/src/fmpz_mat/test/t-rref_mod.c
+++ b/src/fmpz_mat/test/t-rref_mod.c
@@ -10,11 +10,9 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
-#include "flint.h"
-#include "fmpz.h"
-#include "fmpz_vec.h"
-#include "fmpz_mat.h"
 #include "ulong_extras.h"
+#include "fmpz.h"
+#include "fmpz_mat.h"
 
 static void
 check_rref(fmpz_mat_t A)

--- a/src/fmpz_mat/test/t-rref_mul.c
+++ b/src/fmpz_mat/test/t-rref_mul.c
@@ -10,12 +10,9 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
-#include "flint.h"
-#include "fmpz.h"
-#include "fmpz_vec.h"
-#include "fmpz_mat.h"
 #include "perm.h"
-#include "ulong_extras.h"
+#include "fmpz.h"
+#include "fmpz_mat.h"
 
 int
 main(void)

--- a/src/fmpz_mat/test/t-scalar_addmul_fmpz.c
+++ b/src/fmpz_mat/test/t-scalar_addmul_fmpz.c
@@ -9,12 +9,8 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
-#include "flint.h"
 #include "fmpz.h"
 #include "fmpz_mat.h"
-#include "nmod_mat.h"
-#include "ulong_extras.h"
-#include "long_extras.h"
 
 int
 main(void)

--- a/src/fmpz_mat/test/t-scalar_addmul_nmod_mat_fmpz.c
+++ b/src/fmpz_mat/test/t-scalar_addmul_nmod_mat_fmpz.c
@@ -9,12 +9,10 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
-#include "flint.h"
+#include "ulong_extras.h"
+#include "nmod_mat.h"
 #include "fmpz.h"
 #include "fmpz_mat.h"
-#include "nmod_mat.h"
-#include "ulong_extras.h"
-#include "long_extras.h"
 
 int
 main(void)

--- a/src/fmpz_mat/test/t-scalar_addmul_nmod_mat_ui.c
+++ b/src/fmpz_mat/test/t-scalar_addmul_nmod_mat_ui.c
@@ -9,12 +9,9 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
-#include "flint.h"
-#include "fmpz.h"
-#include "fmpz_mat.h"
-#include "nmod_mat.h"
 #include "ulong_extras.h"
-#include "long_extras.h"
+#include "nmod_mat.h"
+#include "fmpz_mat.h"
 
 int
 main(void)

--- a/src/fmpz_mat/test/t-scalar_addmul_si.c
+++ b/src/fmpz_mat/test/t-scalar_addmul_si.c
@@ -9,12 +9,8 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
-#include "flint.h"
-#include "fmpz.h"
-#include "fmpz_mat.h"
-#include "nmod_mat.h"
-#include "ulong_extras.h"
 #include "long_extras.h"
+#include "fmpz_mat.h"
 
 int
 main(void)

--- a/src/fmpz_mat/test/t-scalar_addmul_ui.c
+++ b/src/fmpz_mat/test/t-scalar_addmul_ui.c
@@ -9,12 +9,7 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
-#include "flint.h"
-#include "fmpz.h"
 #include "fmpz_mat.h"
-#include "nmod_mat.h"
-#include "ulong_extras.h"
-#include "long_extras.h"
 
 int
 main(void)

--- a/src/fmpz_mat/test/t-scalar_mod_fmpz.c
+++ b/src/fmpz_mat/test/t-scalar_mod_fmpz.c
@@ -9,12 +9,8 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
-#include "flint.h"
 #include "fmpz.h"
 #include "fmpz_mat.h"
-#include "nmod_mat.h"
-#include "ulong_extras.h"
-#include "long_extras.h"
 
 int
 main(void)

--- a/src/fmpz_mat/test/t-scalar_mul_2exp.c
+++ b/src/fmpz_mat/test/t-scalar_mul_2exp.c
@@ -10,12 +10,7 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
-#include "flint.h"
-#include "fmpz.h"
 #include "fmpz_mat.h"
-#include "nmod_mat.h"
-#include "ulong_extras.h"
-#include "long_extras.h"
 
 int
 main(void)

--- a/src/fmpz_mat/test/t-scalar_mul_fmpz.c
+++ b/src/fmpz_mat/test/t-scalar_mul_fmpz.c
@@ -9,12 +9,8 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
-#include "flint.h"
 #include "fmpz.h"
 #include "fmpz_mat.h"
-#include "nmod_mat.h"
-#include "ulong_extras.h"
-#include "long_extras.h"
 
 int
 main(void)

--- a/src/fmpz_mat/test/t-scalar_mul_si.c
+++ b/src/fmpz_mat/test/t-scalar_mul_si.c
@@ -9,12 +9,8 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
-#include "flint.h"
-#include "fmpz.h"
-#include "fmpz_mat.h"
-#include "nmod_mat.h"
-#include "ulong_extras.h"
 #include "long_extras.h"
+#include "fmpz_mat.h"
 
 int
 main(void)

--- a/src/fmpz_mat/test/t-scalar_mul_ui.c
+++ b/src/fmpz_mat/test/t-scalar_mul_ui.c
@@ -9,11 +9,7 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
-#include "flint.h"
-#include "fmpz.h"
 #include "fmpz_mat.h"
-#include "nmod_mat.h"
-#include "ulong_extras.h"
 
 int
 main(void)

--- a/src/fmpz_mat/test/t-scalar_smod.c
+++ b/src/fmpz_mat/test/t-scalar_smod.c
@@ -9,12 +9,8 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
-#include "flint.h"
 #include "fmpz.h"
 #include "fmpz_mat.h"
-#include "nmod_mat.h"
-#include "ulong_extras.h"
-#include "long_extras.h"
 
 int
 main(void)

--- a/src/fmpz_mat/test/t-snf_diagonal.c
+++ b/src/fmpz_mat/test/t-snf_diagonal.c
@@ -9,7 +9,6 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
-#include "flint.h"
 #include "fmpz.h"
 #include "fmpz_mat.h"
 

--- a/src/fmpz_mat/test/t-snf_iliopoulos.c
+++ b/src/fmpz_mat/test/t-snf_iliopoulos.c
@@ -9,7 +9,6 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
-#include "flint.h"
 #include "fmpz.h"
 #include "fmpz_mat.h"
 

--- a/src/fmpz_mat/test/t-snf_kannan_bachem.c
+++ b/src/fmpz_mat/test/t-snf_kannan_bachem.c
@@ -9,8 +9,6 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
-#include "flint.h"
-#include "fmpz.h"
 #include "fmpz_mat.h"
 
 int

--- a/src/fmpz_mat/test/t-solve.c
+++ b/src/fmpz_mat/test/t-solve.c
@@ -9,12 +9,8 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
-#include "flint.h"
 #include "fmpz.h"
-#include "fmpz_vec.h"
 #include "fmpz_mat.h"
-#include "ulong_extras.h"
-
 
 int
 main(void)

--- a/src/fmpz_mat/test/t-solve_bound.c
+++ b/src/fmpz_mat/test/t-solve_bound.c
@@ -9,12 +9,8 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
-#include "flint.h"
 #include "fmpz.h"
-#include "fmpz_vec.h"
 #include "fmpz_mat.h"
-#include "ulong_extras.h"
-
 
 int
 main(void)

--- a/src/fmpz_mat/test/t-solve_cramer.c
+++ b/src/fmpz_mat/test/t-solve_cramer.c
@@ -9,12 +9,8 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
-#include "flint.h"
 #include "fmpz.h"
-#include "fmpz_vec.h"
 #include "fmpz_mat.h"
-#include "ulong_extras.h"
-
 
 int
 main(void)

--- a/src/fmpz_mat/test/t-solve_dixon.c
+++ b/src/fmpz_mat/test/t-solve_dixon.c
@@ -9,11 +9,8 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
-#include "flint.h"
 #include "fmpz.h"
-#include "fmpz_vec.h"
 #include "fmpz_mat.h"
-#include "ulong_extras.h"
 
 int
 main(void)

--- a/src/fmpz_mat/test/t-solve_dixon_den.c
+++ b/src/fmpz_mat/test/t-solve_dixon_den.c
@@ -9,12 +9,8 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
-#include "flint.h"
 #include "fmpz.h"
-#include "fmpz_vec.h"
 #include "fmpz_mat.h"
-#include "ulong_extras.h"
-
 
 int
 main(void)

--- a/src/fmpz_mat/test/t-solve_fflu.c
+++ b/src/fmpz_mat/test/t-solve_fflu.c
@@ -9,12 +9,8 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
-#include "flint.h"
 #include "fmpz.h"
-#include "fmpz_vec.h"
 #include "fmpz_mat.h"
-#include "ulong_extras.h"
-
 
 int
 main(void)

--- a/src/fmpz_mat/test/t-solve_multi_mod_den.c
+++ b/src/fmpz_mat/test/t-solve_multi_mod_den.c
@@ -9,12 +9,8 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
-#include "flint.h"
 #include "fmpz.h"
-#include "fmpz_vec.h"
 #include "fmpz_mat.h"
-#include "ulong_extras.h"
-
 
 int
 main(void)

--- a/src/fmpz_mat/test/t-sqr.c
+++ b/src/fmpz_mat/test/t-sqr.c
@@ -9,11 +9,7 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
-#include "flint.h"
-#include "fmpz.h"
-#include "fmpz_vec.h"
 #include "fmpz_mat.h"
-#include "ulong_extras.h"
 
 int main(void)
 {

--- a/src/fmpz_mat/test/t-trace.c
+++ b/src/fmpz_mat/test/t-trace.c
@@ -9,11 +9,8 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
-#include "flint.h"
 #include "fmpz.h"
-#include "fmpz_vec.h"
 #include "fmpz_mat.h"
-#include "ulong_extras.h"
 
 int
 main(void)

--- a/src/fmpz_mat/test/t-transpose.c
+++ b/src/fmpz_mat/test/t-transpose.c
@@ -9,10 +9,7 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
-#include "flint.h"
-#include "fmpz.h"
 #include "fmpz_mat.h"
-#include "ulong_extras.h"
 
 int
 main(void)

--- a/src/fmpz_mat/test/t-window_init_clear.c
+++ b/src/fmpz_mat/test/t-window_init_clear.c
@@ -10,10 +10,8 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
-#include "flint.h"
 #include "fmpz.h"
 #include "fmpz_mat.h"
-#include "ulong_extras.h"
 
 int
 main(void)

--- a/src/fmpz_mat/test/t-zero.c
+++ b/src/fmpz_mat/test/t-zero.c
@@ -9,10 +9,8 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
-#include "flint.h"
 #include "fmpz.h"
 #include "fmpz_mat.h"
-#include "ulong_extras.h"
 
 int
 main(void)

--- a/src/fmpz_mat/trace.c
+++ b/src/fmpz_mat/trace.c
@@ -9,6 +9,7 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
+#include "fmpz.h"
 #include "fmpz_mat.h"
 
 void

--- a/src/fmpz_mat/transpose.c
+++ b/src/fmpz_mat/transpose.c
@@ -9,6 +9,7 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
+#include "fmpz.h"
 #include "fmpz_mat.h"
 
 void

--- a/src/fmpz_mpoly/compose_fmpz_poly.c
+++ b/src/fmpz_mpoly/compose_fmpz_poly.c
@@ -10,6 +10,7 @@
 */
 
 #include "fmpz_mat.h"
+#include "fmpz_poly.h"
 #include "fmpz_mpoly.h"
 
 static int _fmpz_poly_pow_fmpz_is_not_feasible(const fmpz_poly_t b, const fmpz_t e)

--- a/src/fmpz_mpoly/content_vars.c
+++ b/src/fmpz_mpoly/content_vars.c
@@ -9,6 +9,7 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
+#include "fmpz_poly.h"
 #include "fmpz_mpoly.h"
 #include "fmpz_mpoly_factor.h"
 

--- a/src/fmpz_mpoly_factor.h
+++ b/src/fmpz_mpoly_factor.h
@@ -19,6 +19,7 @@
 #endif
 
 #include "fmpq.h"
+#include "fmpz_poly_factor.h"
 #include "fmpz_mpoly.h"
 #include "nmod_mpoly.h"
 

--- a/src/fmpz_mpoly_factor/bpoly.c
+++ b/src/fmpz_mpoly_factor/bpoly.c
@@ -9,8 +9,8 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
+#include "fmpz_poly.h"
 #include "fmpz_mpoly_factor.h"
-
 
 void fmpz_bpoly_clear(fmpz_bpoly_t A)
 {

--- a/src/fmpz_mpoly_factor/eval.c
+++ b/src/fmpz_mpoly_factor/eval.c
@@ -9,6 +9,7 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
+#include "fmpz_poly.h"
 #include "fmpz_mpoly_factor.h"
 #include "n_poly.h"
 

--- a/src/fmpz_mpoly_factor/gcd_algo.c
+++ b/src/fmpz_mpoly_factor/gcd_algo.c
@@ -9,6 +9,7 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
+#include "fmpz_poly.h"
 #include "fmpz_mpoly_factor.h"
 
 /*

--- a/src/fmpz_mpoly_factor/irred_wang.c
+++ b/src/fmpz_mpoly_factor/irred_wang.c
@@ -9,8 +9,8 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
+#include "fmpz_poly.h"
 #include "fmpz_mpoly_factor.h"
-
 
 int fmpz_mpoly_factor_irred_wang(
     fmpz_mpolyv_t fac,

--- a/src/fmpz_mpoly_factor/irred_zassenhaus.c
+++ b/src/fmpz_mpoly_factor/irred_zassenhaus.c
@@ -9,6 +9,7 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
+#include "fmpz_poly.h"
 #include "fmpz_mpoly_factor.h"
 #include "nmod_mpoly_factor.h"
 

--- a/src/fmpz_mpoly_factor/irred_zippel.c
+++ b/src/fmpz_mpoly_factor/irred_zippel.c
@@ -9,6 +9,7 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
+#include "fmpz_poly.h"
 #include "nmod_poly_factor.h"
 #include "fmpz_mpoly_factor.h"
 #include "nmod_mpoly_factor.h"

--- a/src/fmpz_mpoly_factor/lcc_kaltofen.c
+++ b/src/fmpz_mpoly_factor/lcc_kaltofen.c
@@ -1,6 +1,17 @@
+/*
+    Copyright (C) 2020 Daniel Schultz
+
+    This file is part of FLINT.
+
+    FLINT is free software: you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License (LGPL) as published
+    by the Free Software Foundation; either version 2.1 of the License, or
+    (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+*/
+
+#include "fmpz_poly.h"
 #include "fmpz_mpoly_factor.h"
 #include "n_poly.h"
-
 
 static void fmpz_mpoly_convert_perm(
     fmpz_mpoly_t A,

--- a/src/fmpz_mpoly_factor/mpoly_pfrac.c
+++ b/src/fmpz_mpoly_factor/mpoly_pfrac.c
@@ -9,8 +9,8 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
+#include "fmpz_poly.h"
 #include "fmpz_mpoly_factor.h"
-
 
 int fmpz_mpoly_pfrac_init(
     fmpz_mpoly_pfrac_t I,

--- a/src/fmpz_mpoly_factor/test/t-gcd_brown.c
+++ b/src/fmpz_mpoly_factor/test/t-gcd_brown.c
@@ -9,8 +9,8 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
+#include "fmpz_poly.h"
 #include "fmpz_mpoly_factor.h"
-
 
 int compute_gcd(
     fmpz_mpoly_t G,

--- a/src/fmpz_mpoly_factor/test/t-lcc_kaltofen.c
+++ b/src/fmpz_mpoly_factor/test/t-lcc_kaltofen.c
@@ -9,6 +9,7 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
+#include "fmpz_poly.h"
 #include "fmpz_mpoly_factor.h"
 
 #define FLINT_ARRAY_ALLOC(n, T) (T *) flint_malloc((n)*sizeof(T))

--- a/src/fmpz_poly_factor/factor_van_hoeij.c
+++ b/src/fmpz_poly_factor/factor_van_hoeij.c
@@ -12,6 +12,7 @@
 
 #include "fmpz_mat.h"
 #include "fmpz_lll.h"
+#include "fmpz_poly.h"
 #include "fmpz_poly_factor.h"
 
 #ifdef __GNUC__

--- a/src/fmpz_poly_factor/van_hoeij_check_if_solved.c
+++ b/src/fmpz_poly_factor/van_hoeij_check_if_solved.c
@@ -13,6 +13,7 @@
 #include <stdlib.h>
 #include "nmod_poly.h"
 #include "fmpz_mat.h"
+#include "fmpz_poly.h"
 #include "fmpz_poly_factor.h"
 
 int _compare_poly_lengths(const void * a, const void * b)

--- a/src/fq_nmod_mpoly_factor/irred_smprime_zassenhaus.c
+++ b/src/fq_nmod_mpoly_factor/irred_smprime_zassenhaus.c
@@ -9,6 +9,7 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
+#include "fmpz_poly_factor.h"
 #include "nmod_mpoly_factor.h"
 #include "fq_nmod_mpoly_factor.h"
 

--- a/src/fq_nmod_mpoly_factor/n_bpoly_fq_factor_lgprime.c
+++ b/src/fq_nmod_mpoly_factor/n_bpoly_fq_factor_lgprime.c
@@ -10,6 +10,7 @@
 */
 
 #include "nmod_mat.h"
+#include "fmpz_poly_factor.h"
 #include "nmod_mpoly_factor.h"
 #include "fq_nmod_mpoly_factor.h"
 

--- a/src/fq_nmod_mpoly_factor/n_bpoly_fq_factor_smprime.c
+++ b/src/fq_nmod_mpoly_factor/n_bpoly_fq_factor_smprime.c
@@ -10,6 +10,7 @@
 */
 
 #include "nmod_mat.h"
+#include "fmpz_poly_factor.h"
 #include "nmod_mpoly_factor.h"
 #include "fq_nmod_mpoly_factor.h"
 

--- a/src/fq_zech_mpoly_factor/bpoly_factor_smprime.c
+++ b/src/fq_zech_mpoly_factor/bpoly_factor_smprime.c
@@ -10,6 +10,7 @@
 */
 
 #include "nmod_mat.h"
+#include "fmpz_poly_factor.h"
 #include "nmod_mpoly_factor.h"
 #include "fq_zech_mpoly_factor.h"
 

--- a/src/fq_zech_mpoly_factor/irred_smprime_zassenhaus.c
+++ b/src/fq_zech_mpoly_factor/irred_smprime_zassenhaus.c
@@ -9,6 +9,7 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
+#include "fmpz_poly_factor.h"
 #include "fq_zech_mpoly_factor.h"
 
 /*

--- a/src/gr/perm.c
+++ b/src/gr/perm.c
@@ -10,6 +10,7 @@
 */
 
 #include "perm.h"
+#include "fmpz.h"
 #include "fmpz_mat.h"
 #include "gr.h"
 

--- a/src/mpf_mat/test/t-set_fmpz_mat.c
+++ b/src/mpf_mat/test/t-set_fmpz_mat.c
@@ -12,9 +12,9 @@
 */
 
 #include "gmpcompat.h"
+#include "fmpz.h"
 #include "fmpz_mat.h"
 #include "mpf_mat.h"
-#include "ulong_extras.h"
 
 int
 main(void)

--- a/src/nmod_mat/test/t-det.c
+++ b/src/nmod_mat/test/t-det.c
@@ -9,8 +9,8 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
-#include "ulong_extras.h"
 #include "nmod_mat.h"
+#include "fmpz.h"
 #include "fmpz_mat.h"
 
 int

--- a/src/nmod_mat/test/t-det_howell.c
+++ b/src/nmod_mat/test/t-det_howell.c
@@ -9,8 +9,8 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
-#include "ulong_extras.h"
 #include "nmod_mat.h"
+#include "fmpz.h"
 #include "fmpz_mat.h"
 
 int

--- a/src/nmod_mpoly_factor/irred_smprime_zassenhaus.c
+++ b/src/nmod_mpoly_factor/irred_smprime_zassenhaus.c
@@ -9,6 +9,7 @@
     (at your option) any later version.  See <https://www.gnu.org/licenses/>.
 */
 
+#include "fmpz_poly_factor.h"
 #include "nmod_mpoly_factor.h"
 #include "fq_nmod_mpoly_factor.h"
 

--- a/src/nmod_mpoly_factor/n_bpoly_mod_factor_lgprime.c
+++ b/src/nmod_mpoly_factor/n_bpoly_mod_factor_lgprime.c
@@ -10,6 +10,7 @@
 */
 
 #include "nmod_mat.h"
+#include "fmpz_poly_factor.h"
 #include "nmod_mpoly_factor.h"
 
 static void n_bpoly_eval_fq_nmod_poly(

--- a/src/nmod_mpoly_factor/n_bpoly_mod_factor_smprime.c
+++ b/src/nmod_mpoly_factor/n_bpoly_mod_factor_smprime.c
@@ -11,6 +11,7 @@
 
 #include "nmod_mat.h"
 #include "nmod_poly_factor.h"
+#include "fmpz_poly_factor.h"
 #include "nmod_mpoly_factor.h"
 
 static void n_bpoly_reverse_gens(n_bpoly_t a, const n_bpoly_t b)

--- a/src/qqbar/eigenvalues_fmpz_mat.c
+++ b/src/qqbar/eigenvalues_fmpz_mat.c
@@ -10,6 +10,7 @@
 */
 
 #include "fmpz_mat.h"
+#include "fmpz_poly.h"
 #include "qqbar.h"
 
 void


### PR DESCRIPTION
The header files speaks for themselfs, but notably deprecate `fmpz_mat_[col/row]_equal` in favor for `fmpz_mat_equal_[col/row]`.

On my system I got a 2% speedup for building the shared library (without optimization flags). So making many of these declusions will definitely build up.