### PR TITLE
Open up the possibility for local optimizations

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -212,15 +212,37 @@ esac],
 enable_dependency_tracking="yes")
 
 AC_ARG_ENABLE(gmp-internals,
-[AS_HELP_STRING([--enable-gmp-internals],[Enables optimization by calling GMP internals directly [default=yes]])],
+[AS_HELP_STRING([--enable-gmp-internals],[Enable calling GMP internals directly [default=yes]])],
 [case $enableval in
 yes|no)
     ;;
 *)
-    AC_MSG_ERROR([Bad value $enableval for --enable-dependency-tracking. Need yes or no.])
+    AC_MSG_ERROR([Bad value $enableval for --enable-gmp-internals. Need yes or no.])
     ;;
 esac],
 enable_gmp_internals="yes")
+
+AC_ARG_ENABLE(avx2,
+[AS_HELP_STRING([--enable-avx2],[Enable AVX2 instructions [default=no]])],
+[case $enableval in
+yes|no)
+    ;;
+*)
+    AC_MSG_ERROR([Bad value $enableval for --enable-avx2. Need yes or no.])
+    ;;
+esac],
+enable_avx2="no")
+
+AC_ARG_ENABLE(avx512,
+[AS_HELP_STRING([--enable-avx512],[Enable AVX512 instructions [default=no]])],
+[case $enableval in
+yes|no)
+    ;;
+*)
+    AC_MSG_ERROR([Bad value $enableval for --enable-avx512. Need yes or no.])
+    ;;
+esac],
+enable_avx512="no")
 
 ################################################################################ 
 # packages
@@ -805,6 +827,23 @@ then
     [AC_MSG_ERROR([$CC does not support the ABI flag -m$ABI])])
 fi
 AC_SUBST(ABI_FLAG)
+
+if test "$enable_avx2" = "yes";
+then
+    AX_CHECK_COMPILE_FLAG([-mavx2],
+    [save_CFLAGS="-mavx2 $save_CFLAGS"
+     AC_DEFINE(FLINT_HAVE_AVX2,1,[Define if system has AVX2])],
+    [AC_MSG_ERROR([$CC does not support -mavx2 needed for AVX2 instructions])])
+    AX_CHECK_COMPILE_FLAG([-mfma], [save_CFLAGS="-mfma $save_CFLAGS"])
+fi
+
+if test "$enable_avx512" = "yes";
+then
+    AX_CHECK_COMPILE_FLAG([-mavx512f],
+    [save_CFLAGS="-mavx512f $save_CFLAGS"
+     AC_DEFINE(FLINT_HAVE_AVX512,1,[Define if system has AVX512])],
+    [AC_MSG_ERROR([$CC does not support -mavx512f needed for AVX512 instructions])])
+fi
 
 case $host_cpu in
     sparc*)

--- a/src/flint.h
+++ b/src/flint.h
@@ -122,6 +122,12 @@ typedef struct __FLINT_FILE FLINT_FILE;
 #define FLINT_NORETURN __attribute__ ((noreturn))
 #define FLINT_CONST __attribute__ ((const))
 #define FLINT_WARN_UNUSED __attribute__((warn_unused_result))
+#define FLINT_PUSH_OPTIONS _Pragma("GCC push_options")
+#define FLINT_POP_OPTIONS _Pragma("GCC pop_options")
+#define FLINT_OPTIMIZE_NESTED_3(part) _Pragma(#part)
+#define FLINT_OPTIMIZE_NESTED_2(part) FLINT_OPTIMIZE_NESTED_3(GCC optimize part)
+#define FLINT_OPTIMIZE_NESTED_1(part) FLINT_OPTIMIZE_NESTED_2(#part)
+#define FLINT_OPTIMIZE(x) FLINT_OPTIMIZE_NESTED_1(x)
 #else
 #define __attribute__(x)
 #define FLINT_UNUSED(x) x
@@ -129,6 +135,9 @@ typedef struct __FLINT_FILE FLINT_FILE;
 #define FLINT_WARN_UNUSED
 #define FLINT_NORETURN
 #define FLINT_CONST
+#define FLINT_PUSH_OPTIONS
+#define FLINT_POP_OPTIONS
+#define FLINT_OPTIMIZE(x)
 #endif
 
 #if FLINT_USES_TLS

--- a/src/flint.h
+++ b/src/flint.h
@@ -116,24 +116,6 @@ typedef struct __FLINT_FILE FLINT_FILE;
 
 #include "longlong.h"
 
