### PR TITLE
Remove file management from qsieve

### DIFF
--- a/src/qsieve.h
+++ b/src/qsieve.h
@@ -234,14 +234,14 @@ do                                  \
 }                                   \
 while (0)
 
-#define QS_STORAGE_ALLOC(storage)                               \
-do                                                              \
-{                                                               \
-    FLINT_ASSERT((storage).mem == NULL);                        \
-    (storage).mem = flint_malloc(QS_STORAGE_ALLOC_START_SIZE);  \
-    (storage).curpos = (storage).mem;                           \
-    (storage).alloc = QS_STORAGE_ALLOC_START_SIZE;              \
-}                                                               \
+#define QS_STORAGE_ALLOC(storage)                                                   \
+do                                                                                  \
+{                                                                                   \
+    FLINT_ASSERT((storage).mem == NULL);                                            \
+    (storage).mem = flint_malloc(sizeof(mp_limb_t) * QS_STORAGE_ALLOC_START_SIZE);  \
+    (storage).curpos = (storage).mem;                                               \
+    (storage).alloc = QS_STORAGE_ALLOC_START_SIZE;                                  \
+}                                                                                   \
 while (0)
 
 #define QS_STORAGE_RESET(storage)       \

--- a/src/qsieve.h
+++ b/src/qsieve.h
@@ -254,20 +254,20 @@ while (0)
 #define QS_STORAGE_REALLOC(storage, alloc_size)                                     \
 do                                                                                  \
 {                                                                                   \
-    ulong diff = (storage).curpos - (storage).mem;                                  \
+    ulong __diff = (storage).curpos - (storage).mem;                                \
     (storage).mem = flint_realloc((storage).mem, sizeof(mp_limb_t) * (alloc_size)); \
-    (storage).curpos = (storage).mem + diff;                                        \
+    (storage).curpos = (storage).mem + __diff;                                      \
     (storage).alloc = (alloc_size);                                                 \
 }                                                                                   \
 while (0)
 
-#define QS_STORAGE_ENSURE_SIZE(storage, size)       \
-do                                                  \
-{                                                   \
-    ulong diff = (storage).curpos - (storage).mem;  \
-    if ((size) >= ((storage).alloc - diff))         \
-        QS_STORAGE_REALLOC(storage, 2 * (size));    \
-}                                                   \
+#define QS_STORAGE_ENSURE_SIZE(storage, size)                   \
+do                                                              \
+{                                                               \
+    ulong __diff = (ulong) ((storage).curpos - (storage).mem);  \
+    if ((size) > ((storage).alloc - __diff))                    \
+        QS_STORAGE_REALLOC(storage, 2 * ((size) + __diff));     \
+}                                                               \
 while (0)
 
 /*

--- a/src/qsieve.h
+++ b/src/qsieve.h
@@ -415,6 +415,7 @@ hash_t * qsieve_get_table_entry(qs_t qs_inf, mp_limb_t prime);
 void qsieve_add_to_hashtable(qs_t qs_inf, mp_limb_t prime);
 
 #define qsieve_parse_relation _Pragma("GCC error \"'qsieve_parse_relation' is deprecated.\"")
+relation_t _qsieve_parse_relation(qs_t qs_inf, mp_srcptr mem);
 
 relation_t qsieve_merge_relation(qs_t qs_inf, relation_t  a, relation_t  b);
 

--- a/src/qsieve/clear.c
+++ b/src/qsieve/clear.c
@@ -24,5 +24,5 @@ void qsieve_clear(qs_t qs_inf)
     qs_inf->factor_base = NULL;
     qs_inf->sqrts       = NULL;
 
-    flint_free(qs_inf->fname);
+    QS_STORAGE_CLEAR(qs_inf->storage);
 }

--- a/src/qsieve/collect_relations.c
+++ b/src/qsieve/collect_relations.c
@@ -378,7 +378,7 @@ slong qsieve_evaluate_candidate(qs_t qs_inf, ulong i, unsigned char * sieve, qs_
 #if FLINT_USES_PTHREAD
          pthread_mutex_lock(&qs_inf->mutex);
 #endif
-	 qsieve_write_to_file(qs_inf, 1, Y, poly);
+         qsieve_write_relation(qs_inf, 1, Y, poly);
 
          qs_inf->full_relation++;
 
@@ -424,7 +424,7 @@ slong qsieve_evaluate_candidate(qs_t qs_inf, ulong i, unsigned char * sieve, qs_
 #endif
                   /* store this partial in file */
 
