### PR TITLE
Internals and intrinsics

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -212,7 +212,7 @@ esac],
 enable_dependency_tracking="yes")
 
 AC_ARG_ENABLE(gmp-internals,
-[AS_HELP_STRING([--enable-gmp-internals],[Enables optimization by calling GMP internals directly [default=no]])],
+[AS_HELP_STRING([--enable-gmp-internals],[Enables optimization by calling GMP internals directly [default=yes]])],
 [case $enableval in
 yes|no)
     ;;
@@ -220,7 +220,7 @@ yes|no)
     AC_MSG_ERROR([Bad value $enableval for --enable-dependency-tracking. Need yes or no.])
     ;;
 esac],
-enable_gmp_internals="no")
+enable_gmp_internals="yes")
 
 ################################################################################ 
 # packages
@@ -611,6 +611,18 @@ AC_CHECK_LIB(gmp,__gmpz_init,
 submit a bug report to <https://github.com/flintlib/flint2/issues/> so
 that we can either fix the issue or give a more proper error message.])])
 
+if test "$enable_gmp_internals" = "yes";
+then
+    AC_CHECK_LIB([gmp],[__gmpn_gcd_11],
+    [],
+    [AC_MSG_ERROR([`mpn_gcd_11' was not found in the GMP library. It is needed to enable GMP
+internals.])])
+    AC_CHECK_LIB([gmp],[__gmpn_div_q],
+    [],
+    [AC_MSG_ERROR([`mpn_div_q' was not found in the GMP library. It is needed to enable GMP
+internals.])])
+fi
+
 AC_CHECK_LIB(mpfr,mpfr_init,
 [LIBS="-lmpfr $LIBS"],
 [AC_MSG_ERROR([MPFR library was not found.  If you indeed have MPFR installed, please
@@ -661,18 +673,6 @@ submit a bug report to <https://github.com/flintlib/flint2/issues/> so
 that we can either fix the issue or give a more proper error message.])])
     AC_LANG_POP
     LIBS="$SAVE_libs"
-fi
-
-if test "$enable_gmp_internals" = "yes";
-then
-    AC_CHECK_LIB([gmp],[__gmpn_gcd_11],
-    [],
-    [AC_MSG_ERROR([`mpn_gcd_11' was not found in the GMP library. It is needed to enable GMP
-internals.])])
-    AC_CHECK_LIB([gmp],[__gmpn_div_q],
-    [],
-    [AC_MSG_ERROR([`mpn_div_q' was not found in the GMP library. It is needed to enable GMP
-internals.])])
 fi
 
 ################################################################################ 

--- a/configure.ac
+++ b/configure.ac
@@ -211,6 +211,17 @@ yes|no)
 esac],
 enable_dependency_tracking="yes")
 
+AC_ARG_ENABLE(gmp-internals,
+[AS_HELP_STRING([--enable-gmp-internals],[Enables optimization by calling GMP internals directly [default=no]])],
+[case $enableval in
+yes|no)
+    ;;
+*)
+    AC_MSG_ERROR([Bad value $enableval for --enable-dependency-tracking. Need yes or no.])
+    ;;
+esac],
+enable_gmp_internals="no")
+
 ################################################################################ 
 # packages
 ################################################################################ 
@@ -652,6 +663,18 @@ that we can either fix the issue or give a more proper error message.])])
     LIBS="$SAVE_libs"
 fi
 
+if test "$enable_gmp_internals" = "yes";
+then
+    AC_CHECK_LIB([gmp],[__gmpn_gcd_11],
+    [],
+    [AC_MSG_ERROR([`mpn_gcd_11' was not found in the GMP library. It is needed to enable GMP
+internals.])])
+    AC_CHECK_LIB([gmp],[__gmpn_div_q],
+    [],
+    [AC_MSG_ERROR([`mpn_div_q' was not found in the GMP library. It is needed to enable GMP
+internals.])])
+fi
+
 ################################################################################ 
 # check settings and environment
 ################################################################################ 
@@ -900,6 +923,11 @@ fi
 if test "$enable_assert" = "yes";
 then
     AC_DEFINE(FLINT_WANT_ASSERT,1,[Define to enable use of asserts.])
+fi
+
+if test "$enable_gmp_internals" = "yes";
+then
+    AC_DEFINE(FLINT_WANT_GMP_INTERNALS,1,[Define to enable use of GMP internals.])
 fi
 
 ################################################################################ 

--- a/configure.ac
+++ b/configure.ac
@@ -741,7 +741,33 @@ AC_COMPILE_IFELSE(
         [AC_LANG_PROGRAM([],[long long int x = __builtin_popcountll(3);])],
         [AC_MSG_RESULT([yes])
          has_popcount="yes"
-         AC_DEFINE(FLINT_USES_POPCNT,1,[Define if system has popcount intrinsics])],
+         AC_DEFINE(FLINT_HAS_POPCNT,1,[Define if compiler has popcount intrinsics])],
+        [AC_MSG_RESULT([no])]
+    )],
+    [AC_MSG_RESULT([no])]
+)
+
+AC_MSG_CHECKING([if $CC has CLZ intrinsics])
+AC_COMPILE_IFELSE(
+    [AC_LANG_PROGRAM([],[long int x = __builtin_clzl(3);])],
+    [AC_COMPILE_IFELSE(
+        [AC_LANG_PROGRAM([],[long long int x = __builtin_clzll(3);])],
+        [AC_MSG_RESULT([yes])
+         has_clz="yes"
+         AC_DEFINE(FLINT_HAS_CLZ,1,[Define if compiler has CLZ intrinsics])],
+        [AC_MSG_RESULT([no])]
+    )],
+    [AC_MSG_RESULT([no])]
+)
+
+AC_MSG_CHECKING([if $CC has CTZ intrinsics])
+AC_COMPILE_IFELSE(
+    [AC_LANG_PROGRAM([],[long int x = __builtin_ctzl(3);])],
+    [AC_COMPILE_IFELSE(
+        [AC_LANG_PROGRAM([],[long long int x = __builtin_ctzll(3);])],
+        [AC_MSG_RESULT([yes])
+         has_ctz="yes"
+         AC_DEFINE(FLINT_HAS_CTZ,1,[Define if compiler has CTZ intrinsics])],
         [AC_MSG_RESULT([no])]
     )],
     [AC_MSG_RESULT([no])]

--- a/configure.ac
+++ b/configure.ac
@@ -724,6 +724,14 @@ AC_COMPILE_IFELSE(
     [AC_MSG_RESULT([no])]
 )
 
+AC_MSG_CHECKING([if $CC has __builtin_constant_p])
+AC_COMPILE_IFELSE(
+    [AC_LANG_PROGRAM([], [int a = __builtin_constant_p(0 == 1);])],
+    [AC_MSG_RESULT([yes])
+     AC_DEFINE(FLINT_HAVE_CONSTANT_P,1,[Define if compiler has __builtin_constant_p])],
+    [AC_MSG_RESULT([no])]
+)
+
 ################################################################################ 
 # CFLAGS
 ################################################################################ 

--- a/doc/source/longlong.rst
+++ b/doc/source/longlong.rst
@@ -32,17 +32,16 @@ Auxiliary asm macros
     rounded towards `0`. Note that as the quotient is signed it must lie in 
     the range `[-2^63, 2^63)`.
 
-.. macro:: count_leading_zeros(count, x)
+.. macro:: flint_clz(x)
 
-    Counts the number of zero-bits from the msb to the first non-zero bit 
-    in the limb ``x``.  This is the number of steps ``x`` needs to 
-    be shifted left to set the msb. If ``x`` is `0` then count is 
-    undefined.
+    Returns the number of zero-bits from the msb to the first non-zero bit in
+    the limb ``x``.  This is the number of steps ``x`` needs to be shifted left
+    to set the msb. If ``x`` is `0` then the return value is undefined.
 
-.. macro:: count_trailing_zeros(count, x)
+.. macro:: flint_ctz(x)
 
-    As for ``count_leading_zeros()``, but counts from the least 
-    significant end. If ``x`` is zero then count is undefined.
+    As for ``flint_clz()``, but counts from the least significant end. If ``x``
+    is zero then the return value is undefined.
 
 .. macro:: add_ssaaaa(high_sum, low_sum, high_addend_1, low_addend_1, high_addend_2, low_addend_2)
 

--- a/src/acb/chebyshev_t_ui.c
+++ b/src/acb/chebyshev_t_ui.c
@@ -25,7 +25,7 @@ acb_chebyshev_t_ui(acb_t y, ulong n, const acb_t x, slong prec)
         return;
     }
 
