### PR TITLE
Add code coverage to CI

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -1,0 +1,17 @@
+coverage:
+  precision: 2
+  round: down
+  range: 70...95 # FIXME: We should set this one to about 90...95
+
+  status:
+    project:
+      default:
+        informational: true
+    patch:
+      default:
+        informational: true
+    changes:
+      default:
+        informational: true
+
+comment: false

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -9,7 +9,7 @@ jobs:
   # ubuntu with gcc
   ##############################################################################
   ubuntu-gcc:
-    name: Ubuntu GCC, default flags with AVX2 (x10)
+    name: Ubuntu GCC, default flags with AVX2, Code Coverage (x10)
 
     runs-on: ubuntu-latest
 
@@ -27,6 +27,7 @@ jobs:
           sudo apt install -y libmpfr-dev
           sudo apt install -y autoconf
           sudo apt install -y libtool-bin
+          sudo apt install -y gcovr
           gcc --version
           make --version
           autoconf --version
@@ -35,7 +36,7 @@ jobs:
       - name: "Configure"
         run: |
           ./bootstrap.sh
-          ./configure CC=${CC} --enable-avx2 TESTCFLAGS="${TESTCFLAGS}" --disable-static
+          ./configure CC=${CC} --enable-avx2 TESTCFLAGS="${TESTCFLAGS}" --disable-static --enable-coverage
 
       - name: "Compile library"
         run: |
@@ -51,6 +52,14 @@ jobs:
         run: |
           export FLINT_TEST_MULTIPLIER=10
           $MAKE check
+
+      - name: "Gather coverage data"
+        run: dev/gather_coverage.sh
+
+      - name: "Upload coverage data"
+        uses: codecov/codecov-action@v3.1.1
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
 
       - if: failure()
         name: "If failure, stop all other jobs"

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -58,8 +58,6 @@ jobs:
 
       - name: "Upload coverage data"
         uses: codecov/codecov-action@v3.1.1
-        with:
-          token: ${{ secrets.CODECOV_TOKEN }}
 
       - if: failure()
         name: "If failure, stop all other jobs"

--- a/configure.ac
+++ b/configure.ac
@@ -854,7 +854,17 @@ if test "$enable_coverage" = "yes";
 then
     AX_CHECK_COMPILE_FLAG([-fprofile-arcs -ftest-coverage],
     [save_CFLAGS="-fprofile-arcs -ftest-coverage $save_CFLAGS"],
-    [AC_MSG_ERROR([$CC does not seem to support test coverage flags.])])
+    [AC_MSG_ERROR([$CC does not to support test coverage flags])])
+fi
+
+if test "$enable_debug" = "yes" || test "$enable_coverage" = "yes";
+then
+    if test "$ac_cv_prog_cc_g" = "yes";
+    then
+        save_CFLAGS="-g $save_CFLAGS"
+    else
+        AC_MSG_ERROR([$CC does not support the flag -g needed to generate debug information])
+    fi
 fi
 
 if test -n "$ABI";
@@ -864,16 +874,6 @@ then
     [AC_MSG_ERROR([$CC does not support the ABI flag -m$ABI])])
 fi
 AC_SUBST(ABI_FLAG)
-
-if test "$enable_debug" = "yes";
-then
-    if test "$ac_cv_prog_cc_g" = "yes";
-    then
-        save_CFLAGS="-g $save_CFLAGS"
-    else
-        AC_MSG_ERROR([$CC does not support the flag -g needed to generate debug information])
-    fi
-fi
 
 if test "$enable_avx2" = "yes";
 then
@@ -928,6 +928,13 @@ else
 fi
 
 CPPFLAGS="-I./src $CPPFLAGS"
+
+# Remove unnecessary whitespaces
+LDFLAGS="`$ECHO \"$LDFLAGS\" | $SED 's/ \+/ /g; s/ $//'`"
+LIBS="`$ECHO \"$LIBS\" | $SED 's/ \+/ /g; s/ $//'`"
+CFLAGS="`$ECHO \"$CFLAGS\" | $SED 's/ \+/ /g; s/ $//'`"
+CPPFLAGS="`$ECHO \"$CPPFLAGS\" | $SED 's/ \+/ /g; s/ $//'`"
+TESTCFLAGS="`$ECHO \"$TESTCFLAGS\" | $SED 's/ \+/ /g; s/ $//'`"
 
 ################################################################################ 
 # substitutions and definitions

--- a/dev/gather_coverage.sh
+++ b/dev/gather_coverage.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+
+# This file was modified from GAP-system's dev/ci-gather-coverage.sh.  Visit
+# their website at <https://www.gap-system.org/>.
+
+# NOTE: This needs to be executed from the FLINT directory *after* checks has
+# been made.
+
+set -ex
+
+find build -type f -name '*.gcno' -exec gcov -pb {} +


### PR DESCRIPTION
Also strip white spaces from some variables in configure.ac

@fredrik-johansson you have to add `CODECOV_TOKEN` to secrets. Read more at https://github.com/codecov/codecov-action.

@fingolfin I modified GAP's `dev/ci-gather-coverage.sh` into `dev/gather_coverage.sh`. I hope this is fine by you.

@fingolfin I would also like to ask you for help on this PR. Basically we set the CFLAGS to `-g -fprofile-arcs -ftest-coverage` (I know that GAP sets `-g --coverage` instead), and then we run `find build -type f -name '*.gcno' -exec gcov -pb {} +`. After this we should be able to push everything to Codecov, right? Or should something be altered? Should we exclude some files perhaps? When I ran this on my machine I got coverage for `gmp.h`, don't know how to exclude such files.