-                  qsieve_write_to_file(qs_inf, prime, Y, poly);
+                  qsieve_write_relation(qs_inf, prime, Y, poly);
 
                   qs_inf->edges++;
 

--- a/src/qsieve/init.c
+++ b/src/qsieve/init.c
@@ -13,23 +13,10 @@
 #include "fmpz.h"
 #include "qsieve.h"
 
-#if (defined(__WIN32) && !defined(__CYGWIN__) && !defined(__MINGW32__) && !defined(__MINGW64__)) || defined(_MSC_VER)
-# ifndef MAX_PATH
-#  define MAX_PATH 260
-# endif
-#endif
-
 void qsieve_init(qs_t qs_inf, const fmpz_t n)
 {
     size_t fname_alloc_size;
     slong i;
-
-#if (defined(__WIN32) && !defined(__CYGWIN__) && !defined(__MINGW32__) && !defined(__MINGW64__)) || defined(_MSC_VER)
-    fname_alloc_size = MAX_PATH;
-#else
-    fname_alloc_size = sizeof(FLINT_TMPDIR "/siqsXXXXXX");
-#endif
-    qs_inf->fname = (char *) flint_malloc(fname_alloc_size); /* space for filename */
 
     /* store n in struct */
     fmpz_init_set(qs_inf->n, n);
@@ -64,4 +51,6 @@ void qsieve_init(qs_t qs_inf, const fmpz_t n)
     qs_inf->sqrts       = NULL;
 
     qs_inf->s = 0;
+
+    QS_STORAGE_INIT(qs_inf->storage);
 }

--- a/src/qsieve/init.c
+++ b/src/qsieve/init.c
@@ -15,7 +15,6 @@
 
 void qsieve_init(qs_t qs_inf, const fmpz_t n)
 {
-    size_t fname_alloc_size;
     slong i;
 
     /* store n in struct */

--- a/src/qsieve/large_prime_variant.c
+++ b/src/qsieve/large_prime_variant.c
@@ -64,8 +64,9 @@ void qsieve_write_relation(qs_t qs_inf, mp_limb_t prime, const fmpz_t Y, const q
         not been filled.
     */
 
-    size_of_write = 1 + qs_inf->small_primes + 1
-                    + 2 * num_factors + 1 + FLINT_MAX(FLINT_ABS(Y_size), 1);
+    size_of_write = 1 + 1 + qs_inf->small_primes
+                    + 1 + (sizeof(fac_t) / sizeof(mp_limb_t)) * num_factors
+                    + 1 + FLINT_MAX(FLINT_ABS(Y_size), 1);
     QS_STORAGE_ENSURE_SIZE(qs_inf->storage, size_of_write + 1);
     mem = qs_inf->storage.curpos;
 
@@ -427,8 +428,8 @@ relation_t _qsieve_parse_relation(qs_t qs_inf, mp_srcptr mem)
     /* small_primes -- not stored in qs_inf->storage */
     rel.small_primes = qs_inf->small_primes;
 
-    /* prime */
-    rel.lp = mem[0];
+    /* prime is overwritten after call in qsieve_process_relation */
+    rel.lp = UWORD(1);
     mem += 1;
 
     /* the array small */
@@ -492,6 +493,7 @@ int qsieve_process_relation(qs_t qs_inf)
         if (prime == 1 || entry->count >= 2)
         {
             rel_list[num_relations] = _qsieve_parse_relation(qs_inf, mem);
+            rel_list[num_relations].lp = prime;
             num_relations++;
         }
 


### PR DESCRIPTION
Could I get some help with this, @fredrik-johansson?

I want to remove the file management from `qsieve` completely. I believe I have converted the most of it, but I get some double frees.

There are two major changes made here: Firstly we do not store string representations, and secondly we store in malloc'ed memory instead of in temporary files.