-    count_trailing_zeros(r, n);
+    r = flint_ctz(n);
 
     if ((n >> r) == 1)
     {

--- a/src/acb/dot_fmpz.c
+++ b/src/acb/dot_fmpz.c
@@ -63,7 +63,7 @@ acb_dot_fmpz(acb_t res, const acb_t initial, int subtract, acb_srcptr x, slong x
         else if (!COEFF_IS_MPZ(v))
         {
             av = FLINT_ABS(v);
-            count_leading_zeros(bc, av);
+            bc = flint_clz(av);
 
             ARF_EXP(arb_midref(t + i)) = FLINT_BITS - bc;
             ARF_NOPTR_D(arb_midref(t + i))[0] = av << bc;
@@ -77,7 +77,7 @@ acb_dot_fmpz(acb_t res, const acb_t initial, int subtract, acb_srcptr x, slong x
             size = FLINT_ABS(ssize);
 
             av = z->_mp_d[size - 1];
-            count_leading_zeros(bc, av);
+            bc = flint_clz(av);
 
             if (size == 1)
             {

--- a/src/acb/dot_si.c
+++ b/src/acb/dot_si.c
@@ -58,7 +58,7 @@ acb_dot_si(acb_t res, const acb_t initial, int subtract, acb_srcptr x, slong xst
         else
         {
             av = FLINT_ABS(v);
-            count_leading_zeros(bc, av);
+            bc = flint_clz(av);
 
             ARF_EXP(arb_midref(t + i)) = FLINT_BITS - bc;
             ARF_NOPTR_D(arb_midref(t + i))[0] = av << bc;

--- a/src/acb/dot_siui.c
+++ b/src/acb/dot_siui.c
@@ -34,7 +34,7 @@ arf_shallow_set_siui(arf_t res, ulong vhi, ulong vlo)
         }
         else
         {
-            count_leading_zeros(bc, vlo);
+            bc = flint_clz(vlo);
             ARF_EXP(res) = FLINT_BITS - bc;
             ARF_NOPTR_D(res)[0] = vlo << bc;
             ARF_XSIZE(res) = ARF_MAKE_XSIZE(1, negative);
@@ -42,14 +42,14 @@ arf_shallow_set_siui(arf_t res, ulong vhi, ulong vlo)
     }
     else if (vlo == 0)
     {
-        count_leading_zeros(bc, vhi);
+        bc = flint_clz(vhi);
         ARF_EXP(res) = 2 * FLINT_BITS - bc;
         ARF_NOPTR_D(res)[0] = vhi << bc;
         ARF_XSIZE(res) = ARF_MAKE_XSIZE(1, negative);
     }
     else
     {
-        count_leading_zeros(bc, vhi);
+        bc = flint_clz(vhi);
         ARF_EXP(res) = 2 * FLINT_BITS - bc;
         ARF_NOPTR_D(res)[0] = vlo << bc;
         if (bc == 0)

--- a/src/acb/dot_ui.c
+++ b/src/acb/dot_ui.c
@@ -56,7 +56,7 @@ acb_dot_ui(acb_t res, const acb_t initial, int subtract, acb_srcptr x, slong xst
         }
         else
         {
-            count_leading_zeros(bc, v);
+            bc = flint_clz(v);
 
             ARF_EXP(arb_midref(t + i)) = FLINT_BITS - bc;
             ARF_NOPTR_D(arb_midref(t + i))[0] = v << bc;

--- a/src/acb/dot_uiui.c
+++ b/src/acb/dot_uiui.c
@@ -25,7 +25,7 @@ arf_shallow_set_uiui(arf_t res, ulong vhi, ulong vlo)
         }
         else
         {
-            count_leading_zeros(bc, vlo);
+            bc = flint_clz(vlo);
             ARF_EXP(res) = FLINT_BITS - bc;
             ARF_NOPTR_D(res)[0] = vlo << bc;
             ARF_XSIZE(res) = ARF_MAKE_XSIZE(1, 0);
@@ -33,14 +33,14 @@ arf_shallow_set_uiui(arf_t res, ulong vhi, ulong vlo)
     }
     else if (vlo == 0)
     {
-        count_leading_zeros(bc, vhi);
+        bc = flint_clz(vhi);
         ARF_EXP(res) = 2 * FLINT_BITS - bc;
         ARF_NOPTR_D(res)[0] = vhi << bc;
         ARF_XSIZE(res) = ARF_MAKE_XSIZE(1, 0);
     }
     else
     {
-        count_leading_zeros(bc, vhi);
+        bc = flint_clz(vhi);
         ARF_EXP(res) = 2 * FLINT_BITS - bc;
         ARF_NOPTR_D(res)[0] = vlo << bc;
         if (bc == 0)

--- a/src/arb.h
+++ b/src/arb.h
@@ -1020,7 +1020,7 @@ _arb_mpn_leading_zeros(mp_srcptr d, mp_size_t n)
 
         if (t != 0)
         {
-            count_leading_zeros(bits, t);
+            bits = flint_clz(t);
             return bits + FLINT_BITS * zero_limbs;
         }
 

--- a/src/arb/dot.c
+++ b/src/arb/dot.c
@@ -51,7 +51,7 @@ mag_set_ui_2exp_small(mag_t z, ulong x, slong e)
         slong bits;
         mp_limb_t overflow;
 
-        count_leading_zeros(bits, x);
+        bits = flint_clz(x);
         bits = FLINT_BITS - bits;
 
         if (bits <= MAG_BITS)

--- a/src/arb/dot_fmpz.c
+++ b/src/arb/dot_fmpz.c
@@ -63,7 +63,7 @@ arb_dot_fmpz(arb_t res, const arb_t initial, int subtract, arb_srcptr x, slong x
         else if (!COEFF_IS_MPZ(v))
         {
             av = FLINT_ABS(v);
-            count_leading_zeros(bc, av);
+            bc = flint_clz(av);
 
             ARF_EXP(arb_midref(t + i)) = FLINT_BITS - bc;
             ARF_NOPTR_D(arb_midref(t + i))[0] = av << bc;
@@ -77,7 +77,7 @@ arb_dot_fmpz(arb_t res, const arb_t initial, int subtract, arb_srcptr x, slong x
             size = FLINT_ABS(ssize);
 
             av = z->_mp_d[size - 1];
-            count_leading_zeros(bc, av);
+            bc = flint_clz(av);
 
             if (size == 1)
             {

--- a/src/arb/dot_si.c
+++ b/src/arb/dot_si.c
@@ -58,7 +58,7 @@ arb_dot_si(arb_t res, const arb_t initial, int subtract, arb_srcptr x, slong xst
         else
         {
             av = FLINT_ABS(v);
-            count_leading_zeros(bc, av);
+            bc = flint_clz(av);
 
             ARF_EXP(arb_midref(t + i)) = FLINT_BITS - bc;
             ARF_NOPTR_D(arb_midref(t + i))[0] = av << bc;

--- a/src/arb/dot_siui.c
+++ b/src/arb/dot_siui.c
@@ -34,7 +34,7 @@ arf_shallow_set_siui(arf_t res, ulong vhi, ulong vlo)
         }
         else
         {
-            count_leading_zeros(bc, vlo);
+            bc = flint_clz(vlo);
             ARF_EXP(res) = FLINT_BITS - bc;
             ARF_NOPTR_D(res)[0] = vlo << bc;
             ARF_XSIZE(res) = ARF_MAKE_XSIZE(1, negative);
@@ -42,14 +42,14 @@ arf_shallow_set_siui(arf_t res, ulong vhi, ulong vlo)
     }
     else if (vlo == 0)
     {
-        count_leading_zeros(bc, vhi);
+        bc = flint_clz(vhi);
         ARF_EXP(res) = 2 * FLINT_BITS - bc;
         ARF_NOPTR_D(res)[0] = vhi << bc;
         ARF_XSIZE(res) = ARF_MAKE_XSIZE(1, negative);
     }
     else
     {
-        count_leading_zeros(bc, vhi);
+        bc = flint_clz(vhi);
         ARF_EXP(res) = 2 * FLINT_BITS - bc;
         ARF_NOPTR_D(res)[0] = vlo << bc;
         if (bc == 0)

--- a/src/arb/dot_ui.c
+++ b/src/arb/dot_ui.c
@@ -56,7 +56,7 @@ arb_dot_ui(arb_t res, const arb_t initial, int subtract, arb_srcptr x, slong xst
         }
         else
         {
-            count_leading_zeros(bc, v);
+            bc = flint_clz(v);
 
             ARF_EXP(arb_midref(t + i)) = FLINT_BITS - bc;
             ARF_NOPTR_D(arb_midref(t + i))[0] = v << bc;

--- a/src/arb/dot_uiui.c
+++ b/src/arb/dot_uiui.c
@@ -25,7 +25,7 @@ arf_shallow_set_uiui(arf_t res, ulong vhi, ulong vlo)
         }
         else
         {
-            count_leading_zeros(bc, vlo);
+            bc = flint_clz(vlo);
             ARF_EXP(res) = FLINT_BITS - bc;
             ARF_NOPTR_D(res)[0] = vlo << bc;
             ARF_XSIZE(res) = ARF_MAKE_XSIZE(1, 0);
@@ -33,14 +33,14 @@ arf_shallow_set_uiui(arf_t res, ulong vhi, ulong vlo)
     }
     else if (vlo == 0)
     {
-        count_leading_zeros(bc, vhi);
+        bc = flint_clz(vhi);
         ARF_EXP(res) = 2 * FLINT_BITS - bc;
         ARF_NOPTR_D(res)[0] = vhi << bc;
         ARF_XSIZE(res) = ARF_MAKE_XSIZE(1, 0);
     }
     else
     {
-        count_leading_zeros(bc, vhi);
+        bc = flint_clz(vhi);
         ARF_EXP(res) = 2 * FLINT_BITS - bc;
         ARF_NOPTR_D(res)[0] = vlo << bc;
         if (bc == 0)

--- a/src/arb/exp_sum_bs_powtab.c
+++ b/src/arb/exp_sum_bs_powtab.c
@@ -134,7 +134,7 @@ bsplit(fmpz_t T, fmpz_t Q, flint_bitcnt_t * Qexp,
 
     if (b - a == 1)
     {
-        count_trailing_zeros(cc, (a + 1));
+        cc = flint_ctz((a + 1));
         fmpz_set_ui(Q, (a + 1) >> cc);
         *Qexp = r + cc;
 
@@ -146,11 +146,11 @@ bsplit(fmpz_t T, fmpz_t Q, flint_bitcnt_t * Qexp,
         fmpz_mul_2exp(T, T, r);
         fmpz_add(T, T, xpow + 1);
 
-        count_trailing_zeros(cc, (a + 2));
+        cc = flint_ctz((a + 2));
         fmpz_set_ui(Q, (a + 2) >> cc);
         *Qexp = r + cc;
 
-        count_trailing_zeros(cc, (a + 1));
+        cc = flint_ctz((a + 1));
         fmpz_mul_ui(Q, Q, (a + 1) >> cc);
         *Qexp += r + cc;
     }

--- a/src/arb/log_ui.c
+++ b/src/arb/log_ui.c
@@ -31,8 +31,8 @@ atanh_bs(arb_t s, ulong p, ulong q, slong prec)
 static int n_width(ulong k)
 {
     int a, b;
-    count_leading_zeros(a, k);
-    count_trailing_zeros(b, k);
+    a = flint_clz(k);
+    b = flint_ctz(k);
     return FLINT_BITS - a - b;
 }
 

--- a/src/arb/sin_cos_arf_bb.c
+++ b/src/arb/sin_cos_arf_bb.c
@@ -26,7 +26,7 @@ bsplit(fmpz_t T, fmpz_t Q, flint_bitcnt_t * Qexp,
 
     if (b - a == 1)
     {
-        count_trailing_zeros(cc, (2 * a + 2));
+        cc = flint_ctz((2 * a + 2));
         fmpz_neg_ui(Q, (2 * a + 2) >> cc);
         fmpz_mul_ui(Q, Q, 2 * a + 3);
         *Qexp = 2 * r + cc;
@@ -40,12 +40,12 @@ bsplit(fmpz_t T, fmpz_t Q, flint_bitcnt_t * Qexp,
         fmpz_neg(T, T);
         fmpz_add(T, T, xpow + 1);
 
-        count_trailing_zeros(cc, (2 * a + 4));
+        cc = flint_ctz((2 * a + 4));
         fmpz_neg_ui(Q, (2 * a + 4) >> cc);
         fmpz_mul_ui(Q, Q, 2 * a + 5);
         *Qexp = 2 * r + cc;
 
-        count_trailing_zeros(cc, (2 * a + 2));
+        cc = flint_ctz((2 * a + 2));
         fmpz_mul2_uiui(Q, Q, (2 * a + 2) >> cc, (2 * a + 3));
         fmpz_neg(Q, Q);
         *Qexp += 2 * r + cc;

--- a/src/arb/sin_cos_pi_fmpq.c
+++ b/src/arb/sin_cos_pi_fmpq.c
@@ -23,7 +23,7 @@ use_algebraic(const fmpz_t v, const fmpz_t w, slong prec)
     if (q <= 6)
         return 1;
 
-    count_trailing_zeros(r, q);
+    r = flint_ctz(q);
     q >>= r;
 
     if (r >= 4 && prec < (r - 3) * 300)
@@ -122,8 +122,8 @@ reduce_octant(fmpz_t v, fmpz_t w, const fmpq_t x)
 
         if (vv != 0)
         {
-            count_trailing_zeros(vval, vv);
-            count_trailing_zeros(wval, ww);
+            vval = flint_ctz(vv);
+            wval = flint_ctz(ww);
             vval = FLINT_MIN(vval, wval);
             vv >>= vval;
             ww >>= vval;

--- a/src/arb/ui_pow_ui.c
+++ b/src/arb/ui_pow_ui.c
@@ -103,7 +103,7 @@ arb_ui_pow_ui(arb_t res, ulong a, ulong exp, slong prec)
     }
 
     aexp = FLINT_BIT_COUNT(a);
-    count_trailing_zeros(trailing, a);
+    trailing = flint_ctz(a);
     awidth = aexp - trailing;
 
     /* a = power of two */
@@ -219,7 +219,7 @@ arb_ui_pow_ui(arb_t res, ulong a, ulong exp, slong prec)
             if (yn > wp_limbs)
             {
                 inexact = 1;
-                count_leading_zeros(leading, yman[yn - 1]);
+                leading = flint_clz(yman[yn - 1]);
                 yexp_lo = yexp_lo + yn * FLINT_BITS - leading;
 
                 if (leading == 0)

--- a/src/arf.h
+++ b/src/arf.h
@@ -362,7 +362,7 @@ arf_init_set_ui(arf_t x, ulong v)
     else
     {
         unsigned int c;
-        count_leading_zeros(c, v);
+        c = flint_clz(v);
         ARF_EXP(x) = FLINT_BITS - c;
         ARF_NOPTR_D(x)[0] = v << c;
         ARF_XSIZE(x) = ARF_MAKE_XSIZE(1, 0);
@@ -394,7 +394,7 @@ arf_set_ui(arf_t x, ulong v)
     else
     {
         unsigned int c;
-        count_leading_zeros(c, v);
+        c = flint_clz(v);
         ARF_EXP(x) = FLINT_BITS - c;
         ARF_NOPTR_D(x)[0] = v << c;
         ARF_XSIZE(x) = ARF_MAKE_XSIZE(1, 0);
@@ -581,7 +581,7 @@ arf_bits(const arf_t x)
         slong c;
 
         ARF_GET_MPN_READONLY(xp, xn, x);
-        count_trailing_zeros(c, xp[0]);
+        c = flint_ctz(xp[0]);
         return xn * FLINT_BITS - c;
     }
 }

--- a/src/arf/get_fmpz_2exp.c
+++ b/src/arf/get_fmpz_2exp.c
@@ -27,7 +27,7 @@ arf_get_fmpz_2exp(fmpz_t man, fmpz_t exp, const arf_t x)
 
         ARF_GET_MPN_READONLY(xptr, xn, x);
 
-        count_trailing_zeros(shift, xptr[0]);
+        shift = flint_ctz(xptr[0]);
 
         fmpz_sub_ui(exp, ARF_EXPREF(x), xn * FLINT_BITS - shift);
 

--- a/src/arf/is_int.c
+++ b/src/arf/is_int.c
@@ -27,7 +27,7 @@ arf_is_int(const arf_t x)
         return mpz_sgn(COEFF_TO_PTR(exp)) > 0;
 
     ARF_GET_MPN_READONLY(xp, xn, x);
-    count_trailing_zeros(c, xp[0]);
+    c = flint_ctz(xp[0]);
     return exp - xn * FLINT_BITS + c >= 0;
 }
 

--- a/src/arf/set_mpn.c
+++ b/src/arf/set_mpn.c
@@ -27,7 +27,7 @@ arf_set_mpn(arf_t y, mp_srcptr x, mp_size_t xn, int sgnbit)
         xn--;
     }
 
-    count_leading_zeros(leading, x[xn - 1]);
+    leading = flint_clz(x[xn - 1]);
 
     bot = x[0];
 

--- a/src/arf/set_round_mpn.c
+++ b/src/arf/set_round_mpn.c
@@ -23,7 +23,7 @@ _arf_set_round_mpn(arf_t y, slong * exp_shift, mp_srcptr x, mp_size_t xn,
     int increment, inexact;
 
     /* Compute the total bit length of x. */
-    count_leading_zeros(leading, x[xn - 1]);
+    leading = flint_clz(x[xn - 1]);
     exp = xn * FLINT_BITS - leading;
 
     /* Set exponent. */
@@ -33,7 +33,7 @@ _arf_set_round_mpn(arf_t y, slong * exp_shift, mp_srcptr x, mp_size_t xn,
     val_limbs = 0;
     while (x[val_limbs] == 0)
         val_limbs++;
-    count_trailing_zeros(val_bits, x[val_limbs]);
+    val_bits = flint_ctz(x[val_limbs]);
     val = val_limbs * FLINT_BITS + val_bits;
 
     if (exp - val <= prec)
@@ -92,7 +92,7 @@ _arf_set_round_mpn(arf_t y, slong * exp_shift, mp_srcptr x, mp_size_t xn,
                 t = x[val_limbs];
             }
 
-            count_trailing_zeros(val_bits, t);
+            val_bits = flint_ctz(t);
             val = val_limbs * FLINT_BITS + val_bits;
         }
         else
@@ -110,7 +110,7 @@ _arf_set_round_mpn(arf_t y, slong * exp_shift, mp_srcptr x, mp_size_t xn,
                     goto END_SCAN1;
                 }
             }
-            count_trailing_zeros(val_bits, t);
+            val_bits = flint_ctz(t);
             END_SCAN1:
             val = val_limbs * FLINT_BITS + val_bits;
 

--- a/src/arf/set_round_ui.c
+++ b/src/arf/set_round_ui.c
@@ -15,7 +15,7 @@
    Writes inexact, v, exp. Warning: macro without parentheses. */
 #define ARF_NORMALISE_ROUND_LIMB(inexact, exp, v, sgnbit, prec, rnd) \
     do { \
-        count_leading_zeros(exp, v); \
+        exp = flint_clz(v); \
         v <<= exp; \
         exp = FLINT_BITS - exp; \
         if (prec >= exp) \

--- a/src/arf/set_round_uiui.c
+++ b/src/arf/set_round_uiui.c
@@ -15,7 +15,7 @@
    Writes inexact, v, exp. Warning: macro without parentheses. */
 #define ARF_NORMALISE_ROUND_LIMB(inexact, exp, v, sgnbit, prec, rnd) \
     do { \
-        count_leading_zeros(exp, v); \
+        exp = flint_clz(v); \
         v <<= exp; \
         exp = FLINT_BITS - exp; \
         if (prec >= exp) \
@@ -73,8 +73,8 @@ _arf_set_round_uiui(arf_t z, slong * fix, mp_limb_t hi, mp_limb_t lo, int sgnbit
     }
     else
     {
-        count_leading_zeros(leading, hi);
-        count_trailing_zeros(trailing, lo);
+        leading = flint_clz(hi);
+        trailing = flint_ctz(lo);
 
         bc = 2 * FLINT_BITS - leading - trailing;
 

--- a/src/flint.h
+++ b/src/flint.h
@@ -65,6 +65,12 @@
 # define FLINT_HAVE_FILE
 #endif
 
+#ifdef FLINT_HAVE_CONSTANT_P
+# define FLINT_CONSTANT_P __builtin_constant_p
+#else
+# define FLINT_CONSTANT_P(x) 0
+#endif
+
 #ifdef FLINT_INLINES_C
 # define FLINT_INLINE
 #else

--- a/src/flint.h
+++ b/src/flint.h
@@ -362,7 +362,7 @@ static __inline__
 mp_limb_t FLINT_BIT_COUNT(mp_limb_t x)
 {
    mp_limb_t zeros = FLINT_BITS;
-   if (x) count_leading_zeros(zeros, x);
+   if (x) zeros = flint_clz(x);
    return FLINT_BITS - zeros;
 }
 

--- a/src/fmpq/get_cfrac_helpers.c
+++ b/src/fmpq/get_cfrac_helpers.c
@@ -518,7 +518,7 @@ again:
     if (n == xd_len + 1)
         xd_ptr[n - 1] = 0;
 
-    count_leading_zeros(x_lzcnt, xn_ptr[n - 1]);
+    x_lzcnt = flint_clz(xn_ptr[n - 1]);
     A1 = MPN_LEFT_SHIFT_HI(xn_ptr[n - 1], xn_ptr[n - 2], x_lzcnt);
     A0 = MPN_LEFT_SHIFT_HI(xn_ptr[n - 2], xn_ptr[n - 3], x_lzcnt);
     B1 = MPN_LEFT_SHIFT_HI(xd_ptr[n - 1], xd_ptr[n - 2], x_lzcnt);
@@ -696,7 +696,7 @@ again:
     if (nr == xrd_len + 1)
         xrd_ptr[nr - 1] = 0;
 
-    count_leading_zeros(x_lzcnt, xln_ptr[nl - 1]);
+    x_lzcnt = flint_clz(xln_ptr[nl - 1]);
     A1 = MPN_LEFT_SHIFT_HI(xln_ptr[nl - 1], xln_ptr[nl - 2], x_lzcnt);
     A0 = MPN_LEFT_SHIFT_HI(xln_ptr[nl - 2], xln_ptr[nl - 3], x_lzcnt);
     B1 = MPN_LEFT_SHIFT_HI(xld_ptr[nl - 1], xld_ptr[nl - 2], x_lzcnt);

--- a/src/fmpq/reconstruct_fmpz_2.c
+++ b/src/fmpq/reconstruct_fmpz_2.c
@@ -439,7 +439,7 @@ int _fmpq_reconstruct_fmpz_2_ui_array(fmpz_t n, fmpz_t d,
     FLINT_ASSERT(n_len > 0);
     FLINT_ASSERT(d_len > 0);
     FLINT_ASSERT(n_ptr[n_len - 1] != 0);
-    count_leading_zeros(n_lzcnt, n_ptr[n_len - 1]);
+    n_lzcnt = flint_clz(n_ptr[n_len - 1]);
 
 again:
 
@@ -456,7 +456,7 @@ again:
         goto gauss;
     }
 
-    count_leading_zeros(a_lzcnt, A[Alen - 1]);
+    a_lzcnt = flint_clz(A[Alen - 1]);
 
     if (Alen - 1 > Blen)
     {
@@ -656,7 +656,7 @@ static int _lehmer(_fmpz_mat22_t M, fmpz_t A, fmpz_t B, const fmpz_t N,
     }
 
     FLINT_ASSERT(n_ptr[n_len - 1] != 0);
-    count_leading_zeros(n_lzcnt, n_ptr[n_len - 1]);
+    n_lzcnt = flint_clz(n_ptr[n_len - 1]);
 
     if (a->_mp_size < 3 || b->_mp_size <= n_len)
     {
@@ -707,7 +707,7 @@ again:
     }
 
     FLINT_ASSERT(a_ptr[a_len - 1] != 0);
-    count_leading_zeros(a_lzcnt, a_ptr[a_len - 1]);
+    a_lzcnt = flint_clz(a_ptr[a_len - 1]);
 
     if (a_len - 1 == n_len && n_lzcnt < a_lzcnt)
     {

--- a/src/fmpz/abs_lbound_ui_2exp.c
+++ b/src/fmpz/abs_lbound_ui_2exp.c
@@ -41,7 +41,7 @@ fmpz_abs_lbound_ui_2exp(slong * exp, const fmpz_t x, int bits)
             /* top limb (which must be nonzero) */
             m = z->_mp_d[size - 1];
 
-            count_leading_zeros(shift, m);
+            shift = flint_clz(m);
             shift = FLINT_BITS - shift - bits;
             e += shift;
 
@@ -61,7 +61,7 @@ fmpz_abs_lbound_ui_2exp(slong * exp, const fmpz_t x, int bits)
         }
     }
 
-    count_leading_zeros(shift, m);
+    shift = flint_clz(m);
     e += FLINT_BITS - shift - bits;
     if (e >= 0)
         m >>= e;

--- a/src/fmpz/abs_ubound_ui_2exp.c
+++ b/src/fmpz/abs_ubound_ui_2exp.c
@@ -42,7 +42,7 @@ fmpz_abs_ubound_ui_2exp(slong * exp, const fmpz_t x, int bits)
             /* top limb (which must be nonzero) */
             m = z->_mp_d[size - 1];
 
-            count_leading_zeros(shift, m);
+            shift = flint_clz(m);
             shift = FLINT_BITS - shift - bits;
             e += shift;
 
@@ -73,7 +73,7 @@ fmpz_abs_ubound_ui_2exp(slong * exp, const fmpz_t x, int bits)
     }
 
     /* single limb, adjust */
-    count_leading_zeros(shift, m);
+    shift = flint_clz(m);
     e = FLINT_BITS - shift - bits;
 
     if (e >= 0)

--- a/src/fmpz/powmod2_fmpz_preinv.c
+++ b/src/fmpz/powmod2_fmpz_preinv.c
@@ -33,7 +33,7 @@ n_powmod2_fmpz_preinv(ulong a, const fmpz_t exp, ulong n, ulong ninv)
     if (a == 0)
         return 0;
 
-    count_leading_zeros(norm, n);
+    norm = flint_clz(n);
     a <<= norm;
     n <<= norm;
 

--- a/src/fmpz/preinvn_init.c
+++ b/src/fmpz/preinvn_init.c
@@ -29,7 +29,7 @@ void fmpz_preinvn_init(fmpz_preinvn_t inv, const fmpz_t f)
    {
       inv->dinv = flint_malloc(sizeof(mp_limb_t));
       if (c < 0) c = -c;
-      count_leading_zeros(norm, c);
+      norm = flint_clz(c);
       if (norm) c <<= norm;
       flint_mpn_preinvn(inv->dinv, (mp_ptr) &c, 1);
       inv->n = 1;
@@ -38,7 +38,7 @@ void fmpz_preinvn_init(fmpz_preinvn_t inv, const fmpz_t f)
       __mpz_struct * mc = COEFF_TO_PTR(c);
       slong size = FLINT_ABS(mc->_mp_size);
       inv->dinv = flint_malloc(size*sizeof(mp_limb_t));
-      count_leading_zeros(norm, mc->_mp_d[size - 1]);
+      norm = flint_clz(mc->_mp_d[size - 1]);
       if (norm)
       {
          t = flint_malloc(size*sizeof(mp_limb_t));

--- a/src/fmpz/val2.c
+++ b/src/fmpz/val2.c
@@ -23,7 +23,7 @@ flint_bitcnt_t fmpz_val2(const fmpz_t x)
         if (c == 0)
             t = 0;
         else
-            count_trailing_zeros(t, FLINT_ABS(c));
+            t = flint_ctz(FLINT_ABS(c));
     }
     else
     {
@@ -37,7 +37,7 @@ flint_bitcnt_t fmpz_val2(const fmpz_t x)
             t += FLINT_BITS;
         }
 
-        count_trailing_zeros(u, *d);
+        u = flint_ctz(*d);
         t += u;
     }
 

--- a/src/fmpz_factor/ecm.c
+++ b/src/fmpz_factor/ecm.c
@@ -75,14 +75,14 @@ fmpz_factor_ecm(fmpz_t f, mp_limb_t curves, mp_limb_t B1, mp_limb_t B2,
 
     if ((!COEFF_IS_MPZ(* n_in)))
     {
-        count_leading_zeros(ecm_inf->normbits, fmpz_get_ui(n_in));
+        ecm_inf->normbits = flint_clz(fmpz_get_ui(n_in));
         n[0] = fmpz_get_ui(n_in);
         n[0] <<= ecm_inf->normbits;
     }
     else
     {
         mptr = COEFF_TO_PTR(* n_in);
-        count_leading_zeros(ecm_inf->normbits, mptr->_mp_d[n_size - 1]);
+        ecm_inf->normbits = flint_clz(mptr->_mp_d[n_size - 1]);
         if (ecm_inf->normbits)
            mpn_lshift(n, mptr->_mp_d, n_size, ecm_inf->normbits);
         else

--- a/src/fmpz_factor/factor_pp1.c
+++ b/src/fmpz_factor/factor_pp1.c
@@ -216,12 +216,12 @@ int fmpz_factor_pp1(fmpz_t fac, const fmpz_t n_in, ulong B1, ulong B2sqrt, ulong
    if (nn == 1)
    {
       n[0] = fmpz_get_ui(n_in);
-      count_leading_zeros(norm, n[0]);
+      norm = flint_clz(n[0]);
       n[0] <<= norm;
    } else
    {
       mp_ptr np = COEFF_TO_PTR(*n_in)->_mp_d;
-      count_leading_zeros(norm, np[nn - 1]);
+      norm = flint_clz(np[nn - 1]);
       if (norm)
          mpn_lshift(n, np, nn, norm);
       else

--- a/src/fmpz_factor/pollard_brent.c
+++ b/src/fmpz_factor/pollard_brent.c
@@ -63,7 +63,7 @@ fmpz_factor_pollard_brent(fmpz_t p_factor, flint_rand_t state, fmpz_t n_in,
     /* copying n_in onto n, and normalizing */
 
     temp = COEFF_TO_PTR(*n_in)->_mp_d;
-    count_leading_zeros(normbits, temp[n_size - 1]);
+    normbits = flint_clz(temp[n_size - 1]);
     if (normbits)
         mpn_lshift(n, temp, n_size, normbits);
     else

--- a/src/fmpz_factor/pollard_brent_single.c
+++ b/src/fmpz_factor/pollard_brent_single.c
@@ -186,7 +186,7 @@ fmpz_factor_pollard_brent_single(fmpz_t p_factor, fmpz_t n_in, fmpz_t yi,
     if (n_size == 1)
     {
         val = fmpz_get_ui(n_in);
-        count_leading_zeros(normbits, val);
+        normbits = flint_clz(val);
         val <<= normbits;
         valinv = n_preinvert_limb(val);
 
@@ -203,7 +203,7 @@ fmpz_factor_pollard_brent_single(fmpz_t p_factor, fmpz_t n_in, fmpz_t yi,
 
     mptr = COEFF_TO_PTR(*yi);
     temp = COEFF_TO_PTR(*n_in)->_mp_d;
-    count_leading_zeros(normbits, temp[n_size - 1]);
+    normbits = flint_clz(temp[n_size - 1]);
 
     TMP_START;
     a    = TMP_ALLOC(n_size * sizeof(mp_limb_t));
@@ -214,7 +214,7 @@ fmpz_factor_pollard_brent_single(fmpz_t p_factor, fmpz_t n_in, fmpz_t yi,
     /* copying n_in onto n, and normalizing */
 
     temp = COEFF_TO_PTR(*n_in)->_mp_d;
-    count_leading_zeros(normbits, temp[n_size - 1]);
+    normbits = flint_clz(temp[n_size - 1]);
     if (normbits)
         mpn_lshift(n, temp, n_size, normbits);
     else

--- a/src/fmpz_mat/fflu.c
+++ b/src/fmpz_mat/fflu.c
@@ -148,7 +148,7 @@ fmpz_mat_fflu(fmpz_mat_t B, fmpz_t den, slong * perm,
         {
             uden = FLINT_ABS((slong)(*den));
             dsgn = 0 > (slong)(*den);
-            count_leading_zeros(norm, uden);
+            norm = flint_clz(uden);
             invert_limb(dinv, uden << norm);
 
             if (fmpz_sizeinbase(den, 2) > SMALL_FMPZ_BITCOUNT_MAX)

--- a/src/fmpz_mat/hadamard.c
+++ b/src/fmpz_mat/hadamard.c
@@ -135,7 +135,7 @@ paley_construction(mp_limb_t * q, mp_limb_t n)
 {
     int i, v;
 
-    count_trailing_zeros(v, n);
+    v = flint_ctz(n);
 
     if (UWORD(1) << v == n)
         return 3;

--- a/src/fmpz_mat/solve_fflu_precomp.c
+++ b/src/fmpz_mat/solve_fflu_precomp.c
@@ -102,7 +102,7 @@ fmpz_mat_solve_fflu_precomp(fmpz_mat_t X,
                     dsgn = 0 > (slong)(diag[i - 1]);
                     if (uden != 0) /* see #1029 */
                     {
-                       count_leading_zeros(norm, uden);
+                       norm = flint_clz(uden);
                        invert_limb(dinv, uden << norm);
                     } else
                        dinv = 0;
@@ -235,7 +235,7 @@ fmpz_mat_solve_fflu_precomp(fmpz_mat_t X,
                     dsgn = 0 > (slong)(diag[l]);
                     if (uden != 0) /* see #1029 */
                     {
-                       count_leading_zeros(norm, uden);
+                       norm = flint_clz(uden);
                        invert_limb(dinv, uden << norm);
                     } else
                        dinv = 0;

--- a/src/fmpz_mpoly/div_monagan_pearce.c
+++ b/src/fmpz_mpoly/div_monagan_pearce.c
@@ -91,7 +91,7 @@ slong _fmpz_mpoly_div_monagan_pearce1(fmpz ** polyq, ulong ** expq,
     {
         lc_abs = FLINT_ABS(poly3[0]);
         lc_sign = FLINT_SIGN_EXT(poly3[0]);
-        count_leading_zeros(lc_norm, lc_abs);
+        lc_norm = flint_clz(lc_abs);
         lc_n = lc_abs << lc_norm;
         invert_limb(lc_i, lc_n);
     }
@@ -412,7 +412,7 @@ slong _fmpz_mpoly_div_monagan_pearce(fmpz ** polyq,
     {
         lc_abs = FLINT_ABS(poly3[0]);
         lc_sign = FLINT_SIGN_EXT(poly3[0]);
-        count_leading_zeros(lc_norm, lc_abs);
+        lc_norm = flint_clz(lc_abs);
         lc_n = lc_abs << lc_norm;
         invert_limb(lc_i, lc_n);
     }

--- a/src/fmpz_mpoly/divides_heap_threaded.c
+++ b/src/fmpz_mpoly/divides_heap_threaded.c
@@ -996,7 +996,7 @@ slong _fmpz_mpoly_divides_stripe1(
         FLINT_ASSERT(!COEFF_IS_MPZ(Bcoeff[0]));
         lc_abs = FLINT_ABS(Bcoeff[0]);
         lc_sign = FLINT_SIGN_EXT(Bcoeff[0]);
-        count_leading_zeros(lc_norm, lc_abs);
+        lc_norm = flint_clz(lc_abs);
         lc_n = lc_abs << lc_norm;
         invert_limb(lc_i, lc_n);
     }
@@ -1347,7 +1347,7 @@ slong _fmpz_mpoly_divides_stripe(
         FLINT_ASSERT(!COEFF_IS_MPZ(Bcoeff[0]));
         lc_abs = FLINT_ABS(Bcoeff[0]);
         lc_sign = FLINT_SIGN_EXT(Bcoeff[0]);
-        count_leading_zeros(lc_norm, lc_abs);
+        lc_norm = flint_clz(lc_abs);
         lc_n = lc_abs << lc_norm;
         invert_limb(lc_i, lc_n);
     }

--- a/src/fmpz_mpoly/divides_monagan_pearce.c
+++ b/src/fmpz_mpoly/divides_monagan_pearce.c
@@ -87,7 +87,7 @@ slong _fmpz_mpoly_divides_monagan_pearce1(fmpz ** poly1, ulong ** exp1,
     {
         lc_abs = FLINT_ABS(poly3[0]);
         lc_sign = FLINT_SIGN_EXT(poly3[0]);
-        count_leading_zeros(lc_norm, lc_abs);
+        lc_norm = flint_clz(lc_abs);
         lc_n = lc_abs << lc_norm;
         invert_limb(lc_i, lc_n);
     }
@@ -379,7 +379,7 @@ slong _fmpz_mpoly_divides_monagan_pearce(fmpz ** poly1, ulong ** exp1,
     {
         lc_abs = FLINT_ABS(poly3[0]);
         lc_sign = FLINT_SIGN_EXT(poly3[0]);
-        count_leading_zeros(lc_norm, lc_abs);
+        lc_norm = flint_clz(lc_abs);
         lc_n = lc_abs << lc_norm;
         invert_limb(lc_i, lc_n);
     }

--- a/src/fmpz_mpoly/divrem_monagan_pearce.c
+++ b/src/fmpz_mpoly/divrem_monagan_pearce.c
@@ -98,7 +98,7 @@ slong _fmpz_mpoly_divrem_monagan_pearce1(slong * lenr,
     {
         lc_abs = FLINT_ABS(poly3[0]);
         lc_sign = FLINT_SIGN_EXT(poly3[0]);
-        count_leading_zeros(lc_norm, lc_abs);
+        lc_norm = flint_clz(lc_abs);
         lc_n = lc_abs << lc_norm;
         invert_limb(lc_i, lc_n);
     }
@@ -437,7 +437,7 @@ slong _fmpz_mpoly_divrem_monagan_pearce(slong * lenr,
     {
         lc_abs = FLINT_ABS(poly3[0]);
         lc_sign = FLINT_SIGN_EXT(poly3[0]);
-        count_leading_zeros(lc_norm, lc_abs);
+        lc_norm = flint_clz(lc_abs);
         lc_n = lc_abs << lc_norm;
         invert_limb(lc_i, lc_n);
     }

--- a/src/fmpz_mpoly/mul_dense.c
+++ b/src/fmpz_mpoly/mul_dense.c
@@ -211,7 +211,7 @@ void fmpz_mpoly_consume_fmpz_mpolyd_clear(fmpz_mpoly_t A, fmpz_mpolyd_t B,
         mpoly_get_cmpmask(ptempexp, N, bits, ctx->minfo);
         if (topmask != WORD(0))
         {
-            count_leading_zeros(msb, topmask);
+            msb = flint_clz(topmask);
             msb = (FLINT_BITS - 1)^msb;
         } else
         {

--- a/src/fmpz_mpoly/quasidiv_heap.c
+++ b/src/fmpz_mpoly/quasidiv_heap.c
@@ -85,7 +85,7 @@ slong _fmpz_mpoly_quasidiv_heap1(fmpz_t scale,
     {
         lc_abs = FLINT_ABS(poly3[0]);
         lc_sign = FLINT_SIGN_EXT(poly3[0]);
-        count_leading_zeros(lc_norm, lc_abs);
+        lc_norm = flint_clz(lc_abs);
         lc_n = lc_abs << lc_norm;
         invert_limb(lc_i, lc_n);
     }
@@ -466,7 +466,7 @@ slong _fmpz_mpoly_quasidiv_heap(fmpz_t scale,
     {
         lc_abs = FLINT_ABS(poly3[0]);
         lc_sign = FLINT_SIGN_EXT(poly3[0]);
-        count_leading_zeros(lc_norm, lc_abs);
+        lc_norm = flint_clz(lc_abs);
         lc_n = lc_abs << lc_norm;
         invert_limb(lc_i, lc_n);
     }

--- a/src/fmpz_mpoly/quasidivrem_heap.c
+++ b/src/fmpz_mpoly/quasidivrem_heap.c
@@ -89,7 +89,7 @@ slong _fmpz_mpoly_quasidivrem_heap1(fmpz_t scale, slong * lenr,
     {
         lc_abs = FLINT_ABS(poly3[0]);
         lc_sign = FLINT_SIGN_EXT(poly3[0]);
-        count_leading_zeros(lc_norm, lc_abs);
+        lc_norm = flint_clz(lc_abs);
         lc_n = lc_abs << lc_norm;
         invert_limb(lc_i, lc_n);
     }
@@ -451,7 +451,7 @@ slong _fmpz_mpoly_quasidivrem_heap(fmpz_t scale, slong * lenr,
     {
         lc_abs = FLINT_ABS(poly3[0]);
         lc_sign = FLINT_SIGN_EXT(poly3[0]);
-        count_leading_zeros(lc_norm, lc_abs);
+        lc_norm = flint_clz(lc_abs);
         lc_n = lc_abs << lc_norm;
         invert_limb(lc_i, lc_n);
     }

--- a/src/fmpz_mpoly/sort_terms.c
+++ b/src/fmpz_mpoly/sort_terms.c
@@ -150,7 +150,7 @@ void fmpz_mpoly_sort_terms(fmpz_mpoly_t A, const fmpz_mpoly_ctx_t ctx)
 
     if (himask != 0)
     {
-        count_leading_zeros(msb, himask);
+        msb = flint_clz(himask);
         msb = (FLINT_BITS - 1)^msb;
     } else
     {

--- a/src/fmpz_mpoly/sqrt_heap.c
+++ b/src/fmpz_mpoly/sqrt_heap.c
@@ -174,7 +174,7 @@ slong _fmpz_mpoly_sqrt_heap1(
     if (fmpz_abs_fits_ui(Qcoeffs + 0))
     {
         lc_abs = fmpz_get_ui(Qcoeffs + 0);
-        count_leading_zeros(lc_norm, lc_abs);
+        lc_norm = flint_clz(lc_abs);
         lc_n = lc_abs << lc_norm;
         invert_limb(lc_i, lc_n);
     }
@@ -640,7 +640,7 @@ slong _fmpz_mpoly_sqrt_heap(
     if (fmpz_abs_fits_ui(Qcoeffs + 0))
     {
         lc_abs = fmpz_get_ui(Qcoeffs + 0);
-        count_leading_zeros(lc_norm, lc_abs);
+        lc_norm = flint_clz(lc_abs);
         lc_n = lc_abs << lc_norm;
         invert_limb(lc_i, lc_n);
     }

--- a/src/fmpz_poly/evaluate_divconquer_fmpq.c
+++ b/src/fmpz_poly/evaluate_divconquer_fmpq.c
@@ -51,7 +51,7 @@ _fmpz_poly_evaluate_divconquer_fmpq(fmpz_t rnum, fmpz_t rden,
         fmpz_set(tden, yden + 0);
 
         i += 2;
-        count_trailing_zeros(c, i);
+        c = flint_ctz(i);
 
         for (k = 1; k < c; k++)
         {
@@ -72,7 +72,7 @@ _fmpz_poly_evaluate_divconquer_fmpq(fmpz_t rnum, fmpz_t rden,
         fmpz_set(tnum, poly + (len - 1));
         fmpz_one(tden);
 
-        count_trailing_zeros(c, len + 1);
+        c = flint_ctz(len + 1);
 
         for (k = 1; k < c; k++)
         {

--- a/src/fmpz_poly/evaluate_divconquer_fmpz.c
+++ b/src/fmpz_poly/evaluate_divconquer_fmpz.c
@@ -34,7 +34,7 @@ _fmpz_poly_evaluate_divconquer_fmpz(fmpz_t res, const fmpz * poly, slong len,
         fmpz_mul(u, y + 0, poly + i + 1);
         fmpz_add(t, poly + i, u);
         i += 2;
-        count_trailing_zeros(c, i);
+        c = flint_ctz(i);
         for (k = 1; k < c; k++)
         {
             fmpz_mul(u, y + k, t);
@@ -45,7 +45,7 @@ _fmpz_poly_evaluate_divconquer_fmpz(fmpz_t res, const fmpz * poly, slong len,
     if (len & WORD(1))
     {
         fmpz_set(t, poly + (len - 1));
-        count_trailing_zeros(c, len + 1);
+        c = flint_ctz(len + 1);
         for (k = 1; k < c; k++)
         {
             fmpz_mul(u, y + k, t);

--- a/src/fq_nmod_mpoly/sort_terms.c
+++ b/src/fq_nmod_mpoly/sort_terms.c
@@ -163,7 +163,7 @@ void fq_nmod_mpoly_sort_terms(fq_nmod_mpoly_t A, const fq_nmod_mpoly_ctx_t ctx)
 
     if (himask != 0)
     {
-        count_leading_zeros(msb, himask);
+        msb = flint_clz(himask);
         msb = (FLINT_BITS - 1)^msb;
     }
     else

--- a/src/gmpcompat.h
+++ b/src/gmpcompat.h
@@ -237,7 +237,7 @@ double flint_mpn_get_d (mp_srcptr ptr, mp_size_t size, mp_size_t sign, long exp)
 
       m0 = ptr[size-1];			    /* high limb */
       m1 = (size >= 2 ? ptr[size-2] : 0);   /* second highest limb */
-      count_leading_zeros (lshift, m0);
+      lshift = flint_clz(m0);
 
       /* relative to just under high non-zero bit */
       exp -= lshift + 1;
@@ -1173,7 +1173,7 @@ double flint_mpf_get_d_2exp(slong * exp2, mpf_srcptr src)
 
   ptr = src->_mp_d;
   abs_size = FLINT_ABS(size);
-  count_leading_zeros (cnt, ptr[abs_size - 1]);
+  cnt = flint_clz(ptr[abs_size - 1]);
 
   exp = src->_mp_exp * FLINT_BITS - cnt;
   *exp2 = exp;

--- a/src/long_extras/kronecker.c
+++ b/src/long_extras/kronecker.c
@@ -28,7 +28,7 @@ int z_kronecker(slong a, slong n)
     if (un == 0)
         return ua == 1;
 
-    count_trailing_zeros(en, un);
+    en = flint_ctz(un);
 
     /* make denominator positive */
     r = sa & sn;

--- a/src/longlong.h
+++ b/src/longlong.h
@@ -4,6 +4,7 @@
 
    Copyright 2009, 2015, 2016 William Hart
    Copyright 2011 Fredrik Johansson
+   Copyright 2023 Albin Ahlbäck
 
    This file is free software; you can redistribute it and/or modify
    it under the terms of the GNU Lesser General Public License as published by
@@ -29,13 +30,32 @@
 #define FLINT_LONGLONG_H
 
 #ifdef __cplusplus
- extern "C" {
+extern "C" {
 #endif
 
-/* Undefine to make the ifndef logic below for the fallback
-   work even if the symbols are already defined (e.g. by givaro).  */
-#undef count_leading_zeros
-#undef count_trailing_zeros
+#ifdef FLINT_HAS_POPCNT
+# ifndef _LONG_LONG_LIMB
+#  define flint_popcount __builtin_popcountl
+# else
+#  define flint_popcount __builtin_popcountll
+# endif
+#endif
+
+#ifdef FLINT_HAS_CLZ
+# ifndef _LONG_LONG_LIMB
+#  define flint_clz __builtin_clzl
+# else
+#  define flint_clz __builtin_clzll
+# endif
+#endif
+
+#ifdef FLINT_HAS_CTZ
+# ifndef _LONG_LONG_LIMB
+#  define flint_ctz __builtin_ctzl
+# else
+#  define flint_ctz __builtin_ctzll
+# endif
+#endif
 
 /* 1 if we know that the hardware is strongly-ordered */
 #define FLINT_KNOW_STRONG_ORDER 0
@@ -100,22 +120,27 @@
        : "=a" (q), "=d" (r)                                                     \
        : "0" ((mp_limb_t)(n0)), "1" ((mp_limb_t)(n1)), "rm" ((mp_limb_t)(dx)))
 
-/* bsrq destination must be a 64-bit register, hence mp_limb_t for __cbtmp. */
-#define count_leading_zeros(count, x)                                 \
-  do {                                                                \
-    mp_limb_t __cbtmp;                                                \
-    FLINT_ASSERT ((x) != 0);                                          \
-    __asm__ ("bsrq %1,%0" : "=r" (__cbtmp) : "rm" ((mp_limb_t)(x)));  \
-    (count) = __cbtmp ^ (mp_limb_t) 63;                               \
-  } while (0)
+#ifndef FLINT_HAS_CLZ
+# define flint_clz flint_clz
+static __inline__ flint_bitcnt_t flint_clz(mp_limb_t x)
+{
+    mp_limb_t count;
+    FLINT_ASSERT(x != 0);
+    __asm__("bsrq %1,%0" : "=r" (count) : "rm" (x));
+    return count ^ (mp_limb_t) 63;
+}
+#endif
 
-/* bsfq destination must be a 64-bit register, "%q0" forces this in case
-   count is only an int. */
-#define count_trailing_zeros(count, x)                               \
-  do {                                                               \
-    FLINT_ASSERT ((x) != 0);                                         \
-    __asm__ ("bsfq %1,%q0" : "=r" (count) : "rm" ((mp_limb_t)(x)));  \
-  } while (0)
+#ifndef FLINT_HAS_CTZ
+# define flint_ctz flint_ctz
+static __inline__ flint_bitcnt_t flint_ctz(mp_limb_t x)
+{
+    mp_limb_t count;
+    FLINT_ASSERT(x != 0);
+    __asm__("bsfq %1,%0" : "=r" (count) : "rm" (x));
+    return count;
+}
+#endif
 
 #define byte_swap(x)                                                 \
   do {                                                               \
@@ -186,19 +211,27 @@
        : "=a" (q), "=d" (r)                                                     \
        : "0" ((mp_limb_t)(n0)), "1" ((mp_limb_t)(n1)), "rm" ((mp_limb_t)(dx)))
 
-#define count_leading_zeros(count, x)                                 \
-  do {                                                                \
-    mp_limb_t __cbtmp;                                                \
-    FLINT_ASSERT ((x) != 0);                                          \
-    __asm__ ("bsrl %1,%0" : "=r" (__cbtmp) : "rm" ((mp_limb_t)(x)));  \
-    (count) = __cbtmp ^ (mp_limb_t) 31;                               \
-  } while (0)
+#ifndef FLINT_HAS_CLZ
+# define flint_clz flint_clz
+static __inline__ flint_bitcnt_t flint_clz(mp_limb_t x)
+{
+    mp_limb_t count;
+    FLINT_ASSERT(x != 0);
+    __asm__("bsrl %1,%0" : "=r" (count) : "rm" (x));
+    return count ^ (mp_limb_t) 31;
+}
+#endif
 
-#define count_trailing_zeros(count, x)                              \
-  do {                                                              \
-    FLINT_ASSERT ((x) != 0);                                        \
-    __asm__ ("bsfl %1,%0" : "=r" (count) : "rm" ((mp_limb_t)(x)));  \
-  } while (0)
+#ifndef FLINT_HAS_CTZ
+# define flint_ctz flint_ctz
+static __inline__ flint_bitcnt_t flint_ctz(mp_limb_t x)
+{
+    mp_limb_t count;
+    FLINT_ASSERT(x != 0);
+    __asm__("bsfl %1,%0" : "=r" (count) : "rm" (x));
+    return count;
+}
+#endif
 
 #define byte_swap(x)                                                 \
   do {                                                               \
@@ -225,13 +258,17 @@
     (sl) = __x;                                 \
   } while (0)
 
-#define count_trailing_zeros(count, x)			   \
-  do {									               \
-    mp_limb_t __ctz_x = (x);		   		      \
-    __asm__ ("popcnt %0 = %1"						   \
-	     : "=r" (count)						         \
-	     : "r" ((__ctz_x-1) & ~__ctz_x));		   \
-  } while (0)
+#ifndef FLINT_HAS_CTZ
+# define flint_ctz(x)                       \
+({                                          \
+    mp_limb_t __ctz_x = (x);                \
+    mp_limb_t count;                        \
+    __asm__ ("popcnt %0 = %1"               \
+            : "=r" (count)                  \
+            : "r" ((__ctz_x-1) & ~__ctz_x));\
+    count;                                  \
+})
+#endif
 
 /* Do both product parts in assembly, since that gives better code with
    all gcc versions.  Some callers will just use the upper part, and in
@@ -468,40 +505,6 @@
   } while (0)
 #endif
 
-/* MIPS and ARM - Use clz builtins */
-/* NOTE: Apple clang version 12.0.5 miscompiles the count_leading_zeros fallback */
-#if (defined (__mips__) || defined (__arm__) || defined (__arm64__))
-
-#ifdef _LONG_LONG_LIMB
-#define count_leading_zeros(count,x)            \
-  do {                                          \
-    FLINT_ASSERT ((x) != 0);                    \
-    (count) = __builtin_clzll (x);              \
-  } while (0)
-#else
-#define count_leading_zeros(count,x)            \
-  do {                                          \
-    FLINT_ASSERT ((x) != 0);                    \
-    (count) = __builtin_clzl (x);               \
-  } while (0)
-#endif
-
-#ifdef _LONG_LONG_LIMB
-#define count_trailing_zeros(count,x)           \
-  do {                                          \
-    FLINT_ASSERT ((x) != 0);                    \
-    (count) = __builtin_ctzll (x);              \
-  } while (0)
-#else
-#define count_trailing_zeros(count,x)           \
-  do {                                          \
-    FLINT_ASSERT ((x) != 0);                    \
-    (count) = __builtin_ctzl (x);               \
-  } while (0)
-#endif
-
-#endif /* MIPS, ARM */
-
 #define udiv_qrnnd_int(q, r, n1, n0, d)                                \
   do {									                                      \
     mp_limb_t __d1, __d0, __q1, __q0, __r1, __r0, __m;			        \
@@ -542,50 +545,44 @@
     (r) = __r0;								                                \
   } while (0)
 
-#ifndef count_leading_zeros
-#define count_leading_zeros(count, x)                        \
-  do {									                            \
-    mp_limb_t __xr = (x);							                \
-    mp_limb_t __a;								                   \
-									                                  \
-    if (GMP_LIMB_BITS == 32)						       \
-      {									                            \
-	__a = __xr < ((mp_limb_t) 1 << 2*__BITS4)				       \
-	  ? (__xr < ((mp_limb_t) 1 << __BITS4) ? 1 : __BITS4 + 1) \
-	  : (__xr < ((mp_limb_t) 1 << 3*__BITS4) ? 2*__BITS4 + 1	 \
-	  : 3*__BITS4 + 1);						                      \
-      }									                            \
-    else								                               \
-      {									                            \
-	for (__a = GMP_LIMB_BITS - 8; __a > 0; __a -= 8) \
-	  if (((__xr >> __a) & 0xff) != 0)				             \
-	    break;							                            \
-	++__a;								                            \
-      }									                            \
-									                                  \
-    (count) = GMP_LIMB_BITS + 1 - __a - __flint_clz_tab[__xr >> __a]; \
-  } while (0)
+FLINT_DLL extern const unsigned char __flint_clz_tab[128];
+
+#ifndef flint_clz
+# define flint_clz flint_clz
+static __inline__ flint_bitcnt_t flint_clz(mp_limb_t x)
+{
+    mp_limb_t __a, __xr = x;
+    if (GMP_LIMB_BITS == 32)
+        __a = __xr < ((mp_limb_t) 1 << 2*__BITS4)
+        ? (__xr < ((mp_limb_t) 1 << __BITS4) ? 1 : __BITS4 + 1)
+        : (__xr < ((mp_limb_t) 1 << 3*__BITS4) ? 2*__BITS4 + 1
+        : 3*__BITS4 + 1);
+    else
+    {
+        for (__a = GMP_LIMB_BITS - 8; __a > 0; __a -= 8)
+            if (((__xr >> __a) & 0xff) != 0)
+                break;
+        ++__a;
+    }
+    return GMP_LIMB_BITS + 1 - __a - __flint_clz_tab[__xr >> __a];
+}
 #endif
 
 #if !(GMP_LIMB_BITS == 64 && defined (__ia64))
-
-#ifndef count_trailing_zeros
-#define count_trailing_zeros(count, x)                 \
-  do {									                      \
-    mp_limb_t __ctz_x = (x);						          \
-    mp_limb_t __ctz_c;							             \
-    FLINT_ASSERT (__ctz_x != 0);						       \
-    count_leading_zeros (__ctz_c, __ctz_x & -__ctz_x); \
-    (count) = GMP_LIMB_BITS - 1 - __ctz_c;	 \
-  } while (0)
-#endif
-
+# ifndef flint_ctz
+#  define flint_ctz flint_ctz
+static __inline__ flint_bitcnt_t flint_ctz(mp_limb_t x)
+{
+    mp_limb_t __ctz_x = (x);
+    FLINT_ASSERT (__ctz_x != 0);
+    return GMP_LIMB_BITS - 1 - flint_clz(__ctz_x & -__ctz_x);
+}
+# endif
 #endif
 
 #define udiv_qrnnd(q, r, n1, n0, d)                  \
     do {                                             \
-       mp_limb_t __norm;                             \
-       count_leading_zeros(__norm, (d));             \
+       mp_limb_t __norm = flint_clz(d);              \
        if (__norm)                                   \
        {                                             \
            udiv_qrnnd_int((q), (r), ((n1) << __norm) + ((n0) >> (GMP_LIMB_BITS - __norm)), (n0) << __norm, (d) << __norm); \

--- a/src/longlong.h
+++ b/src/longlong.h
@@ -33,6 +33,9 @@
 extern "C" {
 #endif
 
+#define count_leading_zeros _Pragma("GCC error \"'count_leading_zeros' is deprecated. Use 'flint_clz' instead.\"")
+#define count_trailing_zeros _Pragma("GCC error \"'count_trailing_zeros' is deprecated. Use 'flint_ctz' instead.\"")
+
 #ifdef FLINT_HAS_POPCNT
 # ifndef _LONG_LONG_LIMB
 #  define flint_popcount __builtin_popcountl

--- a/src/mag/set_ui.c
+++ b/src/mag/set_ui.c
@@ -26,7 +26,7 @@ mag_set_ui(mag_t z, ulong x)
         slong bits;
         mp_limb_t overflow;
 
-        count_leading_zeros(bits, x);
+        bits = flint_clz(x);
         bits = FLINT_BITS - bits;
 
         if (bits <= MAG_BITS)
@@ -60,7 +60,7 @@ mag_set_ui_lower(mag_t z, ulong x)
     {
         unsigned int bits;
 
-        count_leading_zeros(bits, x);
+        bits = flint_clz(x);
         bits = FLINT_BITS - bits;
 
         if (bits <= MAG_BITS)

--- a/src/mag/set_ui_2exp_si.c
+++ b/src/mag/set_ui_2exp_si.c
@@ -26,7 +26,7 @@ mag_set_ui_2exp_si(mag_t z, ulong x, slong e)
         slong bits;
         mp_limb_t overflow;
 
-        count_leading_zeros(bits, x);
+        bits = flint_clz(x);
         bits = FLINT_BITS - bits;
 
         if (bits <= MAG_BITS)

--- a/src/mpn_extras.h
+++ b/src/mpn_extras.h
@@ -380,8 +380,8 @@ t##subtract:                                                                \
         int t##ncnt, t##dcnt;                                               \
         mp_limb_t t##qq = 0;                                                \
                                                                             \
-        count_leading_zeros(t##ncnt, t##r1);                                \
-        count_leading_zeros(t##dcnt, t##b1);                                \
+        t##ncnt = flint_clz(t##r1);                                \
+        t##dcnt = flint_clz(t##b1);                                \
         t##dcnt -= t##ncnt;                                                 \
         if (t##dcnt <= 0)                                                   \
             goto t##subtract;                                               \

--- a/src/mpn_extras/profile/p-mulmod_preinvn.c
+++ b/src/mpn_extras/profile/p-mulmod_preinvn.c
@@ -74,7 +74,7 @@ void sample(void * arg, ulong count)
        mpz_fdiv_r(b, b, d);
 
        /* normalise */
-       count_leading_zeros(norm, d->_mp_d[d->_mp_size - 1]);
+       norm = flint_clz(d->_mp_d[d->_mp_size - 1]);
        mpz_mul_2exp(a, a, norm);
        mpz_mul_2exp(b, b, norm);
        mpz_mul_2exp(d, d, norm);

--- a/src/mpn_extras/test/t-divrem_preinvn.c
+++ b/src/mpn_extras/test/t-divrem_preinvn.c
@@ -48,7 +48,7 @@ int main(void)
        } while (mpz_sgn(d) == 0);
 
        /* normalise */
-       count_leading_zeros(norm, d->_mp_d[d->_mp_size - 1]);
+       norm = flint_clz(d->_mp_d[d->_mp_size - 1]);
        mpz_mul_2exp(d, d, norm);
        mpz_mul_2exp(a, a, norm);
        size2 = a->_mp_size;
@@ -104,7 +104,7 @@ int main(void)
        } while (mpz_sgn(d) == 0);
 
        /* normalise */
-       count_leading_zeros(norm, d->_mp_d[d->_mp_size - 1]);
+       norm = flint_clz(d->_mp_d[d->_mp_size - 1]);
        mpz_mul_2exp(d, d, norm);
        mpz_mul_2exp(a, a, norm);
        size2 = a->_mp_size;

--- a/src/mpn_extras/test/t-mod_preinvn.c
+++ b/src/mpn_extras/test/t-mod_preinvn.c
@@ -46,7 +46,7 @@ int main(void)
        } while (mpz_sgn(d) == 0);
 
        /* normalise */
-       count_leading_zeros(norm, d->_mp_d[d->_mp_size - 1]);
+       norm = flint_clz(d->_mp_d[d->_mp_size - 1]);
        mpz_mul_2exp(d, d, norm);
        mpz_mul_2exp(a, a, norm);
        size2 = a->_mp_size;
@@ -96,7 +96,7 @@ int main(void)
        } while (mpz_sgn(d) == 0);
 
        /* normalise */
-       count_leading_zeros(norm, d->_mp_d[d->_mp_size - 1]);
+       norm = flint_clz(d->_mp_d[d->_mp_size - 1]);
        mpz_mul_2exp(d, d, norm);
        mpz_mul_2exp(a, a, norm);
        size2 = a->_mp_size;

--- a/src/mpn_extras/test/t-mulmod_preinv1.c
+++ b/src/mpn_extras/test/t-mulmod_preinv1.c
@@ -53,7 +53,7 @@ int main(void)
        mpz_fdiv_r(r1, r1, d);
 
        /* normalise */
-       count_leading_zeros(norm, d->_mp_d[d->_mp_size - 1]);
+       norm = flint_clz(d->_mp_d[d->_mp_size - 1]);
        mpz_mul_2exp(a, a, norm);
        mpz_mul_2exp(b, b, norm);
        mpz_mul_2exp(d, d, norm);

--- a/src/mpn_extras/test/t-mulmod_preinvn.c
+++ b/src/mpn_extras/test/t-mulmod_preinvn.c
@@ -54,7 +54,7 @@ int main(void)
        mpz_fdiv_r(r1, r1, d);
 
        /* normalise */
-       count_leading_zeros(norm, d->_mp_d[size_d - 1]);
+       norm = flint_clz(d->_mp_d[size_d - 1]);
        mpz_mul_2exp(a, a, norm);
        mpz_mul_2exp(b, b, norm);
        mpz_mul_2exp(d, d, norm);

--- a/src/nmod.h
+++ b/src/nmod.h
@@ -212,7 +212,7 @@ void nmod_init(nmod_t * mod, mp_limb_t n)
 {
    mod->n = n;
    mod->ninv = n_preinvert_limb(n);
-   count_leading_zeros(mod->norm, n);
+   mod->norm = flint_clz(n);
 }
 
 /* discrete logs a la Pohlig - Hellman ***************************************/

--- a/src/nmod_mat/set_mod.c
+++ b/src/nmod_mat/set_mod.c
@@ -15,6 +15,6 @@
 void nmod_mat_set_mod(nmod_mat_t mat, mp_limb_t n)
 {
     mat->mod.n = n;
-    count_leading_zeros(mat->mod.norm, n);
+    mat->mod.norm = flint_clz(n);
     mat->mod.ninv = n_preinvert_limb_prenorm(n << mat->mod.norm);
 }

--- a/src/nmod_mpoly/divides_dense.c
+++ b/src/nmod_mpoly/divides_dense.c
@@ -132,7 +132,7 @@ int nmod_mpoly_convert_from_nmod_mpolyd_degbound(
         mpoly_get_cmpmask(pcurexp, N, bits, ctx->minfo);
         if (topmask != UWORD(0))
         {
-            count_leading_zeros(msb, topmask);
+            msb = flint_clz(topmask);
             msb = (FLINT_BITS - 1)^msb;
         } else
         {

--- a/src/nmod_mpoly/mpolyd.c
+++ b/src/nmod_mpoly/mpolyd.c
@@ -345,7 +345,7 @@ void nmod_mpoly_convert_from_nmod_mpolyd(
         mpoly_get_cmpmask(pcurexp, N, bits, ctx->minfo);
         if (topmask != WORD(0))
         {
-            count_leading_zeros(msb, topmask);
+            msb = flint_clz(topmask);
             msb = (FLINT_BITS - 1)^msb;
         } else
         {

--- a/src/nmod_mpoly/sort_terms.c
+++ b/src/nmod_mpoly/sort_terms.c
@@ -158,7 +158,7 @@ void nmod_mpoly_sort_terms(nmod_mpoly_t A, const nmod_mpoly_ctx_t ctx)
 
     if (himask != 0)
     {
-        count_leading_zeros(msb, himask);
+        msb = flint_clz(himask);
         msb = (FLINT_BITS - 1)^msb;
     } else
     {

--- a/src/nmod_poly/init.c
+++ b/src/nmod_poly/init.c
@@ -23,7 +23,7 @@ nmod_poly_init_preinv(nmod_poly_t poly, mp_limb_t n, mp_limb_t ninv)
 
     poly->mod.n = n;
     poly->mod.ninv = ninv;
-    count_leading_zeros(poly->mod.norm, n);
+    poly->mod.norm = flint_clz(n);
 }
 
 void

--- a/src/nmod_poly/init2.c
+++ b/src/nmod_poly/init2.c
@@ -25,7 +25,7 @@ nmod_poly_init2_preinv(nmod_poly_t poly,
     poly->mod.n = n;
     poly->mod.ninv = ninv;
 
-    count_leading_zeros(poly->mod.norm, n);
+    poly->mod.norm = flint_clz(n);
 
     poly->alloc = alloc;
     poly->length = 0;

--- a/src/profile/p-udiv_qrnnd_preinv.c
+++ b/src/profile/p-udiv_qrnnd_preinv.c
@@ -23,7 +23,7 @@ void sample(void * arg, ulong count)
    FLINT_TEST_INIT(state);
 
    d = n_randtest_not_zero(state);
-   count_leading_zeros(norm, d);
+   norm = flint_clz(d);
    d <<= norm;
 
    for (i = 0; i < count; i++)

--- a/src/qfb/reduced_forms.c
+++ b/src/qfb/reduced_forms.c
@@ -226,7 +226,7 @@ slong qfb_reduced_forms(qfb ** forms, slong d)
     {
         b2 = ((mp_limb_t)(b*b - d))/4;
 
-        count_trailing_zeros(exp, b2); /* powers of 2 */
+        exp = flint_ctz(b2); /* powers of 2 */
         if (exp)
         {
             fac[b].p[fac[b].num] = 2;

--- a/src/test/t-flint_clz.c
+++ b/src/test/t-flint_clz.c
@@ -18,7 +18,7 @@ int main(void)
    FLINT_TEST_INIT(state);
 
 
-   flint_printf("count_leading_zeros....");
+   flint_printf("flint_clz....");
    fflush(stdout);
 
    for (i = 0; i < 1000000; i++)
@@ -29,7 +29,7 @@ int main(void)
       n = n_randtest(state);
 
       if (n != 0)
-         count_leading_zeros(count, n);
+         count = flint_clz(n);
 
       result = ((n == UWORD(0)) || (((slong)(n << count) < WORD(0)) && (r_shift(n, FLINT_BITS-count) == UWORD(0))));
       if (!result)

--- a/src/test/t-flint_ctz.c
+++ b/src/test/t-flint_ctz.c
@@ -18,7 +18,7 @@ int main(void)
    FLINT_TEST_INIT(state);
 
 
-   flint_printf("count_trailing_zeros....");
+   flint_printf("flint_ctz....");
    fflush(stdout);
 
    for (i = 0; i < 1000000; i++)
@@ -29,7 +29,7 @@ int main(void)
       n = n_randtest(state);
 
       if (n != 0)
-         count_trailing_zeros(count, n);
+         count = flint_ctz(n);
 
       result = ((n == UWORD(0)) || (((n >> count) & UWORD(1)) && (l_shift(n, FLINT_BITS-count) == UWORD(0))));
       if (!result)

--- a/src/test/t-udiv_qrnnd_preinv.c
+++ b/src/test/t-udiv_qrnnd_preinv.c
@@ -29,7 +29,7 @@ int main(void)
       {
          d = n_randtest_not_zero(state);
          nh = n_randtest(state);
-         count_leading_zeros(norm, d);
+         norm = flint_clz(d);
          d <<= norm;
       } while (nh >= d);
       nl = n_randtest(state);

--- a/src/ulong_extras/div2_preinv.c
+++ b/src/ulong_extras/div2_preinv.c
@@ -25,7 +25,7 @@ n_div2_preinv(ulong a, ulong n, ulong ninv)
 
     FLINT_ASSERT(n != 0);
 
-    count_leading_zeros(norm, n);
+    norm = flint_clz(n);
     n <<= norm;
 
     {

--- a/src/ulong_extras/divrem2_preinv.c
+++ b/src/ulong_extras/divrem2_preinv.c
@@ -25,7 +25,7 @@ n_divrem2_preinv(ulong * q, ulong a, ulong n, ulong ninv)
 
     FLINT_ASSERT(n != 0);
 
-    count_leading_zeros(norm, n);
+    norm = flint_clz(n);
     n <<= norm;
 
     {

--- a/src/ulong_extras/factor_SQUFOF.c
+++ b/src/ulong_extras/factor_SQUFOF.c
@@ -88,7 +88,7 @@ mp_limb_t _ll_factor_SQUFOF(mp_limb_t n_hi, mp_limb_t n_lo, ulong max_iters)
 	if (sqrt[1])
 	{
         int norm;
-        count_leading_zeros(norm, qlast);
+        norm = flint_clz(qlast);
         udiv_qrnnd(q, rem[0], (sqrt[1] << norm) + r_shift(sqrt[0], FLINT_BITS - norm), sqrt[0] << norm, qlast << norm);
         rem[0] >>= norm;
     }

--- a/src/ulong_extras/factor_ecm.c
+++ b/src/ulong_extras/factor_ecm.c
@@ -46,7 +46,7 @@ n_factor_ecm(mp_limb_t *f, mp_limb_t curves, mp_limb_t B1, mp_limb_t B2,
 
     const mp_limb_t *prime_array;
 
-    count_leading_zeros(n_ecm_inf->normbits, n);
+    n_ecm_inf->normbits = flint_clz(n);
     n <<= n_ecm_inf->normbits;
     n_ecm_inf->ninv = n_preinvert_limb(n);
     n_ecm_inf->one = UWORD(1) << n_ecm_inf->normbits;

--- a/src/ulong_extras/factor_pollard_brent.c
+++ b/src/ulong_extras/factor_pollard_brent.c
@@ -130,7 +130,7 @@ n_factor_pollard_brent(mp_limb_t *factor, flint_rand_t state, mp_limb_t n_in,
     ret = 0;
     max = n_in -3;    /* 1 <= a <= n - 3 */
 
-    count_leading_zeros(normbits, n_in);
+    normbits = flint_clz(n_in);
     n = n_in;
     n <<= normbits;
     ninv = n_preinvert_limb(n);

--- a/src/ulong_extras/factor_pp1.c
+++ b/src/ulong_extras/factor_pp1.c
@@ -130,7 +130,7 @@ mp_limb_t n_factor_pp1(mp_limb_t n, ulong B1, ulong c)
    sqrt = n_sqrt(B1);
    bits0 = FLINT_BIT_COUNT(B1);
 
-   count_leading_zeros(norm, n);
+   norm = flint_clz(n);
    n <<= norm;
 
    ninv = n_preinvert_limb(n);

--- a/src/ulong_extras/is_perfect_power.c
+++ b/src/ulong_extras/is_perfect_power.c
@@ -118,7 +118,7 @@ int n_is_perfect_power(ulong * root, ulong n)
     }
 
     /* highest power of 2 */
-    count_trailing_zeros(count, n);
+    count = flint_ctz(n);
     n >>= count;
 
     if (n == 1)

--- a/src/ulong_extras/is_probabprime.c
+++ b/src/ulong_extras/is_probabprime.c
@@ -48,7 +48,7 @@ int n_is_probabprime(mp_limb_t n)
 
     isprime = 0;
     d = n - 1;
-    count_trailing_zeros(norm, d);
+    norm = flint_ctz(d);
     d >>= norm;
 
 #if !FLINT64

--- a/src/ulong_extras/jacobi.c
+++ b/src/ulong_extras/jacobi.c
@@ -29,7 +29,7 @@ int _n_jacobi_unsigned(mp_limb_t x, mp_limb_t y, unsigned int r)
             return 0;
 
         /* x = odd part of x */
-        count_trailing_zeros(e, x);
+        e = flint_ctz(x);
         x >>= e;
         r ^= ((y ^ (y>>1)) & (2*e)); /* (2|y) = (-1)^((y^2-1)/8) */
 

--- a/src/ulong_extras/ll_mod_preinv.c
+++ b/src/ulong_extras/ll_mod_preinv.c
@@ -25,7 +25,7 @@ n_ll_mod_preinv(ulong a_hi, ulong a_lo, ulong n, ulong ninv)
 
     FLINT_ASSERT(n != 0);
 
-    count_leading_zeros(norm, n);
+    norm = flint_clz(n);
 
     /* reduce a_hi modulo n */
     if (a_hi >= n)

--- a/src/ulong_extras/lll_mod_preinv.c
+++ b/src/ulong_extras/lll_mod_preinv.c
@@ -23,7 +23,7 @@ n_lll_mod_preinv(ulong a_hi, ulong a_mi, ulong a_lo, ulong n, ulong ninv)
 {
     ulong q0, q1, r, norm;
 
-    count_leading_zeros(norm, n);
+    norm = flint_clz(n);
     n <<= norm;
 
     /*

--- a/src/ulong_extras/mod2_preinv.c
+++ b/src/ulong_extras/mod2_preinv.c
@@ -25,7 +25,7 @@ n_mod2_preinv(ulong a, ulong n, ulong ninv)
 
     FLINT_ASSERT(n != 0);
 
-    count_leading_zeros(norm, n);
+    norm = flint_clz(n);
     n <<= norm;
 
     {

--- a/src/ulong_extras/powmod2_preinv.c
+++ b/src/ulong_extras/powmod2_preinv.c
@@ -33,7 +33,7 @@ n_powmod2_preinv(ulong a, slong exp, ulong n, ulong ninv)
         exp = -exp;
     }
 
-    count_leading_zeros(norm, n);
+    norm = flint_clz(n);
 
     return n_powmod_ui_preinv(a << norm, exp, n << norm, ninv, norm) >> norm;
 }

--- a/src/ulong_extras/powmod2_ui_preinv.c
+++ b/src/ulong_extras/powmod2_ui_preinv.c
@@ -31,7 +31,7 @@ n_powmod2_ui_preinv(ulong a, ulong exp, ulong n, ulong ninv)
     if (a >= n)
         a = n_mod2_preinv(a, n, ninv);
 
-    count_leading_zeros(norm, n);
+    norm = flint_clz(n);
     a <<= norm;
     n <<= norm;
 

--- a/src/ulong_extras/preinvert_limb.c
+++ b/src/ulong_extras/preinvert_limb.c
@@ -119,7 +119,7 @@ ulong n_preinvert_limb(ulong n)
 {
    ulong norm, ninv;
 
-   count_leading_zeros(norm, n);
+   norm = flint_clz(n);
    _invert_limb(ninv, n << norm);
 
    return ninv;

--- a/src/ulong_extras/remove.c
+++ b/src/ulong_extras/remove.c
@@ -21,7 +21,7 @@ n_remove(mp_limb_t * n, mp_limb_t p)
 
     if (p == 2)
     {
-        count_trailing_zeros(exp, *n);
+        exp = flint_ctz(*n);
         if (exp)
             (*n) >>= exp;
 

--- a/src/ulong_extras/remove2_precomp.c
+++ b/src/ulong_extras/remove2_precomp.c
@@ -20,7 +20,7 @@ n_remove2_precomp(mp_limb_t * n, mp_limb_t p, double ppre)
 
     if (p == 2)
     {
-        count_trailing_zeros(exp, *n);
+        exp = flint_ctz(*n);
         if (exp)
             (*n) >>= exp;
 

--- a/src/ulong_extras/test/t-is_strong_probabprime2_preinv.c
+++ b/src/ulong_extras/test/t-is_strong_probabprime2_preinv.c
@@ -48,7 +48,7 @@ int main(void)
          while (a == UWORD(0));
 
          dinv = n_preinvert_limb(d);
-         count_trailing_zeros(norm, d - 1);
+         norm = flint_ctz(d - 1);
          result = n_is_strong_probabprime2_preinv(d, dinv, a, (d - 1)>>norm);
 
          if (!result)
@@ -84,7 +84,7 @@ int main(void)
          while (a == UWORD(0));
 
          dinv = n_preinvert_limb(d);
-         count_trailing_zeros(norm, d - 1);
+         norm = flint_ctz(d - 1);
          result = !n_is_strong_probabprime2_preinv(d, dinv, a, (d - 1)>>norm);
 
          if (!result) count++;

--- a/src/ulong_extras/test/t-is_strong_probabprime_precomp.c
+++ b/src/ulong_extras/test/t-is_strong_probabprime_precomp.c
@@ -49,7 +49,7 @@ int main(void)
          while (a == UWORD(0));
 
          dpre = n_precompute_inverse(d);
-         count_trailing_zeros(norm, d - 1);
+         norm = flint_ctz(d - 1);
          result = n_is_strong_probabprime_precomp(d, dpre, a, (d - 1)>>norm);
 
          if (!result)
@@ -85,7 +85,7 @@ int main(void)
          while (a == UWORD(0));
 
          dpre = n_precompute_inverse(d);
-         count_trailing_zeros(norm, d - 1);
+         norm = flint_ctz(d - 1);
          result = !n_is_strong_probabprime_precomp(d, dpre, a, (d - 1)>>norm);
 
          if (!result) count++;

--- a/src/ulong_extras/test/t-mulmod_preinv.c
+++ b/src/ulong_extras/test/t-mulmod_preinv.c
@@ -29,7 +29,7 @@ main(void)
         a = n_randtest(state) % d;
         b = n_randtest(state) % d;
 
-        count_leading_zeros(norm, d);
+        norm = flint_clz(d);
 
         dinv = n_preinvert_limb(d << norm);
 

--- a/src/ulong_extras/test/t-powmod_ui_preinv.c
+++ b/src/ulong_extras/test/t-powmod_ui_preinv.c
@@ -38,7 +38,7 @@ main(void)
         } while (n_gcd(d, a) != UWORD(1));
         exp = n_randtest(state);
 
-        count_leading_zeros(norm, d);
+        norm = flint_clz(d);
 
         dinv = n_preinvert_limb(d);
         r1 = n_powmod_ui_preinv(a << norm, exp, d << norm, dinv, norm) >> norm;
@@ -70,7 +70,7 @@ main(void)
 
         d = n_randtest_not_zero(state);
 
-        count_leading_zeros(norm, d);
+        norm = flint_clz(d);
 
         dinv = n_preinvert_limb(d);
         r = n_powmod_ui_preinv(0, 0, d << norm, dinv, norm) >> norm;
@@ -93,7 +93,7 @@ main(void)
 
         exp = n_randtest(state);
 
-        count_leading_zeros(norm, 1);
+        norm = flint_clz(1);
 
         dinv = n_preinvert_limb(1);
         r = n_powmod_ui_preinv(0, exp, UWORD(1) << norm, dinv, norm) >> norm;


### PR DESCRIPTION
This PR
- checks if `__builtin_constant_p` is available,
- makes it possible to enable GMP internals (although nothing has been altered in the source code yet), which should allow FLINT to directly use functions like `mpn_gcd_11` if enabled (@fredrik-johansson I added check for `mpn_div_q` as well, I know that Arb used to use it, right?), and
- changes syntax for counting trailing and leading zeros from `count_leading_zeros` to `flint_clz` and likewise for trailing.

Note that `flint_clz` returns a value, unlike `count_leading_zeros`.

~It should also be noted that pedantic compilers hate braced groups within expressions, so the current definitions of `flint_clz` and `flint_ctz` will print A LOT of warnings when `-pedantic` is set. I would really advocate against the use of this flag as it is pretty standard to use braced groups in expressions (for reference, see [GLIBC's source code](https://sourceware.org/git/?p=glibc.git;a=blob;f=sysdeps/ieee754/dbl-64/s_sin.c;h=18ed1dd56fc708f3a10ab501bba78dafe6d0bdea;hb=HEAD#l60)).~

Edit: I changed `flint_clz` to be an inlined function in case the compiler does not have `__builtin_clz`.