-void * flint_malloc(size_t size);
-void * flint_realloc(void * ptr, size_t size);
-void * flint_calloc(size_t num, size_t size);
-void flint_free(void * ptr);
-
-typedef void (*flint_cleanup_function_t)(void);
-void flint_register_cleanup_function(flint_cleanup_function_t cleanup_function);
-void flint_cleanup(void);
-void flint_cleanup_master(void);
-
-void __flint_set_memory_functions(void *(*alloc_func) (size_t),
-     void *(*calloc_func) (size_t, size_t), void *(*realloc_func) (void *, size_t),
-                                                              void (*free_func) (void *));
-
-void __flint_get_memory_functions(void *(**alloc_func) (size_t),
-     void *(**calloc_func) (size_t, size_t), void *(**realloc_func) (void *, size_t),
-                                                              void (**free_func) (void *));
-
 #if defined(__GNUC__)
 #define FLINT_UNUSED(x) UNUSED_ ## x __attribute__((unused))
 #define FLINT_SET_BUT_UNUSED(x) x __attribute__((unused))
@@ -149,14 +131,19 @@ void __flint_get_memory_functions(void *(**alloc_func) (size_t),
 #define FLINT_CONST
 #endif
 
-FLINT_NORETURN void flint_abort(void);
-void flint_set_abort(FLINT_NORETURN void (*func)(void));
-  /* flint_abort is calling abort by default
-   * if flint_set_abort is used, then instead of abort this function
-   * is called. EXPERIMENTALLY use at your own risk!
-   * May disappear in future versions.
-   */
-
+#if FLINT_USES_TLS
+# if defined(__GNUC__)
+#  define FLINT_TLS_PREFIX __thread
+# elif __STDC_VERSION__ >= 201112L
+#  define FLINT_TLS_PREFIX _Thread_local
+# elif defined(_MSC_VER)
+#  define FLINT_TLS_PREFIX __declspec(thread)
+# else
+#  error "thread local prefix defined in C11 or later"
+# endif
+#else
+# define FLINT_TLS_PREFIX
+#endif
 
 #if defined(_LONG_LONG_LIMB)
 # define WORD_FMT "%ll"
@@ -191,22 +178,28 @@ void flint_set_abort(FLINT_NORETURN void (*func)(void));
 # define FLINT_D_BITS 31
 #endif
 
-#if FLINT_USES_TLS
-#if defined(__GNUC__) && __STDC_VERSION__ >= 201112L && __GNUC__ == 4 && __GNUC_MINOR__ < 9
-/* GCC 4.7, 4.8 with -std=gnu11 purport to support C11 via __STDC_VERSION__ but lack _Thread_local */
-#define FLINT_TLS_PREFIX __thread
-#elif __STDC_VERSION__ >= 201112L
-#define FLINT_TLS_PREFIX _Thread_local
-#elif defined(_MSC_VER)
-#define FLINT_TLS_PREFIX __declspec(thread)
-#elif defined(__GNUC__)
-#define FLINT_TLS_PREFIX __thread
-#else
-#error "thread local prefix defined in C11 or later"
-#endif
-#else
-#define FLINT_TLS_PREFIX
-#endif
+void * flint_malloc(size_t size);
+void * flint_realloc(void * ptr, size_t size);
+void * flint_calloc(size_t num, size_t size);
+void flint_free(void * ptr);
+
+typedef void (*flint_cleanup_function_t)(void);
+void flint_register_cleanup_function(flint_cleanup_function_t cleanup_function);
+void flint_cleanup(void);
+void flint_cleanup_master(void);
+
+void __flint_set_memory_functions(void *(*alloc_func) (size_t),
+     void *(*calloc_func) (size_t, size_t), void *(*realloc_func) (void *, size_t),
+                                                              void (*free_func) (void *));
+
+void __flint_get_memory_functions(void *(**alloc_func) (size_t),
+     void *(**calloc_func) (size_t, size_t), void *(**realloc_func) (void *, size_t),
+                                                              void (**free_func) (void *));
+
+FLINT_NORETURN void flint_abort(void);
+
+/* If user want to set change abort function from `abort' */
+void flint_set_abort(FLINT_NORETURN void (*func)(void));
 
 int flint_get_num_threads(void);
 void flint_set_num_threads(int num_threads);

--- a/src/flint.h
+++ b/src/flint.h
@@ -139,11 +139,7 @@ void __flint_get_memory_functions(void *(**alloc_func) (size_t),
 #define FLINT_SET_BUT_UNUSED(x) x __attribute__((unused))
 #define FLINT_NORETURN __attribute__ ((noreturn))
 #define FLINT_CONST __attribute__ ((const))
-#if __GNUC__ >= 4
 #define FLINT_WARN_UNUSED __attribute__((warn_unused_result))
-#else
-#define FLINT_WARN_UNUSED
-#endif
 #else
 #define __attribute__(x)
 #define FLINT_UNUSED(x) x


### PR DESCRIPTION
Add options `--enable-avx2` and `--enable-avx512`.

Clean up `flint.h`.

Add macros `FLINT_PUSH_OPTIONS`, `FLINT_POP_OPTIONS` and `FLINT_OPTIMIZE` to optimize locally instead of writing
```c
#ifdef __GNUC__
# pragma GCC push_options
# pragma GCC optimize(blabla)
#endif

int myfunc()
{
    ...
}

#ifdef __GNUC__
# pragma GCC pop_options
#endif
```