### PR TITLE
Fix compiler warnings

### DIFF
--- a/src/acb/test/t-acos.c
+++ b/src/acb/test/t-acos.c
@@ -11,7 +11,7 @@
 
 #include "acb.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/acb/test/t-acosh.c
+++ b/src/acb/test/t-acosh.c
@@ -11,7 +11,7 @@
 
 #include "acb.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/acb/test/t-agm.c
+++ b/src/acb/test/t-agm.c
@@ -271,7 +271,7 @@ const double agm_testdata[NUM_TESTS][6] = {
     {2, 2, 2, 2, 2.00000000000000, 2.00000000000000},
 };
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/acb/test/t-agm1.c
+++ b/src/acb/test/t-agm1.c
@@ -63,7 +63,7 @@ const double agm_testdata[NUM_TESTS][10] = {
         92537341636.835656296},
 };
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/acb/test/t-approx_dot.c
+++ b/src/acb/test/t-approx_dot.c
@@ -13,7 +13,7 @@
 
 FLINT_DLL extern slong acb_dot_gauss_dot_cutoff;
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/acb/test/t-asin.c
+++ b/src/acb/test/t-asin.c
@@ -11,7 +11,7 @@
 
 #include "acb.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/acb/test/t-asinh.c
+++ b/src/acb/test/t-asinh.c
@@ -11,7 +11,7 @@
 
 #include "acb.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/acb/test/t-atan.c
+++ b/src/acb/test/t-atan.c
@@ -11,7 +11,7 @@
 
 #include "acb.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/acb/test/t-atanh.c
+++ b/src/acb/test/t-atanh.c
@@ -11,7 +11,7 @@
 
 #include "acb.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/acb/test/t-barnes_g.c
+++ b/src/acb/test/t-barnes_g.c
@@ -11,7 +11,7 @@
 
 #include "acb.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/acb/test/t-bernoulli_poly_ui.c
+++ b/src/acb/test/t-bernoulli_poly_ui.c
@@ -11,7 +11,7 @@
 
 #include "acb.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/acb/test/t-chebyshev_t_ui.c
+++ b/src/acb/test/t-chebyshev_t_ui.c
@@ -11,7 +11,7 @@
 
 #include "acb.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/acb/test/t-chebyshev_u_ui.c
+++ b/src/acb/test/t-chebyshev_u_ui.c
@@ -11,7 +11,7 @@
 
 #include "acb.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/acb/test/t-cos_pi.c
+++ b/src/acb/test/t-cos_pi.c
@@ -11,7 +11,7 @@
 
 #include "acb.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/acb/test/t-cot.c
+++ b/src/acb/test/t-cot.c
@@ -11,7 +11,7 @@
 
 #include "acb.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/acb/test/t-cot_pi.c
+++ b/src/acb/test/t-cot_pi.c
@@ -11,7 +11,7 @@
 
 #include "acb.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/acb/test/t-coth.c
+++ b/src/acb/test/t-coth.c
@@ -11,7 +11,7 @@
 
 #include "acb.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/acb/test/t-csc.c
+++ b/src/acb/test/t-csc.c
@@ -11,7 +11,7 @@
 
 #include "acb.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/acb/test/t-csc_pi.c
+++ b/src/acb/test/t-csc_pi.c
@@ -12,7 +12,7 @@
 
 #include "acb.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/acb/test/t-csch.c
+++ b/src/acb/test/t-csch.c
@@ -11,7 +11,7 @@
 
 #include "acb.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/acb/test/t-csgn.c
+++ b/src/acb/test/t-csgn.c
@@ -11,7 +11,7 @@
 
 #include "acb.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/acb/test/t-digamma.c
+++ b/src/acb/test/t-digamma.c
@@ -11,7 +11,7 @@
 
 #include "acb.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/acb/test/t-div.c
+++ b/src/acb/test/t-div.c
@@ -11,7 +11,7 @@
 
 #include "acb.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/acb/test/t-dot.c
+++ b/src/acb/test/t-dot.c
@@ -13,7 +13,7 @@
 
 FLINT_DLL extern slong acb_dot_gauss_dot_cutoff;
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/acb/test/t-dot_fmpz.c
+++ b/src/acb/test/t-dot_fmpz.c
@@ -12,7 +12,7 @@
 #include "fmpz_vec.h"
 #include "acb.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/acb/test/t-dot_si.c
+++ b/src/acb/test/t-dot_si.c
@@ -11,7 +11,7 @@
 
 #include "acb.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/acb/test/t-dot_siui.c
+++ b/src/acb/test/t-dot_siui.c
@@ -11,7 +11,7 @@
 
 #include "acb.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/acb/test/t-dot_ui.c
+++ b/src/acb/test/t-dot_ui.c
@@ -11,7 +11,7 @@
 
 #include "acb.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/acb/test/t-dot_uiui.c
+++ b/src/acb/test/t-dot_uiui.c
@@ -11,7 +11,7 @@
 
 #include "acb.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/acb/test/t-exp.c
+++ b/src/acb/test/t-exp.c
@@ -11,7 +11,7 @@
 
 #include "acb.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/acb/test/t-exp_invexp.c
+++ b/src/acb/test/t-exp_invexp.c
@@ -11,7 +11,7 @@
 
 #include "acb.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/acb/test/t-exp_pi_i.c
+++ b/src/acb/test/t-exp_pi_i.c
@@ -11,7 +11,7 @@
 
 #include "acb.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/acb/test/t-expm1.c
+++ b/src/acb/test/t-expm1.c
@@ -11,7 +11,7 @@
 
 #include "acb.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/acb/test/t-gamma.c
+++ b/src/acb/test/t-gamma.c
@@ -11,7 +11,7 @@
 
 #include "acb.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/acb/test/t-get_abs_lbound_arf.c
+++ b/src/acb/test/t-get_abs_lbound_arf.c
@@ -11,7 +11,7 @@
 
 #include "acb.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/acb/test/t-get_abs_ubound_arf.c
+++ b/src/acb/test/t-get_abs_ubound_arf.c
@@ -11,7 +11,7 @@
 
 #include "acb.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/acb/test/t-get_mag.c
+++ b/src/acb/test/t-get_mag.c
@@ -11,7 +11,7 @@
 
 #include "acb.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/acb/test/t-get_mag_lower.c
+++ b/src/acb/test/t-get_mag_lower.c
@@ -11,7 +11,7 @@
 
 #include "acb.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/acb/test/t-inv.c
+++ b/src/acb/test/t-inv.c
@@ -52,7 +52,7 @@ acb_inv_naive(acb_t z, const acb_t x, slong prec)
 #undef d
 }
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/acb/test/t-lambertw.c
+++ b/src/acb/test/t-lambertw.c
@@ -11,7 +11,7 @@
 
 #include "acb.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/acb/test/t-lgamma.c
+++ b/src/acb/test/t-lgamma.c
@@ -11,7 +11,7 @@
 
 #include "acb.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/acb/test/t-log.c
+++ b/src/acb/test/t-log.c
@@ -128,7 +128,7 @@ acb_log_old(acb_t r, const acb_t z, slong prec)
 #undef b
 }
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/acb/test/t-log1p.c
+++ b/src/acb/test/t-log1p.c
@@ -11,7 +11,7 @@
 
 #include "acb.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/acb/test/t-log_sin_pi.c
+++ b/src/acb/test/t-log_sin_pi.c
@@ -11,7 +11,7 @@
 
 #include "acb.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/acb/test/t-mul.c
+++ b/src/acb/test/t-mul.c
@@ -11,7 +11,7 @@
 
 #include "acb.h"
 
-int main()
+int main(void)
 {
     slong iter, iter2;
     flint_rand_t state;

--- a/src/acb/test/t-mul_naive.c
+++ b/src/acb/test/t-mul_naive.c
@@ -11,7 +11,7 @@
 
 #include "acb.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/acb/test/t-polygamma.c
+++ b/src/acb/test/t-polygamma.c
@@ -19,7 +19,7 @@ static const char *testdata[5] = {
     "-2.404113806319188570799476323022899981529972584680997763584543110683676411572626180372911747218670516 +/- 1e-90",
 };
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/acb/test/t-pow.c
+++ b/src/acb/test/t-pow.c
@@ -11,7 +11,7 @@
 
 #include "acb.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/acb/test/t-pow_fmpz.c
+++ b/src/acb/test/t-pow_fmpz.c
@@ -11,7 +11,7 @@
 
 #include "acb.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/acb/test/t-quadratic_roots_fmpz.c
+++ b/src/acb/test/t-quadratic_roots_fmpz.c
@@ -11,7 +11,7 @@
 
 #include "acb.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/acb/test/t-rel_accuracy_bits.c
+++ b/src/acb/test/t-rel_accuracy_bits.c
@@ -11,7 +11,7 @@
 
 #include "acb.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/acb/test/t-rgamma.c
+++ b/src/acb/test/t-rgamma.c
@@ -11,7 +11,7 @@
 
 #include "acb.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/acb/test/t-rising2_ui.c
+++ b/src/acb/test/t-rising2_ui.c
@@ -13,7 +13,7 @@
 #include "arith.h"
 #include "acb_poly.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/acb/test/t-rising_ui.c
+++ b/src/acb/test/t-rising_ui.c
@@ -11,7 +11,7 @@
 
 #include "acb.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/acb/test/t-rising_ui_get_mag.c
+++ b/src/acb/test/t-rising_ui_get_mag.c
@@ -11,7 +11,7 @@
 
 #include "acb.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/acb/test/t-root_ui.c
+++ b/src/acb/test/t-root_ui.c
@@ -11,7 +11,7 @@
 
 #include "acb.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/acb/test/t-rsqrt.c
+++ b/src/acb/test/t-rsqrt.c
@@ -11,7 +11,7 @@
 
 #include "acb.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/acb/test/t-sec.c
+++ b/src/acb/test/t-sec.c
@@ -11,7 +11,7 @@
 
 #include "acb.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/acb/test/t-sech.c
+++ b/src/acb/test/t-sech.c
@@ -11,7 +11,7 @@
 
 #include "acb.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/acb/test/t-sgn.c
+++ b/src/acb/test/t-sgn.c
@@ -11,7 +11,7 @@
 
 #include "acb.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/acb/test/t-sin_cos.c
+++ b/src/acb/test/t-sin_cos.c
@@ -11,7 +11,7 @@
 
 #include "acb.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/acb/test/t-sin_pi.c
+++ b/src/acb/test/t-sin_pi.c
@@ -11,7 +11,7 @@
 
 #include "acb.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/acb/test/t-sinc.c
+++ b/src/acb/test/t-sinc.c
@@ -11,7 +11,7 @@
 
 #include "acb.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/acb/test/t-sinc_pi.c
+++ b/src/acb/test/t-sinc_pi.c
@@ -11,7 +11,7 @@
 
 #include "acb.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/acb/test/t-sinh_cosh.c
+++ b/src/acb/test/t-sinh_cosh.c
@@ -11,7 +11,7 @@
 
 #include "acb.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/acb/test/t-sqrt.c
+++ b/src/acb/test/t-sqrt.c
@@ -11,7 +11,7 @@
 
 #include "acb.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/acb/test/t-tan.c
+++ b/src/acb/test/t-tan.c
@@ -11,7 +11,7 @@
 
 #include "acb.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/acb/test/t-tan_pi.c
+++ b/src/acb/test/t-tan_pi.c
@@ -11,7 +11,7 @@
 
 #include "acb.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/acb/test/t-tanh.c
+++ b/src/acb/test/t-tanh.c
@@ -11,7 +11,7 @@
 
 #include "acb.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/acb/test/t-vec_unit_roots.c
+++ b/src/acb/test/t-vec_unit_roots.c
@@ -12,7 +12,7 @@
 #include "fmpq.h"
 #include "acb.h"
 
-int main()
+int main(void)
 {
     slong len;
     flint_rand_t state;

--- a/src/acb/test/t-zeta.c
+++ b/src/acb/test/t-zeta.c
@@ -11,7 +11,7 @@
 
 #include "acb.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/acb_calc/integrate_gl_auto_deg.c
+++ b/src/acb_calc/integrate_gl_auto_deg.c
@@ -39,7 +39,7 @@ gl_cache_struct;
 
 FLINT_TLS_PREFIX gl_cache_struct * gl_cache = NULL;
 
-void gl_cleanup()
+void gl_cleanup(void)
 {
     slong i;
 
@@ -59,7 +59,7 @@ void gl_cleanup()
     gl_cache = NULL;
 }
 
-void gl_init()
+void gl_init(void)
 {
     gl_cache = flint_calloc(1, sizeof(gl_cache_struct));
     flint_register_cleanup_function(gl_cleanup);

--- a/src/acb_calc/test/t-cauchy_bound.c
+++ b/src/acb_calc/test/t-cauchy_bound.c
@@ -33,7 +33,7 @@ static const double answers[10] = {
   2815.70144392142227
 };
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/acb_calc/test/t-integrate.c
+++ b/src/acb_calc/test/t-integrate.c
@@ -334,7 +334,7 @@ f_min(acb_ptr res, const acb_t z, void * param, slong order, slong prec)
 }
 
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/acb_calc/test/t-integrate_taylor.c
+++ b/src/acb_calc/test/t-integrate_taylor.c
@@ -26,7 +26,7 @@ sin_x(acb_ptr out, const acb_t inp, void * params, slong order, slong prec)
     return 0;
 }
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/acb_dft/test/t-convol.c
+++ b/src/acb_dft/test/t-convol.c
@@ -50,7 +50,7 @@ check_vec_eq_prec(acb_srcptr w1, acb_srcptr w2, slong len, slong prec, slong dig
     }
 }
 
-int main()
+int main(void)
 {
 
     slong k;

--- a/src/acb_dft/test/t-dft.c
+++ b/src/acb_dft/test/t-dft.c
@@ -50,7 +50,7 @@ check_vec_eq_prec(acb_srcptr w1, acb_srcptr w2, slong len, slong prec, slong dig
     }
 }
 
-int main()
+int main(void)
 {
     slong k;
     slong prec = 100, digits = 30;

--- a/src/acb_dirichlet/test/t-backlund_s.c
+++ b/src/acb_dirichlet/test/t-backlund_s.c
@@ -10,7 +10,7 @@
 
 #include "acb_dirichlet.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/acb_dirichlet/test/t-backlund_s_bound.c
+++ b/src/acb_dirichlet/test/t-backlund_s_bound.c
@@ -11,7 +11,7 @@
 
 #include "acb_dirichlet.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/acb_dirichlet/test/t-backlund_s_gram.c
+++ b/src/acb_dirichlet/test/t-backlund_s_gram.c
@@ -11,7 +11,7 @@
 
 #include "acb_dirichlet.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/acb_dirichlet/test/t-chi.c
+++ b/src/acb_dirichlet/test/t-chi.c
@@ -11,7 +11,7 @@
 
 #include "acb_dirichlet.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/acb_dirichlet/test/t-dft.c
+++ b/src/acb_dirichlet/test/t-dft.c
@@ -51,7 +51,7 @@ check_vec_eq_prec(acb_srcptr w1, acb_srcptr w2, slong len, slong prec, slong dig
 }
 
 
-int main()
+int main(void)
 {
     slong k;
     slong prec = 100, digits = 30;

--- a/src/acb_dirichlet/test/t-eta.c
+++ b/src/acb_dirichlet/test/t-eta.c
@@ -11,7 +11,7 @@
 
 #include "acb_dirichlet.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/acb_dirichlet/test/t-euler_product_real_ui.c
+++ b/src/acb_dirichlet/test/t-euler_product_real_ui.c
@@ -39,7 +39,7 @@ const double L10[8] = {
   0.999007468458940084215357132419
 };
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/acb_dirichlet/test/t-gauss.c
+++ b/src/acb_dirichlet/test/t-gauss.c
@@ -11,7 +11,7 @@
 
 #include "acb_dirichlet.h"
 
-int main()
+int main(void)
 {
     slong prec = 128;
     ulong q;

--- a/src/acb_dirichlet/test/t-gram_point.c
+++ b/src/acb_dirichlet/test/t-gram_point.c
@@ -11,7 +11,7 @@
 
 #include "acb_dirichlet.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/acb_dirichlet/test/t-hardy_theta_series.c
+++ b/src/acb_dirichlet/test/t-hardy_theta_series.c
@@ -12,7 +12,7 @@
 #include "acb_poly.h"
 #include "acb_dirichlet.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/acb_dirichlet/test/t-hardy_z.c
+++ b/src/acb_dirichlet/test/t-hardy_z.c
@@ -11,7 +11,7 @@
 
 #include "acb_dirichlet.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/acb_dirichlet/test/t-hardy_z_series.c
+++ b/src/acb_dirichlet/test/t-hardy_z_series.c
@@ -12,7 +12,7 @@
 #include "acb_poly.h"
 #include "acb_dirichlet.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/acb_dirichlet/test/t-hardy_z_zero.c
+++ b/src/acb_dirichlet/test/t-hardy_z_zero.c
@@ -11,7 +11,7 @@
 
 #include "acb_dirichlet.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/acb_dirichlet/test/t-hardy_z_zeros.c
+++ b/src/acb_dirichlet/test/t-hardy_z_zeros.c
@@ -11,7 +11,7 @@
 
 #include "acb_dirichlet.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/acb_dirichlet/test/t-hurwitz.c
+++ b/src/acb_dirichlet/test/t-hurwitz.c
@@ -11,7 +11,7 @@
 
 #include "acb_dirichlet.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/acb_dirichlet/test/t-hurwitz_precomp.c
+++ b/src/acb_dirichlet/test/t-hurwitz_precomp.c
@@ -12,7 +12,7 @@
 #include "acb_dirichlet.h"
 #include "acb_poly.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/acb_dirichlet/test/t-isolate_hardy_z_zero.c
+++ b/src/acb_dirichlet/test/t-isolate_hardy_z_zero.c
@@ -46,7 +46,7 @@ _check_interval(const arf_t a, const arf_t b, const fmpz_t n)
     arb_clear(v);
 }
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/acb_dirichlet/test/t-jacobi.c
+++ b/src/acb_dirichlet/test/t-jacobi.c
@@ -11,7 +11,7 @@
 
 #include "acb_dirichlet.h"
 
-int main()
+int main(void)
 {
     slong prec = 128;
     ulong q;

--- a/src/acb_dirichlet/test/t-l.c
+++ b/src/acb_dirichlet/test/t-l.c
@@ -11,7 +11,7 @@
 
 #include "acb_dirichlet.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/acb_dirichlet/test/t-l_euler_product.c
+++ b/src/acb_dirichlet/test/t-l_euler_product.c
@@ -11,7 +11,7 @@
 
 #include "acb_dirichlet.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/acb_dirichlet/test/t-l_fmpq.c
+++ b/src/acb_dirichlet/test/t-l_fmpq.c
@@ -12,7 +12,7 @@
 #include "fmpq.h"
 #include "acb_dirichlet.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/acb_dirichlet/test/t-l_fmpq_afe.c
+++ b/src/acb_dirichlet/test/t-l_fmpq_afe.c
@@ -12,7 +12,7 @@
 #include "fmpq.h"
 #include "acb_dirichlet.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/acb_dirichlet/test/t-l_hurwitz.c
+++ b/src/acb_dirichlet/test/t-l_hurwitz.c
@@ -14,7 +14,7 @@
 #define nq 5
 #define nx 3
 
-int main()
+int main(void)
 {
 
     slong i, j;

--- a/src/acb_dirichlet/test/t-l_jet.c
+++ b/src/acb_dirichlet/test/t-l_jet.c
@@ -60,7 +60,7 @@ static const double laurent_data[TESTQ][TESTLEN] = {
         0.024624650443138705595, -0.004951850872731033514, -0.00020178815459414925709}
 };
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/acb_dirichlet/test/t-l_series.c
+++ b/src/acb_dirichlet/test/t-l_series.c
@@ -12,7 +12,7 @@
 #include "acb_poly.h"
 #include "acb_dirichlet.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/acb_dirichlet/test/t-l_vec_hurwitz.c
+++ b/src/acb_dirichlet/test/t-l_vec_hurwitz.c
@@ -12,7 +12,7 @@
 
 #include "acb_dirichlet.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/acb_dirichlet/test/t-lerch_phi.c
+++ b/src/acb_dirichlet/test/t-lerch_phi.c
@@ -59,7 +59,7 @@ const double testdata[NUM_TESTS][8] = {
     { -3.0, 0.0, -2.0, 0.0, -2.0, 0.0, 1.84375, 0.0 },
 };
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/acb_dirichlet/test/t-platt_beta.c
+++ b/src/acb_dirichlet/test/t-platt_beta.c
@@ -30,7 +30,7 @@ _arb_lt_d(const arb_t a, double d)
     return result;
 }
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/acb_dirichlet/test/t-platt_hardy_z_zeros.c
+++ b/src/acb_dirichlet/test/t-platt_hardy_z_zeros.c
@@ -11,7 +11,7 @@
 
 #include "acb_dirichlet.h"
 
-int main()
+int main(void)
 {
     fmpz_t n;
     arb_ptr pa, pb;

--- a/src/acb_dirichlet/test/t-platt_local_hardy_z_zeros.c
+++ b/src/acb_dirichlet/test/t-platt_local_hardy_z_zeros.c
@@ -11,7 +11,7 @@
 
 #include "acb_dirichlet.h"
 
-int main()
+int main(void)
 {
     /* Check a specific combination of parameter values that is relatively fast
      * to evaluate and that has relatively tight bounds. */

--- a/src/acb_dirichlet/test/t-platt_multieval.c
+++ b/src/acb_dirichlet/test/t-platt_multieval.c
@@ -59,7 +59,7 @@ _check_containment(const char *name, const arb_t x, const char *s)
     arb_clear(u);
 }
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/acb_dirichlet/test/t-platt_multieval_threaded.c
+++ b/src/acb_dirichlet/test/t-platt_multieval_threaded.c
@@ -32,7 +32,7 @@ _arb_vec_overlaps(arb_srcptr a, arb_srcptr b, slong len)
     return 1;
 }
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/acb_dirichlet/test/t-platt_ws_interpolation.c
+++ b/src/acb_dirichlet/test/t-platt_ws_interpolation.c
@@ -11,7 +11,7 @@
 
 #include "acb_dirichlet.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/acb_dirichlet/test/t-platt_zeta_zeros.c
+++ b/src/acb_dirichlet/test/t-platt_zeta_zeros.c
@@ -11,7 +11,7 @@
 
 #include "acb_dirichlet.h"
 
-int main()
+int main(void)
 {
     fmpz_t n;
     acb_ptr pa, pb;

--- a/src/acb_dirichlet/test/t-powsum_smooth.c
+++ b/src/acb_dirichlet/test/t-powsum_smooth.c
@@ -12,7 +12,7 @@
 #include "acb_dirichlet.h"
 #include "acb_poly.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/acb_dirichlet/test/t-roots.c
+++ b/src/acb_dirichlet/test/t-roots.c
@@ -11,7 +11,7 @@
 
 #include "acb_dirichlet.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/acb_dirichlet/test/t-stieltjes.c
+++ b/src/acb_dirichlet/test/t-stieltjes.c
@@ -14,7 +14,7 @@
 void acb_dirichlet_stieltjes_integral(acb_t res, const fmpz_t n, const acb_t a, slong prec);
 void acb_dirichlet_stieltjes_em(acb_t res, const fmpz_t n, const acb_t a, slong prec);
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/acb_dirichlet/test/t-thetanull.c
+++ b/src/acb_dirichlet/test/t-thetanull.c
@@ -11,7 +11,7 @@
 
 #include "acb_dirichlet.h"
 
-int main()
+int main(void)
 {
     slong prec = 64;
     ulong q;

--- a/src/acb_dirichlet/test/t-turing_method_bound.c
+++ b/src/acb_dirichlet/test/t-turing_method_bound.c
@@ -11,7 +11,7 @@
 
 #include "acb_dirichlet.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/acb_dirichlet/test/t-xi.c
+++ b/src/acb_dirichlet/test/t-xi.c
@@ -11,7 +11,7 @@
 
 #include "acb_dirichlet.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/acb_dirichlet/test/t-zeta_bound.c
+++ b/src/acb_dirichlet/test/t-zeta_bound.c
@@ -11,7 +11,7 @@
 
 #include "acb_dirichlet.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/acb_dirichlet/test/t-zeta_jet_rs.c
+++ b/src/acb_dirichlet/test/t-zeta_jet_rs.c
@@ -12,7 +12,7 @@
 #include "acb_poly.h"
 #include "acb_dirichlet.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/acb_dirichlet/test/t-zeta_nzeros.c
+++ b/src/acb_dirichlet/test/t-zeta_nzeros.c
@@ -11,7 +11,7 @@
 
 #include "acb_dirichlet.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/acb_dirichlet/test/t-zeta_nzeros_gram.c
+++ b/src/acb_dirichlet/test/t-zeta_nzeros_gram.c
@@ -11,7 +11,7 @@
 
 #include "acb_dirichlet.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/acb_dirichlet/test/t-zeta_rs.c
+++ b/src/acb_dirichlet/test/t-zeta_rs.c
@@ -11,7 +11,7 @@
 
 #include "acb_dirichlet.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/acb_dirichlet/test/t-zeta_rs_r.c
+++ b/src/acb_dirichlet/test/t-zeta_rs_r.c
@@ -11,7 +11,7 @@
 
 #include "acb_dirichlet.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/acb_dirichlet/test/t-zeta_zero.c
+++ b/src/acb_dirichlet/test/t-zeta_zero.c
@@ -11,7 +11,7 @@
 
 #include "acb_dirichlet.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/acb_dirichlet/test/t-zeta_zeros.c
+++ b/src/acb_dirichlet/test/t-zeta_zeros.c
@@ -11,7 +11,7 @@
 
 #include "acb_dirichlet.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/acb_elliptic/test/t-e_inc.c
+++ b/src/acb_elliptic/test/t-e_inc.c
@@ -13,7 +13,7 @@
 #include "acb_elliptic.h"
 #include "acb_modular.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/acb_elliptic/test/t-f.c
+++ b/src/acb_elliptic/test/t-f.c
@@ -13,7 +13,7 @@
 #include "acb_elliptic.h"
 #include "acb_modular.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/acb_elliptic/test/t-inv_p.c
+++ b/src/acb_elliptic/test/t-inv_p.c
@@ -12,7 +12,7 @@
 #include "acb.h"
 #include "acb_elliptic.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/acb_elliptic/test/t-invariants.c
+++ b/src/acb_elliptic/test/t-invariants.c
@@ -12,7 +12,7 @@
 #include "acb.h"
 #include "acb_elliptic.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/acb_elliptic/test/t-p_p_prime.c
+++ b/src/acb_elliptic/test/t-p_p_prime.c
@@ -12,7 +12,7 @@
 #include "acb.h"
 #include "acb_elliptic.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/acb_elliptic/test/t-pi.c
+++ b/src/acb_elliptic/test/t-pi.c
@@ -39,7 +39,7 @@ static const double testdata_pi[17][6] = {
   {2.0, 1.0, 2.0, 0.0, 2.78474654927885845, 2.02204728966993314},
 };
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/acb_elliptic/test/t-pi_inc.c
+++ b/src/acb_elliptic/test/t-pi_inc.c
@@ -13,7 +13,7 @@
 #include "acb_elliptic.h"
 #include "acb_modular.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/acb_elliptic/test/t-rc1.c
+++ b/src/acb_elliptic/test/t-rc1.c
@@ -13,7 +13,7 @@
 #include "acb_elliptic.h"
 #include "acb_hypgeom.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/acb_elliptic/test/t-rf.c
+++ b/src/acb_elliptic/test/t-rf.c
@@ -12,7 +12,7 @@
 #include "acb.h"
 #include "acb_elliptic.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/acb_elliptic/test/t-rg.c
+++ b/src/acb_elliptic/test/t-rg.c
@@ -31,7 +31,7 @@ static const double testdata_rg[7][8] = {
     {0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0},
 };
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/acb_elliptic/test/t-rj.c
+++ b/src/acb_elliptic/test/t-rj.c
@@ -49,7 +49,7 @@ static const double testdata_rd[6][8] = {
     {-2.0, -1.0, 0.0, -1.0, -1.0, 1.0, 1.8249027393703805305, -1.2218475784827035855},
 };
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/acb_elliptic/test/t-sigma.c
+++ b/src/acb_elliptic/test/t-sigma.c
@@ -39,7 +39,7 @@ acb_set_dddd(acb_t z, double a, double ar, double b, double br)
     mag_set_d(arb_radref(acb_imagref(z)), br);
 }
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/acb_elliptic/test/t-zeta.c
+++ b/src/acb_elliptic/test/t-zeta.c
@@ -39,7 +39,7 @@ acb_set_dddd(acb_t z, double a, double ar, double b, double br)
     mag_set_d(arb_radref(acb_imagref(z)), br);
 }
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/acb_hypgeom/test/t-0f1.c
+++ b/src/acb_hypgeom/test/t-0f1.c
@@ -12,7 +12,7 @@
 #include "acb.h"
 #include "acb_hypgeom.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/acb_hypgeom/test/t-2f1.c
+++ b/src/acb_hypgeom/test/t-2f1.c
@@ -12,7 +12,7 @@
 #include "acb.h"
 #include "acb_hypgeom.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/acb_hypgeom/test/t-2f1_continuation.c
+++ b/src/acb_hypgeom/test/t-2f1_continuation.c
@@ -12,7 +12,7 @@
 #include "acb.h"
 #include "acb_hypgeom.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/acb_hypgeom/test/t-airy.c
+++ b/src/acb_hypgeom/test/t-airy.c
@@ -13,7 +13,7 @@
 #include "acb.h"
 #include "acb_hypgeom.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/acb_hypgeom/test/t-airy_bound.c
+++ b/src/acb_hypgeom/test/t-airy_bound.c
@@ -12,7 +12,7 @@
 #include "acb.h"
 #include "acb_hypgeom.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/acb_hypgeom/test/t-airy_series.c
+++ b/src/acb_hypgeom/test/t-airy_series.c
@@ -13,7 +13,7 @@
 #include "acb_poly.h"
 #include "acb_hypgeom.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/acb_hypgeom/test/t-bessel_i.c
+++ b/src/acb_hypgeom/test/t-bessel_i.c
@@ -12,7 +12,7 @@
 #include "acb.h"
 #include "acb_hypgeom.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/acb_hypgeom/test/t-bessel_j.c
+++ b/src/acb_hypgeom/test/t-bessel_j.c
@@ -12,7 +12,7 @@
 #include "acb.h"
 #include "acb_hypgeom.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/acb_hypgeom/test/t-bessel_k.c
+++ b/src/acb_hypgeom/test/t-bessel_k.c
@@ -12,7 +12,7 @@
 #include "acb.h"
 #include "acb_hypgeom.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/acb_hypgeom/test/t-bessel_y.c
+++ b/src/acb_hypgeom/test/t-bessel_y.c
@@ -12,7 +12,7 @@
 #include "acb.h"
 #include "acb_hypgeom.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/acb_hypgeom/test/t-beta_lower.c
+++ b/src/acb_hypgeom/test/t-beta_lower.c
@@ -12,7 +12,7 @@
 #include "acb.h"
 #include "acb_hypgeom.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/acb_hypgeom/test/t-beta_lower_series.c
+++ b/src/acb_hypgeom/test/t-beta_lower_series.c
@@ -12,7 +12,7 @@
 #include "acb_poly.h"
 #include "acb_hypgeom.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/acb_hypgeom/test/t-chebyshev_t.c
+++ b/src/acb_hypgeom/test/t-chebyshev_t.c
@@ -12,7 +12,7 @@
 #include "acb.h"
 #include "acb_hypgeom.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/acb_hypgeom/test/t-chebyshev_u.c
+++ b/src/acb_hypgeom/test/t-chebyshev_u.c
@@ -12,7 +12,7 @@
 #include "acb.h"
 #include "acb_hypgeom.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/acb_hypgeom/test/t-chi.c
+++ b/src/acb_hypgeom/test/t-chi.c
@@ -12,7 +12,7 @@
 #include "acb.h"
 #include "acb_hypgeom.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/acb_hypgeom/test/t-chi_series.c
+++ b/src/acb_hypgeom/test/t-chi_series.c
@@ -12,7 +12,7 @@
 #include "acb_poly.h"
 #include "acb_hypgeom.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/acb_hypgeom/test/t-ci.c
+++ b/src/acb_hypgeom/test/t-ci.c
@@ -12,7 +12,7 @@
 #include "acb.h"
 #include "acb_hypgeom.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/acb_hypgeom/test/t-ci_series.c
+++ b/src/acb_hypgeom/test/t-ci_series.c
@@ -12,7 +12,7 @@
 #include "acb_poly.h"
 #include "acb_hypgeom.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/acb_hypgeom/test/t-coulomb.c
+++ b/src/acb_hypgeom/test/t-coulomb.c
@@ -13,7 +13,7 @@
 #include "acb.h"
 #include "acb_hypgeom.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/acb_hypgeom/test/t-coulomb_series.c
+++ b/src/acb_hypgeom/test/t-coulomb_series.c
@@ -13,7 +13,7 @@
 #include "acb_poly.h"
 #include "acb_hypgeom.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/acb_hypgeom/test/t-dilog.c
+++ b/src/acb_hypgeom/test/t-dilog.c
@@ -12,7 +12,7 @@
 #include "acb.h"
 #include "acb_hypgeom.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/acb_hypgeom/test/t-ei.c
+++ b/src/acb_hypgeom/test/t-ei.c
@@ -44,7 +44,7 @@ acb_hypgeom_ei_fallback(acb_t res, const acb_t z, slong prec)
     acb_clear(u);
 }
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/acb_hypgeom/test/t-ei_series.c
+++ b/src/acb_hypgeom/test/t-ei_series.c
@@ -12,7 +12,7 @@
 #include "acb_poly.h"
 #include "acb_hypgeom.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/acb_hypgeom/test/t-erf.c
+++ b/src/acb_hypgeom/test/t-erf.c
@@ -12,7 +12,7 @@
 #include "acb.h"
 #include "acb_hypgeom.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/acb_hypgeom/test/t-erf_series.c
+++ b/src/acb_hypgeom/test/t-erf_series.c
@@ -12,7 +12,7 @@
 #include "acb_poly.h"
 #include "acb_hypgeom.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/acb_hypgeom/test/t-erfc.c
+++ b/src/acb_hypgeom/test/t-erfc.c
@@ -12,7 +12,7 @@
 #include "acb.h"
 #include "acb_hypgeom.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/acb_hypgeom/test/t-erfc_series.c
+++ b/src/acb_hypgeom/test/t-erfc_series.c
@@ -12,7 +12,7 @@
 #include "acb_poly.h"
 #include "acb_hypgeom.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/acb_hypgeom/test/t-erfi_series.c
+++ b/src/acb_hypgeom/test/t-erfi_series.c
@@ -12,7 +12,7 @@
 #include "acb_poly.h"
 #include "acb_hypgeom.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/acb_hypgeom/test/t-fresnel.c
+++ b/src/acb_hypgeom/test/t-fresnel.c
@@ -12,7 +12,7 @@
 #include "acb.h"
 #include "acb_hypgeom.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/acb_hypgeom/test/t-fresnel_series.c
+++ b/src/acb_hypgeom/test/t-fresnel_series.c
@@ -12,7 +12,7 @@
 #include "acb_poly.h"
 #include "acb_hypgeom.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/acb_hypgeom/test/t-gamma_lower.c
+++ b/src/acb_hypgeom/test/t-gamma_lower.c
@@ -12,7 +12,7 @@
 #include "acb.h"
 #include "acb_hypgeom.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/acb_hypgeom/test/t-gamma_lower_series.c
+++ b/src/acb_hypgeom/test/t-gamma_lower_series.c
@@ -12,7 +12,7 @@
 #include "acb_poly.h"
 #include "acb_hypgeom.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/acb_hypgeom/test/t-gamma_stirling_sum.c
+++ b/src/acb_hypgeom/test/t-gamma_stirling_sum.c
@@ -12,7 +12,7 @@
 #include "acb.h"
 #include "acb_hypgeom.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/acb_hypgeom/test/t-gamma_taylor.c
+++ b/src/acb_hypgeom/test/t-gamma_taylor.c
@@ -12,7 +12,7 @@
 #include "acb.h"
 #include "acb_hypgeom.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/acb_hypgeom/test/t-gamma_upper.c
+++ b/src/acb_hypgeom/test/t-gamma_upper.c
@@ -35,7 +35,7 @@ _accuracy_regression_test(const acb_t s, const acb_t z,
 }
 
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/acb_hypgeom/test/t-gamma_upper_series.c
+++ b/src/acb_hypgeom/test/t-gamma_upper_series.c
@@ -12,7 +12,7 @@
 #include "acb_poly.h"
 #include "acb_hypgeom.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/acb_hypgeom/test/t-gegenbauer_c.c
+++ b/src/acb_hypgeom/test/t-gegenbauer_c.c
@@ -12,7 +12,7 @@
 #include "acb.h"
 #include "acb_hypgeom.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/acb_hypgeom/test/t-hermite_h.c
+++ b/src/acb_hypgeom/test/t-hermite_h.c
@@ -12,7 +12,7 @@
 #include "acb.h"
 #include "acb_hypgeom.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/acb_hypgeom/test/t-jacobi_p.c
+++ b/src/acb_hypgeom/test/t-jacobi_p.c
@@ -12,7 +12,7 @@
 #include "acb.h"
 #include "acb_hypgeom.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/acb_hypgeom/test/t-laguerre_l.c
+++ b/src/acb_hypgeom/test/t-laguerre_l.c
@@ -12,7 +12,7 @@
 #include "acb.h"
 #include "acb_hypgeom.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/acb_hypgeom/test/t-legendre_p.c
+++ b/src/acb_hypgeom/test/t-legendre_p.c
@@ -12,7 +12,7 @@
 #include "acb.h"
 #include "acb_hypgeom.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/acb_hypgeom/test/t-legendre_q.c
+++ b/src/acb_hypgeom/test/t-legendre_q.c
@@ -18,7 +18,7 @@ void _acb_hypgeom_legendre_q_single(acb_t res, const acb_t n, const acb_t m,
 void _acb_hypgeom_legendre_q_double(acb_t res, const acb_t n, const acb_t m,
     const acb_t z, slong prec);
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/acb_hypgeom/test/t-lgamma.c
+++ b/src/acb_hypgeom/test/t-lgamma.c
@@ -12,7 +12,7 @@
 #include "acb.h"
 #include "acb_hypgeom.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/acb_hypgeom/test/t-li_series.c
+++ b/src/acb_hypgeom/test/t-li_series.c
@@ -12,7 +12,7 @@
 #include "acb_poly.h"
 #include "acb_hypgeom.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/acb_hypgeom/test/t-log_rising_ui.c
+++ b/src/acb_hypgeom/test/t-log_rising_ui.c
@@ -34,7 +34,7 @@ acb_hypgeom_log_rising_ui_naive(acb_t res, const acb_t z, ulong r, slong prec)
     acb_clear(u);
 }
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/acb_hypgeom/test/t-log_rising_ui_jet.c
+++ b/src/acb_hypgeom/test/t-log_rising_ui_jet.c
@@ -12,7 +12,7 @@
 #include "acb_poly.h"
 #include "acb_hypgeom.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/acb_hypgeom/test/t-m.c
+++ b/src/acb_hypgeom/test/t-m.c
@@ -12,7 +12,7 @@
 #include "acb.h"
 #include "acb_hypgeom.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/acb_hypgeom/test/t-pfq.c
+++ b/src/acb_hypgeom/test/t-pfq.c
@@ -12,7 +12,7 @@
 #include "acb.h"
 #include "acb_hypgeom.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/acb_hypgeom/test/t-pfq_series_direct.c
+++ b/src/acb_hypgeom/test/t-pfq_series_direct.c
@@ -12,7 +12,7 @@
 #include "acb_poly.h"
 #include "acb_hypgeom.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/acb_hypgeom/test/t-pfq_series_sum_bs.c
+++ b/src/acb_hypgeom/test/t-pfq_series_sum_bs.c
@@ -12,7 +12,7 @@
 #include "acb_poly.h"
 #include "acb_hypgeom.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/acb_hypgeom/test/t-pfq_series_sum_rs.c
+++ b/src/acb_hypgeom/test/t-pfq_series_sum_rs.c
@@ -12,7 +12,7 @@
 #include "acb_poly.h"
 #include "acb_hypgeom.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/acb_hypgeom/test/t-pfq_sum_bs.c
+++ b/src/acb_hypgeom/test/t-pfq_sum_bs.c
@@ -12,7 +12,7 @@
 #include "acb.h"
 #include "acb_hypgeom.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/acb_hypgeom/test/t-pfq_sum_fme.c
+++ b/src/acb_hypgeom/test/t-pfq_sum_fme.c
@@ -12,7 +12,7 @@
 #include "acb.h"
 #include "acb_hypgeom.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/acb_hypgeom/test/t-pfq_sum_invz.c
+++ b/src/acb_hypgeom/test/t-pfq_sum_invz.c
@@ -12,7 +12,7 @@
 #include "acb.h"
 #include "acb_hypgeom.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/acb_hypgeom/test/t-pfq_sum_rs.c
+++ b/src/acb_hypgeom/test/t-pfq_sum_rs.c
@@ -12,7 +12,7 @@
 #include "acb.h"
 #include "acb_hypgeom.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/acb_hypgeom/test/t-rising_ui.c
+++ b/src/acb_hypgeom/test/t-rising_ui.c
@@ -34,7 +34,7 @@ rising_algorithm(acb_t res, const acb_t x, ulong n, ulong m, slong prec, int alg
         acb_hypgeom_rising_ui(res, x, n, prec);
 }
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/acb_hypgeom/test/t-rising_ui_jet.c
+++ b/src/acb_hypgeom/test/t-rising_ui_jet.c
@@ -25,7 +25,7 @@ rising_algorithm(acb_ptr res, const acb_t x, ulong n, ulong m, slong len, slong 
         acb_hypgeom_rising_ui_jet(res, x, n, len, prec);
 }
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/acb_hypgeom/test/t-shi_series.c
+++ b/src/acb_hypgeom/test/t-shi_series.c
@@ -12,7 +12,7 @@
 #include "acb_poly.h"
 #include "acb_hypgeom.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/acb_hypgeom/test/t-si.c
+++ b/src/acb_hypgeom/test/t-si.c
@@ -12,7 +12,7 @@
 #include "acb.h"
 #include "acb_hypgeom.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/acb_hypgeom/test/t-si_series.c
+++ b/src/acb_hypgeom/test/t-si_series.c
@@ -12,7 +12,7 @@
 #include "acb_poly.h"
 #include "acb_hypgeom.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/acb_hypgeom/test/t-spherical_y.c
+++ b/src/acb_hypgeom/test/t-spherical_y.c
@@ -97,7 +97,7 @@ static const double testdata[] = {
     0.00051935757617903067671, -0.0014726339944978705874,
 };
 
-int main()
+int main(void)
 {
     flint_printf("spherical_y....");
     fflush(stdout);

--- a/src/acb_hypgeom/test/t-u.c
+++ b/src/acb_hypgeom/test/t-u.c
@@ -23,7 +23,7 @@ acb_hypgeom_u_asymp_proper(acb_t res, const acb_t a, const acb_t b, const acb_t 
     acb_clear(t);
 }
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/acb_hypgeom/test/t-u_asymp.c
+++ b/src/acb_hypgeom/test/t-u_asymp.c
@@ -12,7 +12,7 @@
 #include "acb.h"
 #include "acb_hypgeom.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/acb_mat/test/t-approx_eig_qr.c
+++ b/src/acb_mat/test/t-approx_eig_qr.c
@@ -11,7 +11,7 @@
 
 #include "acb_mat.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/acb_mat/test/t-det.c
+++ b/src/acb_mat/test/t-det.c
@@ -13,7 +13,7 @@
 #include "fmpq_mat.h"
 #include "acb_mat.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/acb_mat/test/t-det_precond.c
+++ b/src/acb_mat/test/t-det_precond.c
@@ -13,7 +13,7 @@
 #include "fmpq_mat.h"
 #include "acb_mat.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/acb_mat/test/t-dft.c
+++ b/src/acb_mat/test/t-dft.c
@@ -11,7 +11,7 @@
 
 #include "acb_mat.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/acb_mat/test/t-eig_enclosure_rump.c
+++ b/src/acb_mat/test/t-eig_enclosure_rump.c
@@ -11,7 +11,7 @@
 
 #include "acb_mat.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/acb_mat/test/t-eig_global_enclosure.c
+++ b/src/acb_mat/test/t-eig_global_enclosure.c
@@ -11,7 +11,7 @@
 
 #include "acb_mat.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/acb_mat/test/t-eig_multiple.c
+++ b/src/acb_mat/test/t-eig_multiple.c
@@ -12,7 +12,7 @@
 #include "fmpq_mat.h"
 #include "acb_mat.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/acb_mat/test/t-eig_simple.c
+++ b/src/acb_mat/test/t-eig_simple.c
@@ -13,7 +13,7 @@
 #include "acb_poly.h"
 #include "acb_mat.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/acb_mat/test/t-exp.c
+++ b/src/acb_mat/test/t-exp.c
@@ -34,7 +34,7 @@ _fmpq_mat_randtest_for_exp(fmpq_mat_t mat, flint_rand_t state, flint_bitcnt_t bi
     }
 }
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/acb_mat/test/t-exp_taylor_sum.c
+++ b/src/acb_mat/test/t-exp_taylor_sum.c
@@ -11,7 +11,7 @@
 
 #include "acb_mat.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/acb_mat/test/t-frobenius_norm.c
+++ b/src/acb_mat/test/t-frobenius_norm.c
@@ -54,7 +54,7 @@ _fmpq_mat_sum_of_squares(fmpq_t res, const fmpq_mat_t Q)
     }
 }
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/acb_mat/test/t-inv.c
+++ b/src/acb_mat/test/t-inv.c
@@ -12,7 +12,7 @@
 #include "fmpq_mat.h"
 #include "acb_mat.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/acb_mat/test/t-lu.c
+++ b/src/acb_mat/test/t-lu.c
@@ -25,7 +25,7 @@ int fmpq_mat_is_invertible(const fmpq_mat_t A)
     return r;
 }
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/acb_mat/test/t-lu_recursive.c
+++ b/src/acb_mat/test/t-lu_recursive.c
@@ -25,7 +25,7 @@ int fmpq_mat_is_invertible(const fmpq_mat_t A)
     return r;
 }
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/acb_mat/test/t-mul.c
+++ b/src/acb_mat/test/t-mul.c
@@ -27,7 +27,7 @@ _acb_mat_nprintd(const char * name, acb_mat_t mat)
     flint_printf("\n\n");
 }
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/acb_mat/test/t-mul_entrywise.c
+++ b/src/acb_mat/test/t-mul_entrywise.c
@@ -28,7 +28,7 @@ _fmpq_mat_mul_entrywise(fmpq_mat_t C, const fmpq_mat_t A, const fmpq_mat_t B)
     }
 }
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/acb_mat/test/t-mul_reorder.c
+++ b/src/acb_mat/test/t-mul_reorder.c
@@ -27,7 +27,7 @@ _acb_mat_nprintd(const char * name, acb_mat_t mat)
     flint_printf("\n\n");
 }
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/acb_mat/test/t-mul_threaded.c
+++ b/src/acb_mat/test/t-mul_threaded.c
@@ -12,7 +12,7 @@
 #include "fmpq_mat.h"
 #include "acb_mat.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/acb_mat/test/t-solve.c
+++ b/src/acb_mat/test/t-solve.c
@@ -12,7 +12,7 @@
 #include "fmpq_mat.h"
 #include "acb_mat.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/acb_mat/test/t-solve_lu.c
+++ b/src/acb_mat/test/t-solve_lu.c
@@ -12,7 +12,7 @@
 #include "fmpq_mat.h"
 #include "acb_mat.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/acb_mat/test/t-solve_precond.c
+++ b/src/acb_mat/test/t-solve_precond.c
@@ -12,7 +12,7 @@
 #include "fmpq_mat.h"
 #include "acb_mat.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/acb_mat/test/t-solve_tril.c
+++ b/src/acb_mat/test/t-solve_tril.c
@@ -11,7 +11,7 @@
 
 #include "acb_mat.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/acb_mat/test/t-solve_triu.c
+++ b/src/acb_mat/test/t-solve_triu.c
@@ -11,7 +11,7 @@
 
 #include "acb_mat.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/acb_mat/test/t-sqr.c
+++ b/src/acb_mat/test/t-sqr.c
@@ -12,7 +12,7 @@
 #include "fmpq_mat.h"
 #include "acb_mat.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/acb_mat/test/t-trace.c
+++ b/src/acb_mat/test/t-trace.c
@@ -13,7 +13,7 @@
 #include "fmpq_mat.h"
 #include "acb_mat.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/acb_mat/test/t-transpose.c
+++ b/src/acb_mat/test/t-transpose.c
@@ -11,7 +11,7 @@
 
 #include "acb_mat.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/acb_modular/hilbert_class_poly.c
+++ b/src/acb_modular/hilbert_class_poly.c
@@ -134,7 +134,7 @@ _acb_modular_hilbert_class_poly(fmpz_poly_t res, slong D,
 void
 acb_modular_hilbert_class_poly(fmpz_poly_t res, slong D)
 {
-    slong i, a, b, c, ac, h, qbf_alloc, qbf_len, prec;
+    slong i, a, b, c, ac, qbf_alloc, qbf_len, prec;
     slong * qbf;
     double lgh;
 
@@ -147,7 +147,6 @@ acb_modular_hilbert_class_poly(fmpz_poly_t res, slong D)
     qbf_alloc = qbf_len = 0;
     qbf = NULL;
     b = D & 1;
-    h = 0;
 
     /* Cohen algorithm 5.3.5 */
     do
@@ -172,7 +171,6 @@ acb_modular_hilbert_class_poly(fmpz_poly_t res, slong D)
                     qbf[3 * qbf_len + 0] = a;
                     qbf[3 * qbf_len + 1] = b;
                     qbf[3 * qbf_len + 2] = c;
-                    h += 1;
                 }
                 else
                 {
@@ -180,7 +178,6 @@ acb_modular_hilbert_class_poly(fmpz_poly_t res, slong D)
                     qbf[3 * qbf_len + 0] = a;
                     qbf[3 * qbf_len + 1] = -b;
                     qbf[3 * qbf_len + 2] = c;
-                    h += 2;
                 }
 
                 qbf_len++;

--- a/src/acb_modular/test/t-delta.c
+++ b/src/acb_modular/test/t-delta.c
@@ -12,7 +12,7 @@
 #include "acb.h"
 #include "acb_modular.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/acb_modular/test/t-eisenstein.c
+++ b/src/acb_modular/test/t-eisenstein.c
@@ -12,7 +12,7 @@
 #include "acb.h"
 #include "acb_modular.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/acb_modular/test/t-elliptic_e.c
+++ b/src/acb_modular/test/t-elliptic_e.c
@@ -12,7 +12,7 @@
 #include "acb.h"
 #include "acb_modular.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/acb_modular/test/t-elliptic_k.c
+++ b/src/acb_modular/test/t-elliptic_k.c
@@ -42,7 +42,7 @@ const double k_testdata[NUM_TESTS][10] = {
         -0.01044301570409968822, -0.0013811810360989366762, -0.0011248246747562196271}
 };
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/acb_modular/test/t-elliptic_p.c
+++ b/src/acb_modular/test/t-elliptic_p.c
@@ -38,7 +38,7 @@ acb_set_dddd(acb_t z, double a, double ar, double b, double br)
     mag_set_d(arb_radref(acb_imagref(z)), br);
 }
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/acb_modular/test/t-elliptic_p_zpx.c
+++ b/src/acb_modular/test/t-elliptic_p_zpx.c
@@ -12,7 +12,7 @@
 #include "acb_poly.h"
 #include "acb_modular.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/acb_modular/test/t-epsilon_arg.c
+++ b/src/acb_modular/test/t-epsilon_arg.c
@@ -49,7 +49,7 @@ acb_modular_epsilon_arg_naive(fmpq_t arg, const psl2z_t g)
 #undef d
 }
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/acb_modular/test/t-eta.c
+++ b/src/acb_modular/test/t-eta.c
@@ -13,7 +13,7 @@
 #include "acb.h"
 #include "acb_modular.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/acb_modular/test/t-fundamental_domain_approx.c
+++ b/src/acb_modular/test/t-fundamental_domain_approx.c
@@ -13,7 +13,7 @@
 #include "acb.h"
 #include "acb_modular.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/acb_modular/test/t-hilbert_class_poly.c
+++ b/src/acb_modular/test/t-hilbert_class_poly.c
@@ -114,7 +114,7 @@ static const int hilbert_poly_values_2[] = {
     0, 0,
 };
 
-int main()
+int main(void)
 {
     flint_printf("hilbert_class_poly....");
     fflush(stdout);

--- a/src/acb_modular/test/t-j.c
+++ b/src/acb_modular/test/t-j.c
@@ -12,7 +12,7 @@
 #include "acb.h"
 #include "acb_modular.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/acb_modular/test/t-lambda.c
+++ b/src/acb_modular/test/t-lambda.c
@@ -12,7 +12,7 @@
 #include "acb.h"
 #include "acb_modular.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/acb_modular/test/t-psl2z_inv.c
+++ b/src/acb_modular/test/t-psl2z_inv.c
@@ -12,7 +12,7 @@
 #include "arb.h"
 #include "acb_modular.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/acb_modular/test/t-psl2z_mul.c
+++ b/src/acb_modular/test/t-psl2z_mul.c
@@ -12,7 +12,7 @@
 #include "arb.h"
 #include "acb_modular.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/acb_modular/test/t-theta.c
+++ b/src/acb_modular/test/t-theta.c
@@ -12,7 +12,7 @@
 #include "acb.h"
 #include "acb_modular.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/acb_modular/test/t-theta_const_sum_rs.c
+++ b/src/acb_modular/test/t-theta_const_sum_rs.c
@@ -12,7 +12,7 @@
 #include "acb.h"
 #include "acb_modular.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/acb_modular/test/t-theta_jet.c
+++ b/src/acb_modular/test/t-theta_jet.c
@@ -12,7 +12,7 @@
 #include "acb.h"
 #include "acb_modular.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/acb_modular/test/t-theta_series.c
+++ b/src/acb_modular/test/t-theta_series.c
@@ -13,7 +13,7 @@
 #include "acb_poly.h"
 #include "acb_modular.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/acb_modular/test/t-theta_sum.c
+++ b/src/acb_modular/test/t-theta_sum.c
@@ -12,7 +12,7 @@
 #include "acb.h"
 #include "acb_modular.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/acb_modular/test/t-transform.c
+++ b/src/acb_modular/test/t-transform.c
@@ -12,7 +12,7 @@
 #include "acb.h"
 #include "acb_modular.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/acb_poly/test/t-add.c
+++ b/src/acb_poly/test/t-add.c
@@ -12,7 +12,7 @@
 #include "fmpq_poly.h"
 #include "acb_poly.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/acb_poly/test/t-add_series.c
+++ b/src/acb_poly/test/t-add_series.c
@@ -12,7 +12,7 @@
 #include "acb_poly.h"
 
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/acb_poly/test/t-add_si.c
+++ b/src/acb_poly/test/t-add_si.c
@@ -11,7 +11,7 @@
 
 #include "acb_poly.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/acb_poly/test/t-agm1_series.c
+++ b/src/acb_poly/test/t-agm1_series.c
@@ -11,7 +11,7 @@
 
 #include "acb_poly.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/acb_poly/test/t-atan_series.c
+++ b/src/acb_poly/test/t-atan_series.c
@@ -12,7 +12,7 @@
 #include "fmpq_poly.h"
 #include "acb_poly.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/acb_poly/test/t-binomial_transform.c
+++ b/src/acb_poly/test/t-binomial_transform.c
@@ -11,7 +11,7 @@
 
 #include "acb_poly.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/acb_poly/test/t-binomial_transform_basecase.c
+++ b/src/acb_poly/test/t-binomial_transform_basecase.c
@@ -11,7 +11,7 @@
 
 #include "acb_poly.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/acb_poly/test/t-binomial_transform_convolution.c
+++ b/src/acb_poly/test/t-binomial_transform_convolution.c
@@ -11,7 +11,7 @@
 
 #include "acb_poly.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/acb_poly/test/t-borel_transform.c
+++ b/src/acb_poly/test/t-borel_transform.c
@@ -11,7 +11,7 @@
 
 #include "acb_poly.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/acb_poly/test/t-compose.c
+++ b/src/acb_poly/test/t-compose.c
@@ -12,7 +12,7 @@
 #include "fmpq_poly.h"
 #include "acb_poly.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/acb_poly/test/t-compose_series.c
+++ b/src/acb_poly/test/t-compose_series.c
@@ -12,7 +12,7 @@
 #include "fmpq_poly.h"
 #include "acb_poly.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/acb_poly/test/t-cos_pi_series.c
+++ b/src/acb_poly/test/t-cos_pi_series.c
@@ -11,7 +11,7 @@
 
 #include "acb_poly.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/acb_poly/test/t-cot_pi_series.c
+++ b/src/acb_poly/test/t-cot_pi_series.c
@@ -11,7 +11,7 @@
 
 #include "acb_poly.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/acb_poly/test/t-digamma_series.c
+++ b/src/acb_poly/test/t-digamma_series.c
@@ -11,7 +11,7 @@
 
 #include "acb_poly.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/acb_poly/test/t-div_series.c
+++ b/src/acb_poly/test/t-div_series.c
@@ -12,7 +12,7 @@
 #include "fmpq_poly.h"
 #include "acb_poly.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/acb_poly/test/t-divrem.c
+++ b/src/acb_poly/test/t-divrem.c
@@ -12,7 +12,7 @@
 #include "fmpq_poly.h"
 #include "acb_poly.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/acb_poly/test/t-elliptic_k_series.c
+++ b/src/acb_poly/test/t-elliptic_k_series.c
@@ -11,7 +11,7 @@
 
 #include "acb_poly.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/acb_poly/test/t-elliptic_p_series.c
+++ b/src/acb_poly/test/t-elliptic_p_series.c
@@ -11,7 +11,7 @@
 
 #include "acb_poly.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/acb_poly/test/t-evaluate.c
+++ b/src/acb_poly/test/t-evaluate.c
@@ -13,7 +13,7 @@
 #include "fmpq_poly.h"
 #include "acb_poly.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/acb_poly/test/t-evaluate2.c
+++ b/src/acb_poly/test/t-evaluate2.c
@@ -11,7 +11,7 @@
 
 #include "acb_poly.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/acb_poly/test/t-evaluate2_horner.c
+++ b/src/acb_poly/test/t-evaluate2_horner.c
@@ -11,7 +11,7 @@
 
 #include "acb_poly.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/acb_poly/test/t-evaluate2_rectangular.c
+++ b/src/acb_poly/test/t-evaluate2_rectangular.c
@@ -11,7 +11,7 @@
 
 #include "acb_poly.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/acb_poly/test/t-evaluate_horner.c
+++ b/src/acb_poly/test/t-evaluate_horner.c
@@ -13,7 +13,7 @@
 #include "fmpq_poly.h"
 #include "acb_poly.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/acb_poly/test/t-evaluate_rectangular.c
+++ b/src/acb_poly/test/t-evaluate_rectangular.c
@@ -11,7 +11,7 @@
 
 #include "acb_poly.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/acb_poly/test/t-evaluate_vec_fast.c
+++ b/src/acb_poly/test/t-evaluate_vec_fast.c
@@ -14,7 +14,7 @@
 #include "fmpq_poly.h"
 #include "acb_poly.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/acb_poly/test/t-evaluate_vec_iter.c
+++ b/src/acb_poly/test/t-evaluate_vec_iter.c
@@ -14,7 +14,7 @@
 #include "fmpq_poly.h"
 #include "acb_poly.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/acb_poly/test/t-exp_pi_i_series.c
+++ b/src/acb_poly/test/t-exp_pi_i_series.c
@@ -11,7 +11,7 @@
 
 #include "acb_poly.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/acb_poly/test/t-exp_series.c
+++ b/src/acb_poly/test/t-exp_series.c
@@ -13,7 +13,7 @@
 
 FLINT_DLL extern slong acb_poly_newton_exp_cutoff;
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/acb_poly/test/t-exp_series_basecase.c
+++ b/src/acb_poly/test/t-exp_series_basecase.c
@@ -11,7 +11,7 @@
 
 #include "acb_poly.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/acb_poly/test/t-find_roots.c
+++ b/src/acb_poly/test/t-find_roots.c
@@ -12,7 +12,7 @@
 #include "acb_poly.h"
 
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/acb_poly/test/t-gamma_series.c
+++ b/src/acb_poly/test/t-gamma_series.c
@@ -11,7 +11,7 @@
 
 #include "acb_poly.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/acb_poly/test/t-get_unique_fmpz_poly.c
+++ b/src/acb_poly/test/t-get_unique_fmpz_poly.c
@@ -12,7 +12,7 @@
 #include "fmpz_poly.h"
 #include "acb_poly.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/acb_poly/test/t-graeffe_transform.c
+++ b/src/acb_poly/test/t-graeffe_transform.c
@@ -11,7 +11,7 @@
 
 #include "acb_poly.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/acb_poly/test/t-interpolate_barycentric.c
+++ b/src/acb_poly/test/t-interpolate_barycentric.c
@@ -13,7 +13,7 @@
 #include "fmpq_poly.h"
 #include "acb_poly.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/acb_poly/test/t-interpolate_fast.c
+++ b/src/acb_poly/test/t-interpolate_fast.c
@@ -13,7 +13,7 @@
 #include "fmpq_poly.h"
 #include "acb_poly.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/acb_poly/test/t-interpolate_newton.c
+++ b/src/acb_poly/test/t-interpolate_newton.c
@@ -13,7 +13,7 @@
 #include "fmpq_poly.h"
 #include "acb_poly.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/acb_poly/test/t-inv_series.c
+++ b/src/acb_poly/test/t-inv_series.c
@@ -12,7 +12,7 @@
 #include "fmpq_poly.h"
 #include "acb_poly.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/acb_poly/test/t-lambertw_series.c
+++ b/src/acb_poly/test/t-lambertw_series.c
@@ -11,7 +11,7 @@
 
 #include "acb_poly.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/acb_poly/test/t-lgamma_series.c
+++ b/src/acb_poly/test/t-lgamma_series.c
@@ -11,7 +11,7 @@
 
 #include "acb_poly.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/acb_poly/test/t-log1p_series.c
+++ b/src/acb_poly/test/t-log1p_series.c
@@ -11,7 +11,7 @@
 
 #include "acb_poly.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/acb_poly/test/t-log_series.c
+++ b/src/acb_poly/test/t-log_series.c
@@ -12,7 +12,7 @@
 #include "fmpq_poly.h"
 #include "acb_poly.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/acb_poly/test/t-mullow.c
+++ b/src/acb_poly/test/t-mullow.c
@@ -12,7 +12,7 @@
 #include "fmpq_poly.h"
 #include "acb_poly.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/acb_poly/test/t-mullow_classical.c
+++ b/src/acb_poly/test/t-mullow_classical.c
@@ -12,7 +12,7 @@
 #include "fmpq_poly.h"
 #include "acb_poly.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/acb_poly/test/t-mullow_transpose.c
+++ b/src/acb_poly/test/t-mullow_transpose.c
@@ -12,7 +12,7 @@
 #include "fmpq_poly.h"
 #include "acb_poly.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/acb_poly/test/t-mullow_transpose_gauss.c
+++ b/src/acb_poly/test/t-mullow_transpose_gauss.c
@@ -12,7 +12,7 @@
 #include "fmpq_poly.h"
 #include "acb_poly.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/acb_poly/test/t-polylog_cpx.c
+++ b/src/acb_poly/test/t-polylog_cpx.c
@@ -248,7 +248,7 @@ const double polylog_testdata[NUM_TESTS][10] = {
     0.0780220225006149953, 0.0215283250955342792},
 };
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/acb_poly/test/t-polylog_series.c
+++ b/src/acb_poly/test/t-polylog_series.c
@@ -11,7 +11,7 @@
 
 #include "acb_poly.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/acb_poly/test/t-pow_acb_series.c
+++ b/src/acb_poly/test/t-pow_acb_series.c
@@ -11,7 +11,7 @@
 
 #include "acb_poly.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/acb_poly/test/t-pow_series.c
+++ b/src/acb_poly/test/t-pow_series.c
@@ -11,7 +11,7 @@
 
 #include "acb_poly.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/acb_poly/test/t-pow_ui.c
+++ b/src/acb_poly/test/t-pow_ui.c
@@ -12,7 +12,7 @@
 #include "fmpz_poly.h"
 #include "acb_poly.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/acb_poly/test/t-pow_ui_trunc_binexp.c
+++ b/src/acb_poly/test/t-pow_ui_trunc_binexp.c
@@ -12,7 +12,7 @@
 #include "fmpz_poly.h"
 #include "acb_poly.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/acb_poly/test/t-powsum_one_series_sieved.c
+++ b/src/acb_poly/test/t-powsum_one_series_sieved.c
@@ -11,7 +11,7 @@
 
 #include "acb_poly.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/acb_poly/test/t-powsum_series_naive_threaded.c
+++ b/src/acb_poly/test/t-powsum_series_naive_threaded.c
@@ -11,7 +11,7 @@
 
 #include "acb_poly.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/acb_poly/test/t-product_roots.c
+++ b/src/acb_poly/test/t-product_roots.c
@@ -11,7 +11,7 @@
 
 #include "acb_poly.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/acb_poly/test/t-revert_series.c
+++ b/src/acb_poly/test/t-revert_series.c
@@ -12,7 +12,7 @@
 #include "fmpq_poly.h"
 #include "acb_poly.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/acb_poly/test/t-revert_series_lagrange.c
+++ b/src/acb_poly/test/t-revert_series_lagrange.c
@@ -12,7 +12,7 @@
 #include "fmpq_poly.h"
 #include "acb_poly.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/acb_poly/test/t-revert_series_lagrange_fast.c
+++ b/src/acb_poly/test/t-revert_series_lagrange_fast.c
@@ -12,7 +12,7 @@
 #include "fmpq_poly.h"
 #include "acb_poly.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/acb_poly/test/t-revert_series_newton.c
+++ b/src/acb_poly/test/t-revert_series_newton.c
@@ -12,7 +12,7 @@
 #include "fmpq_poly.h"
 #include "acb_poly.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/acb_poly/test/t-rgamma_series.c
+++ b/src/acb_poly/test/t-rgamma_series.c
@@ -11,7 +11,7 @@
 
 #include "acb_poly.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/acb_poly/test/t-rising_ui_series.c
+++ b/src/acb_poly/test/t-rising_ui_series.c
@@ -12,7 +12,7 @@
 #include "acb_poly.h"
 
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/acb_poly/test/t-root_bound_fujiwara.c
+++ b/src/acb_poly/test/t-root_bound_fujiwara.c
@@ -11,7 +11,7 @@
 
 #include "acb_poly.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/acb_poly/test/t-rsqrt_series.c
+++ b/src/acb_poly/test/t-rsqrt_series.c
@@ -12,7 +12,7 @@
 #include "fmpq_poly.h"
 #include "acb_poly.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/acb_poly/test/t-sin_cos_pi_series.c
+++ b/src/acb_poly/test/t-sin_cos_pi_series.c
@@ -12,7 +12,7 @@
 #include "fmpq_poly.h"
 #include "acb_poly.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/acb_poly/test/t-sin_cos_series.c
+++ b/src/acb_poly/test/t-sin_cos_series.c
@@ -12,7 +12,7 @@
 #include "fmpq_poly.h"
 #include "acb_poly.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/acb_poly/test/t-sin_pi_series.c
+++ b/src/acb_poly/test/t-sin_pi_series.c
@@ -11,7 +11,7 @@
 
 #include "acb_poly.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/acb_poly/test/t-sin_series_cos_series.c
+++ b/src/acb_poly/test/t-sin_series_cos_series.c
@@ -12,7 +12,7 @@
 #include "fmpq_poly.h"
 #include "acb_poly.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/acb_poly/test/t-sinc_series.c
+++ b/src/acb_poly/test/t-sinc_series.c
@@ -11,7 +11,7 @@
 
 #include "acb_poly.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/acb_poly/test/t-sinh_cosh_series.c
+++ b/src/acb_poly/test/t-sinh_cosh_series.c
@@ -11,7 +11,7 @@
 
 #include "acb_poly.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/acb_poly/test/t-sqrt_series.c
+++ b/src/acb_poly/test/t-sqrt_series.c
@@ -12,7 +12,7 @@
 #include "fmpq_poly.h"
 #include "acb_poly.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/acb_poly/test/t-sub.c
+++ b/src/acb_poly/test/t-sub.c
@@ -12,7 +12,7 @@
 #include "fmpq_poly.h"
 #include "acb_poly.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/acb_poly/test/t-sub_series.c
+++ b/src/acb_poly/test/t-sub_series.c
@@ -12,7 +12,7 @@
 #include "acb_poly.h"
 
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/acb_poly/test/t-tan_series.c
+++ b/src/acb_poly/test/t-tan_series.c
@@ -11,7 +11,7 @@
 
 #include "acb_poly.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/acb_poly/test/t-taylor_shift.c
+++ b/src/acb_poly/test/t-taylor_shift.c
@@ -11,7 +11,7 @@
 
 #include "acb_poly.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/acb_poly/test/t-zeta_cpx_series.c
+++ b/src/acb_poly/test/t-zeta_cpx_series.c
@@ -11,7 +11,7 @@
 
 #include "acb_poly.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/acb_poly/test/t-zeta_em_tail_bsplit.c
+++ b/src/acb_poly/test/t-zeta_em_tail_bsplit.c
@@ -11,7 +11,7 @@
 
 #include "acb_poly.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/acb_poly/test/t-zeta_series.c
+++ b/src/acb_poly/test/t-zeta_series.c
@@ -11,7 +11,7 @@
 
 #include "acb_poly.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/acf/test/t-approx_dot.c
+++ b/src/acf/test/t-approx_dot.c
@@ -12,7 +12,7 @@
 #include "acf.h"
 #include "acb.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/acf/test/t-init_clear.c
+++ b/src/acf/test/t-init_clear.c
@@ -11,7 +11,7 @@
 
 #include "acf.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/arb/exp_arf_bb.c
+++ b/src/arb/exp_arf_bb.c
@@ -151,7 +151,7 @@ _arb_vec_prod_bsplit_threaded(arb_t res, arb_srcptr vec, slong len, slong prec)
 void
 arb_exp_arf_bb(arb_t z, const arf_t x, slong prec, int minus_one)
 {
-    slong k, iter, bits, r, mag, q, wp, N;
+    slong k, bits, r, mag, q, wp, N;
     slong argred_bits, start_bits;
     slong num_threads;
     flint_bitcnt_t Qexp[1];
@@ -227,8 +227,7 @@ arb_exp_arf_bb(arb_t z, const arf_t x, slong prec, int minus_one)
     if (num_threads == 1 || prec >= 1e9)
     {
         /* Bit-burst loop. */
-        for (iter = 0, bits = start_bits; !fmpz_is_zero(t);
-            iter++, bits *= 2)
+        for (bits = start_bits; !fmpz_is_zero(t); bits *= 2)
         {
             /* Extract bits. */
             r = FLINT_MIN(bits, wp);
@@ -281,8 +280,7 @@ arb_exp_arf_bb(arb_t z, const arf_t x, slong prec, int minus_one)
         rs = flint_malloc(sizeof(slong) * FLINT_BITS);
 
         /* Bit-burst loop. */
-        for (iter = 0, bits = start_bits; !fmpz_is_zero(t);
-            iter++, bits *= 2)
+        for (bits = start_bits; !fmpz_is_zero(t); bits *= 2)
         {
             /* Extract bits. */
             r = FLINT_MIN(bits, wp);

--- a/src/arb/sin_cos_arf_bb.c
+++ b/src/arb/sin_cos_arf_bb.c
@@ -411,7 +411,7 @@ _acb_vec_prod_bsplit_threaded(acb_t res, acb_ptr vec, slong len, slong prec)
 void
 arb_sin_cos_arf_bb(arb_t zsin, arb_t zcos, const arf_t x, slong prec)
 {
-    slong k, iter, bits, r, xmag, q, wp;
+    slong k, bits, r, xmag, q, wp;
     slong argred_bits, start_bits;
     int inexact, negative;
     fmpz_t t, u;
@@ -484,7 +484,7 @@ arb_sin_cos_arf_bb(arb_t zsin, arb_t zcos, const arf_t x, slong prec)
     if (flint_get_num_available_threads() == 1 || prec >= 4e8)
     {
         /* Bit-burst loop. */
-        for (iter = 0, bits = start_bits; !fmpz_is_zero(t); iter++, bits *= 3)
+        for (bits = start_bits; !fmpz_is_zero(t); bits *= 3)
         {
             /* Extract bits. */
             r = FLINT_MIN(bits, wp);
@@ -521,8 +521,7 @@ arb_sin_cos_arf_bb(arb_t zsin, arb_t zcos, const arf_t x, slong prec)
         rs = flint_malloc(sizeof(slong) * FLINT_BITS);
 
         /* Bit-burst loop. */
-        for (iter = 0, bits = start_bits; !fmpz_is_zero(t);
-            iter++, bits *= 3)
+        for (bits = start_bits; !fmpz_is_zero(t); bits *= 3)
         {
             /* Extract bits. */
             r = FLINT_MIN(bits, wp);

--- a/src/arb/test/t-acos.c
+++ b/src/arb/test/t-acos.c
@@ -13,7 +13,7 @@
 #include "fmpq.h"
 #include "arb.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/arb/test/t-acosh.c
+++ b/src/arb/test/t-acosh.c
@@ -11,7 +11,7 @@
 
 #include "arb.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/arb/test/t-add.c
+++ b/src/arb/test/t-add.c
@@ -12,7 +12,7 @@
 #include "fmpq.h"
 #include "arb.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/arb/test/t-add_arf.c
+++ b/src/arb/test/t-add_arf.c
@@ -11,7 +11,7 @@
 
 #include "arb.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/arb/test/t-add_error.c
+++ b/src/arb/test/t-add_error.c
@@ -11,7 +11,7 @@
 
 #include "arb.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/arb/test/t-add_fmpz.c
+++ b/src/arb/test/t-add_fmpz.c
@@ -11,7 +11,7 @@
 
 #include "arb.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/arb/test/t-add_fmpz_2exp.c
+++ b/src/arb/test/t-add_fmpz_2exp.c
@@ -11,7 +11,7 @@
 
 #include "arb.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/arb/test/t-add_si.c
+++ b/src/arb/test/t-add_si.c
@@ -12,7 +12,7 @@
 #include "arb.h"
 #include "long_extras.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/arb/test/t-add_ui.c
+++ b/src/arb/test/t-add_ui.c
@@ -12,7 +12,7 @@
 #include "arb.h"
 #include "ulong_extras.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/arb/test/t-addmul.c
+++ b/src/arb/test/t-addmul.c
@@ -63,7 +63,7 @@ arb_addmul_naive(arb_t z, const arb_t x, const arb_t y, slong prec)
     arb_clear(t);
 }
 
-int main()
+int main(void)
 {
     slong iter, iter2;
     flint_rand_t state;

--- a/src/arb/test/t-addmul_arf.c
+++ b/src/arb/test/t-addmul_arf.c
@@ -11,7 +11,7 @@
 
 #include "arb.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/arb/test/t-addmul_fmpz.c
+++ b/src/arb/test/t-addmul_fmpz.c
@@ -11,7 +11,7 @@
 
 #include "arb.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/arb/test/t-addmul_si.c
+++ b/src/arb/test/t-addmul_si.c
@@ -12,7 +12,7 @@
 #include "arb.h"
 #include "long_extras.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/arb/test/t-addmul_ui.c
+++ b/src/arb/test/t-addmul_ui.c
@@ -12,7 +12,7 @@
 #include "arb.h"
 #include "ulong_extras.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/arb/test/t-agm.c
+++ b/src/arb/test/t-agm.c
@@ -13,7 +13,7 @@
 #include "fmpq.h"
 #include "arb.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/arb/test/t-approx_dot.c
+++ b/src/arb/test/t-approx_dot.c
@@ -11,7 +11,7 @@
 
 #include "arb.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/arb/test/t-asin.c
+++ b/src/arb/test/t-asin.c
@@ -13,7 +13,7 @@
 #include "fmpq.h"
 #include "arb.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/arb/test/t-asinh.c
+++ b/src/arb/test/t-asinh.c
@@ -11,7 +11,7 @@
 
 #include "arb.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/arb/test/t-atan.c
+++ b/src/arb/test/t-atan.c
@@ -13,7 +13,7 @@
 #include "fmpq.h"
 #include "arb.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/arb/test/t-atan2.c
+++ b/src/arb/test/t-atan2.c
@@ -13,7 +13,7 @@
 #include "fmpq.h"
 #include "arb.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/arb/test/t-atan_arf.c
+++ b/src/arb/test/t-atan_arf.c
@@ -11,7 +11,7 @@
 
 #include "arb.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/arb/test/t-atan_arf_bb.c
+++ b/src/arb/test/t-atan_arf_bb.c
@@ -35,7 +35,7 @@ arb_atan_arf_via_mpfr(arb_t z, const arf_t x, slong prec)
     mpfr_clear(u);
 }
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/arb/test/t-atan_arf_newton.c
+++ b/src/arb/test/t-atan_arf_newton.c
@@ -35,7 +35,7 @@ arb_atan_arf_via_mpfr(arb_t z, const arf_t x, slong prec)
     mpfr_clear(u);
 }
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/arb/test/t-atan_frac_bsplit.c
+++ b/src/arb/test/t-atan_frac_bsplit.c
@@ -17,7 +17,7 @@
 # include <math.h>
 #endif
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/arb/test/t-atan_gauss_primes_vec_bsplit.c
+++ b/src/arb/test/t-atan_gauss_primes_vec_bsplit.c
@@ -22,7 +22,7 @@ static const signed char small_gaussian_primes[] = {
     5, 26, 15, 22, 2, 27, 9, 26
 };
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/arb/test/t-atan_newton.c
+++ b/src/arb/test/t-atan_newton.c
@@ -11,7 +11,7 @@
 
 #include "arb.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/arb/test/t-atan_sum_bs_powtab.c
+++ b/src/arb/test/t-atan_sum_bs_powtab.c
@@ -12,7 +12,7 @@
 #include "fmpq.h"
 #include "arb.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/arb/test/t-atan_tab.c
+++ b/src/arb/test/t-atan_tab.c
@@ -12,7 +12,7 @@
 #include <mpfr.h>
 #include "arb.h"
 
-int main()
+int main(void)
 {
     slong i;
 

--- a/src/arb/test/t-atan_taylor_rs.c
+++ b/src/arb/test/t-atan_taylor_rs.c
@@ -12,7 +12,7 @@
 #include "mpn_extras.h"
 #include "arb.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/arb/test/t-atanh.c
+++ b/src/arb/test/t-atanh.c
@@ -11,7 +11,7 @@
 
 #include "arb.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/arb/test/t-bell_fmpz.c
+++ b/src/arb/test/t-bell_fmpz.c
@@ -11,7 +11,7 @@
 
 #include "arb.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/arb/test/t-bell_sum_taylor.c
+++ b/src/arb/test/t-bell_sum_taylor.c
@@ -11,7 +11,7 @@
 
 #include "arb.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/arb/test/t-bernoulli_poly_ui.c
+++ b/src/arb/test/t-bernoulli_poly_ui.c
@@ -11,7 +11,7 @@
 
 #include "arb.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/arb/test/t-bernoulli_ui.c
+++ b/src/arb/test/t-bernoulli_ui.c
@@ -11,7 +11,7 @@
 
 #include "arb.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/arb/test/t-can_round_mpfr.c
+++ b/src/arb/test/t-can_round_mpfr.c
@@ -12,7 +12,7 @@
 #include <mpfr.h>
 #include "arb.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/arb/test/t-ceil.c
+++ b/src/arb/test/t-ceil.c
@@ -12,7 +12,7 @@
 #include "fmpq.h"
 #include "arb.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/arb/test/t-chebyshev_t_ui.c
+++ b/src/arb/test/t-chebyshev_t_ui.c
@@ -11,7 +11,7 @@
 
 #include "arb.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/arb/test/t-chebyshev_u_ui.c
+++ b/src/arb/test/t-chebyshev_u_ui.c
@@ -11,7 +11,7 @@
 
 #include "arb.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/arb/test/t-const_apery.c
+++ b/src/arb/test/t-const_apery.c
@@ -12,7 +12,7 @@
 #include <mpfr.h>
 #include "arb.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/arb/test/t-const_catalan.c
+++ b/src/arb/test/t-const_catalan.c
@@ -12,7 +12,7 @@
 #include <mpfr.h>
 #include "arb.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/arb/test/t-const_e.c
+++ b/src/arb/test/t-const_e.c
@@ -12,7 +12,7 @@
 #include <mpfr.h>
 #include "arb.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/arb/test/t-const_euler.c
+++ b/src/arb/test/t-const_euler.c
@@ -12,7 +12,7 @@
 #include <mpfr.h>
 #include "arb.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/arb/test/t-const_glaisher.c
+++ b/src/arb/test/t-const_glaisher.c
@@ -11,7 +11,7 @@
 
 #include "arb.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/arb/test/t-const_khinchin.c
+++ b/src/arb/test/t-const_khinchin.c
@@ -11,7 +11,7 @@
 
 #include "arb.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/arb/test/t-const_log10.c
+++ b/src/arb/test/t-const_log10.c
@@ -12,7 +12,7 @@
 #include <mpfr.h>
 #include "arb.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/arb/test/t-const_log2.c
+++ b/src/arb/test/t-const_log2.c
@@ -12,7 +12,7 @@
 #include <mpfr.h>
 #include "arb.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/arb/test/t-const_pi.c
+++ b/src/arb/test/t-const_pi.c
@@ -12,7 +12,7 @@
 #include <mpfr.h>
 #include "arb.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/arb/test/t-contains.c
+++ b/src/arb/test/t-contains.c
@@ -12,7 +12,7 @@
 #include "fmpq.h"
 #include "arb.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/arb/test/t-contains_arf.c
+++ b/src/arb/test/t-contains_arf.c
@@ -12,7 +12,7 @@
 #include "fmpq.h"
 #include "arb.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/arb/test/t-contains_fmpq.c
+++ b/src/arb/test/t-contains_fmpq.c
@@ -12,7 +12,7 @@
 #include "fmpq.h"
 #include "arb.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/arb/test/t-contains_int.c
+++ b/src/arb/test/t-contains_int.c
@@ -11,7 +11,7 @@
 
 #include "arb.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/arb/test/t-contains_interior.c
+++ b/src/arb/test/t-contains_interior.c
@@ -12,7 +12,7 @@
 #include "fmpq.h"
 #include "arb.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/arb/test/t-cos.c
+++ b/src/arb/test/t-cos.c
@@ -13,7 +13,7 @@
 #include "fmpq.h"
 #include "arb.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/arb/test/t-cos_pi.c
+++ b/src/arb/test/t-cos_pi.c
@@ -11,7 +11,7 @@
 
 #include "arb.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/arb/test/t-cos_pi_fmpq.c
+++ b/src/arb/test/t-cos_pi_fmpq.c
@@ -12,7 +12,7 @@
 #include "fmpq.h"
 #include "arb.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/arb/test/t-cos_pi_fmpq_algebraic.c
+++ b/src/arb/test/t-cos_pi_fmpq_algebraic.c
@@ -12,7 +12,7 @@
 #include "ulong_extras.h"
 #include "arb.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/arb/test/t-cosh.c
+++ b/src/arb/test/t-cosh.c
@@ -13,7 +13,7 @@
 #include "fmpq.h"
 #include "arb.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/arb/test/t-cot_pi.c
+++ b/src/arb/test/t-cot_pi.c
@@ -11,7 +11,7 @@
 
 #include "arb.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/arb/test/t-coth.c
+++ b/src/arb/test/t-coth.c
@@ -11,7 +11,7 @@
 
 #include "arb.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/arb/test/t-csc.c
+++ b/src/arb/test/t-csc.c
@@ -11,7 +11,7 @@
 
 #include "arb.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/arb/test/t-csc_pi.c
+++ b/src/arb/test/t-csc_pi.c
@@ -12,7 +12,7 @@
 
 #include "arb.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/arb/test/t-csch.c
+++ b/src/arb/test/t-csch.c
@@ -11,7 +11,7 @@
 
 #include "arb.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/arb/test/t-digamma.c
+++ b/src/arb/test/t-digamma.c
@@ -11,7 +11,7 @@
 
 #include "arb.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/arb/test/t-digits_round_inplace.c
+++ b/src/arb/test/t-digits_round_inplace.c
@@ -12,7 +12,7 @@
 #include <string.h>
 #include "arb.h"
 
-int main()
+int main(void)
 {
     flint_rand_t state;
 

--- a/src/arb/test/t-div.c
+++ b/src/arb/test/t-div.c
@@ -12,7 +12,7 @@
 #include "fmpq.h"
 #include "arb.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/arb/test/t-div_2expm1_ui.c
+++ b/src/arb/test/t-div_2expm1_ui.c
@@ -11,7 +11,7 @@
 
 #include "arb.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/arb/test/t-div_arf.c
+++ b/src/arb/test/t-div_arf.c
@@ -11,7 +11,7 @@
 
 #include "arb.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/arb/test/t-div_fmpz.c
+++ b/src/arb/test/t-div_fmpz.c
@@ -11,7 +11,7 @@
 
 #include "arb.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/arb/test/t-div_si.c
+++ b/src/arb/test/t-div_si.c
@@ -12,7 +12,7 @@
 #include "arb.h"
 #include "long_extras.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/arb/test/t-div_ui.c
+++ b/src/arb/test/t-div_ui.c
@@ -12,7 +12,7 @@
 #include "arb.h"
 #include "ulong_extras.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/arb/test/t-dot.c
+++ b/src/arb/test/t-dot.c
@@ -11,7 +11,7 @@
 
 #include "arb.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/arb/test/t-dot_fmpz.c
+++ b/src/arb/test/t-dot_fmpz.c
@@ -12,7 +12,7 @@
 #include "fmpz_vec.h"
 #include "arb.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/arb/test/t-dot_si.c
+++ b/src/arb/test/t-dot_si.c
@@ -11,7 +11,7 @@
 
 #include "arb.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/arb/test/t-dot_siui.c
+++ b/src/arb/test/t-dot_siui.c
@@ -11,7 +11,7 @@
 
 #include "arb.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/arb/test/t-dot_ui.c
+++ b/src/arb/test/t-dot_ui.c
@@ -11,7 +11,7 @@
 
 #include "arb.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/arb/test/t-dot_uiui.c
+++ b/src/arb/test/t-dot_uiui.c
@@ -11,7 +11,7 @@
 
 #include "arb.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/arb/test/t-doublefac_ui.c
+++ b/src/arb/test/t-doublefac_ui.c
@@ -11,7 +11,7 @@
 
 #include "arb.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/arb/test/t-dump_file.c
+++ b/src/arb/test/t-dump_file.c
@@ -12,7 +12,7 @@
 #include <string.h>
 #include "arb.h"
 
-int main()
+int main(void)
 {
     flint_rand_t state;
     slong iter;

--- a/src/arb/test/t-dump_str.c
+++ b/src/arb/test/t-dump_str.c
@@ -12,7 +12,7 @@
 #include <string.h>
 #include "arb.h"
 
-int main()
+int main(void)
 {
     flint_rand_t state;
     slong iter;

--- a/src/arb/test/t-euler_number_fmpz.c
+++ b/src/arb/test/t-euler_number_fmpz.c
@@ -12,7 +12,7 @@
 #include "arith.h"
 #include "arb.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/arb/test/t-euler_number_ui.c
+++ b/src/arb/test/t-euler_number_ui.c
@@ -41,7 +41,7 @@ divisor_table_odd(unsigned int * tab, slong len)
     }
 }
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/arb/test/t-exp.c
+++ b/src/arb/test/t-exp.c
@@ -33,7 +33,7 @@ void arb_exp_simple(arb_t res, const arb_t x, slong prec)
     mag_clear(u);
 }
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/arb/test/t-exp_arf_bb.c
+++ b/src/arb/test/t-exp_arf_bb.c
@@ -35,7 +35,7 @@ arb_exp_arf_via_mpfr(arb_t z, const arf_t x, slong prec)
     mpfr_clear(u);
 }
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/arb/test/t-exp_arf_rs_generic.c
+++ b/src/arb/test/t-exp_arf_rs_generic.c
@@ -15,7 +15,7 @@
    but it still makes sense to test them explicitly */
 void arb_exp_taylor_sum_rs_generic(arb_t s, const arb_t x, slong N, slong prec);
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/arb/test/t-exp_invexp.c
+++ b/src/arb/test/t-exp_invexp.c
@@ -11,7 +11,7 @@
 
 #include "arb.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/arb/test/t-exp_sum_bs_powtab.c
+++ b/src/arb/test/t-exp_sum_bs_powtab.c
@@ -12,7 +12,7 @@
 #include "fmpq.h"
 #include "arb.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/arb/test/t-exp_tab.c
+++ b/src/arb/test/t-exp_tab.c
@@ -12,7 +12,7 @@
 #include <mpfr.h>
 #include "arb.h"
 
-int main()
+int main(void)
 {
     slong i;
 

--- a/src/arb/test/t-exp_taylor_rs.c
+++ b/src/arb/test/t-exp_taylor_rs.c
@@ -12,7 +12,7 @@
 #include "mpn_extras.h"
 #include "arb.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/arb/test/t-expm1.c
+++ b/src/arb/test/t-expm1.c
@@ -13,7 +13,7 @@
 #include "fmpq.h"
 #include "arb.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/arb/test/t-fac_ui.c
+++ b/src/arb/test/t-fac_ui.c
@@ -11,7 +11,7 @@
 
 #include "arb.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/arb/test/t-fib.c
+++ b/src/arb/test/t-fib.c
@@ -11,7 +11,7 @@
 
 #include "arb.h"
 
-int main()
+int main(void)
 {
     flint_printf("fib....");
     fflush(stdout);

--- a/src/arb/test/t-floor.c
+++ b/src/arb/test/t-floor.c
@@ -12,7 +12,7 @@
 #include "fmpq.h"
 #include "arb.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/arb/test/t-fma.c
+++ b/src/arb/test/t-fma.c
@@ -22,7 +22,7 @@ arb_fma_naive(arb_t res, const arb_t x, const arb_t y, const arb_t z, slong prec
     arb_clear(t);
 }
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/arb/test/t-gamma.c
+++ b/src/arb/test/t-gamma.c
@@ -11,7 +11,7 @@
 
 #include "arb.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/arb/test/t-gamma_fmpq.c
+++ b/src/arb/test/t-gamma_fmpq.c
@@ -19,7 +19,7 @@
 # include <math.h>
 #endif
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/arb/test/t-get_abs_lbound_arf.c
+++ b/src/arb/test/t-get_abs_lbound_arf.c
@@ -12,7 +12,7 @@
 #include "fmpq.h"
 #include "arb.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/arb/test/t-get_fmpz_mid_rad_10exp.c
+++ b/src/arb/test/t-get_fmpz_mid_rad_10exp.c
@@ -11,7 +11,7 @@
 
 #include "arb.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/arb/test/t-get_interval_arf.c
+++ b/src/arb/test/t-get_interval_arf.c
@@ -11,7 +11,7 @@
 
 #include "arb.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/arb/test/t-get_interval_fmpz_2exp.c
+++ b/src/arb/test/t-get_interval_fmpz_2exp.c
@@ -11,7 +11,7 @@
 
 #include "arb.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/arb/test/t-get_interval_mpfr.c
+++ b/src/arb/test/t-get_interval_mpfr.c
@@ -12,7 +12,7 @@
 #include <mpfr.h>
 #include "arb.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/arb/test/t-get_lbound_arf.c
+++ b/src/arb/test/t-get_lbound_arf.c
@@ -12,7 +12,7 @@
 #include "fmpq.h"
 #include "arb.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/arb/test/t-get_mag.c
+++ b/src/arb/test/t-get_mag.c
@@ -11,7 +11,7 @@
 
 #include "arb.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/arb/test/t-get_mag_lower.c
+++ b/src/arb/test/t-get_mag_lower.c
@@ -11,7 +11,7 @@
 
 #include "arb.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/arb/test/t-get_mag_lower_nonnegative.c
+++ b/src/arb/test/t-get_mag_lower_nonnegative.c
@@ -11,7 +11,7 @@
 
 #include "arb.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/arb/test/t-get_mpn_fixed_mod_log2.c
+++ b/src/arb/test/t-get_mpn_fixed_mod_log2.c
@@ -11,7 +11,7 @@
 
 #include "arb.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/arb/test/t-get_mpn_fixed_mod_pi4.c
+++ b/src/arb/test/t-get_mpn_fixed_mod_pi4.c
@@ -11,7 +11,7 @@
 
 #include "arb.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/arb/test/t-get_rand_fmpq.c
+++ b/src/arb/test/t-get_rand_fmpq.c
@@ -12,7 +12,7 @@
 #include "fmpq.h"
 #include "arb.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/arb/test/t-get_str.c
+++ b/src/arb/test/t-get_str.c
@@ -12,7 +12,7 @@
 #include <string.h>
 #include "arb.h"
 
-int main()
+int main(void)
 {
     flint_rand_t state;
     slong iter;

--- a/src/arb/test/t-get_unique_fmpz.c
+++ b/src/arb/test/t-get_unique_fmpz.c
@@ -11,7 +11,7 @@
 
 #include "arb.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/arb/test/t-hurwitz_zeta.c
+++ b/src/arb/test/t-hurwitz_zeta.c
@@ -12,7 +12,7 @@
 #include "arb.h"
 #include "acb.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/arb/test/t-intersection.c
+++ b/src/arb/test/t-intersection.c
@@ -12,7 +12,7 @@
 #include "fmpq.h"
 #include "arb.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/arb/test/t-lambertw.c
+++ b/src/arb/test/t-lambertw.c
@@ -11,7 +11,7 @@
 
 #include "arb.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/arb/test/t-lgamma.c
+++ b/src/arb/test/t-lgamma.c
@@ -11,7 +11,7 @@
 
 #include "arb.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/arb/test/t-log.c
+++ b/src/arb/test/t-log.c
@@ -13,7 +13,7 @@
 #include "fmpq.h"
 #include "arb.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/arb/test/t-log1p.c
+++ b/src/arb/test/t-log1p.c
@@ -11,7 +11,7 @@
 
 #include "arb.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/arb/test/t-log_arf.c
+++ b/src/arb/test/t-log_arf.c
@@ -11,7 +11,7 @@
 
 #include "arb.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/arb/test/t-log_base_ui.c
+++ b/src/arb/test/t-log_base_ui.c
@@ -12,7 +12,7 @@
 #include "ulong_extras.h"
 #include "arb.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/arb/test/t-log_hypot.c
+++ b/src/arb/test/t-log_hypot.c
@@ -11,7 +11,7 @@
 
 #include "arb.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/arb/test/t-log_newton.c
+++ b/src/arb/test/t-log_newton.c
@@ -13,7 +13,7 @@
 #include "fmpq.h"
 #include "arb.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/arb/test/t-log_primes_vec_bsplit.c
+++ b/src/arb/test/t-log_primes_vec_bsplit.c
@@ -12,7 +12,7 @@
 #include "ulong_extras.h"
 #include "arb.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/arb/test/t-log_tab.c
+++ b/src/arb/test/t-log_tab.c
@@ -12,7 +12,7 @@
 #include <mpfr.h>
 #include "arb.h"
 
-int main()
+int main(void)
 {
     slong i;
 

--- a/src/arb/test/t-log_ui_from_prev.c
+++ b/src/arb/test/t-log_ui_from_prev.c
@@ -11,7 +11,7 @@
 
 #include "arb.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/arb/test/t-max.c
+++ b/src/arb/test/t-max.c
@@ -42,7 +42,7 @@ void _sample_arf_in_arb(arf_t x, arb_t y, flint_rand_t state)
     arf_clear(b);
 }
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/arb/test/t-min.c
+++ b/src/arb/test/t-min.c
@@ -42,7 +42,7 @@ void _sample_arf_in_arb(arf_t x, arb_t y, flint_rand_t state)
     arf_clear(b);
 }
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/arb/test/t-mul.c
+++ b/src/arb/test/t-mul.c
@@ -122,7 +122,7 @@ arb_mul_naive(arb_t z, const arb_t x, const arb_t y, slong prec)
     arf_clear(u);
 }
 
-int main()
+int main(void)
 {
     slong iter, iter2;
     flint_rand_t state;

--- a/src/arb/test/t-mul_arf.c
+++ b/src/arb/test/t-mul_arf.c
@@ -11,7 +11,7 @@
 
 #include "arb.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/arb/test/t-mul_fmpz.c
+++ b/src/arb/test/t-mul_fmpz.c
@@ -11,7 +11,7 @@
 
 #include "arb.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/arb/test/t-mul_more.c
+++ b/src/arb/test/t-mul_more.c
@@ -12,7 +12,7 @@
 #include "fmpq.h"
 #include "arb.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/arb/test/t-mul_si.c
+++ b/src/arb/test/t-mul_si.c
@@ -12,7 +12,7 @@
 #include "arb.h"
 #include "long_extras.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/arb/test/t-mul_ui.c
+++ b/src/arb/test/t-mul_ui.c
@@ -12,7 +12,7 @@
 #include "arb.h"
 #include "ulong_extras.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/arb/test/t-nonnegative_abs.c
+++ b/src/arb/test/t-nonnegative_abs.c
@@ -117,7 +117,7 @@ int nearly_equal(const arb_t x, const arb_t y)
     return res;
 }
 
-int main()
+int main(void)
 {
     slong iter, wide;
     flint_rand_t state;

--- a/src/arb/test/t-overlaps.c
+++ b/src/arb/test/t-overlaps.c
@@ -12,7 +12,7 @@
 #include "fmpq.h"
 #include "arb.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/arb/test/t-partitions_fmpz.c
+++ b/src/arb/test/t-partitions_fmpz.c
@@ -11,7 +11,7 @@
 
 #include "arb.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/arb/test/t-pos_times_posinf.c
+++ b/src/arb/test/t-pos_times_posinf.c
@@ -111,7 +111,7 @@ void print_arf_and_type(arf_t x, const char *s, const value_type t)
     flint_printf(" of type: %d\n", t);
 }
 
-int main()
+int main(void)
 {
     slong i, j, k, prec;
     arb_t t, u, v, w;

--- a/src/arb/test/t-pow.c
+++ b/src/arb/test/t-pow.c
@@ -12,7 +12,7 @@
 #include "arb.h"
 #include "double_extras.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/arb/test/t-pow_fmpq.c
+++ b/src/arb/test/t-pow_fmpq.c
@@ -12,7 +12,7 @@
 #include "fmpq.h"
 #include "arb.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/arb/test/t-pow_fmpz.c
+++ b/src/arb/test/t-pow_fmpz.c
@@ -11,7 +11,7 @@
 
 #include "arb.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/arb/test/t-power_sum_vec.c
+++ b/src/arb/test/t-power_sum_vec.c
@@ -11,7 +11,7 @@
 
 #include "arb.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/arb/test/t-primorial.c
+++ b/src/arb/test/t-primorial.c
@@ -12,7 +12,7 @@
 #include "ulong_extras.h"
 #include "arb.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/arb/test/t-rgamma.c
+++ b/src/arb/test/t-rgamma.c
@@ -11,7 +11,7 @@
 
 #include "arb.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/arb/test/t-richcmp.c
+++ b/src/arb/test/t-richcmp.c
@@ -117,7 +117,7 @@ arb_richcmp_fallback(const arb_t x, const arb_t y, int op)
     return res;
 }
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/arb/test/t-rising2_ui.c
+++ b/src/arb/test/t-rising2_ui.c
@@ -13,7 +13,7 @@
 #include "arith.h"
 #include "arb_poly.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/arb/test/t-rising_ui.c
+++ b/src/arb/test/t-rising_ui.c
@@ -12,7 +12,7 @@
 #include "fmpq.h"
 #include "arb.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/arb/test/t-root_ui.c
+++ b/src/arb/test/t-root_ui.c
@@ -11,7 +11,7 @@
 
 #include "arb.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/arb/test/t-rsqrt.c
+++ b/src/arb/test/t-rsqrt.c
@@ -11,7 +11,7 @@
 
 #include "arb.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/arb/test/t-sec.c
+++ b/src/arb/test/t-sec.c
@@ -11,7 +11,7 @@
 
 #include "arb.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/arb/test/t-sech.c
+++ b/src/arb/test/t-sech.c
@@ -11,7 +11,7 @@
 
 #include "arb.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/arb/test/t-set_interval_arf.c
+++ b/src/arb/test/t-set_interval_arf.c
@@ -11,7 +11,7 @@
 
 #include "arb.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/arb/test/t-set_interval_mag.c
+++ b/src/arb/test/t-set_interval_mag.c
@@ -11,7 +11,7 @@
 
 #include "arb.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/arb/test/t-set_interval_mpfr.c
+++ b/src/arb/test/t-set_interval_mpfr.c
@@ -12,7 +12,7 @@
 #include <mpfr.h>
 #include "arb.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/arb/test/t-set_interval_neg_pos_mag.c
+++ b/src/arb/test/t-set_interval_neg_pos_mag.c
@@ -11,7 +11,7 @@
 
 #include "arb.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/arb/test/t-set_str.c
+++ b/src/arb/test/t-set_str.c
@@ -147,7 +147,7 @@ const char * testdata_invalid[] = {
     NULL,
 };
 
-int main()
+int main(void)
 {
     flint_rand_t state;
     arb_t t, u, v;

--- a/src/arb/test/t-sgn.c
+++ b/src/arb/test/t-sgn.c
@@ -11,7 +11,7 @@
 
 #include "arb.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/arb/test/t-sin.c
+++ b/src/arb/test/t-sin.c
@@ -13,7 +13,7 @@
 #include "fmpq.h"
 #include "arb.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/arb/test/t-sin_cos.c
+++ b/src/arb/test/t-sin_cos.c
@@ -13,7 +13,7 @@
 #include "fmpq.h"
 #include "arb.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/arb/test/t-sin_cos_arf_bb.c
+++ b/src/arb/test/t-sin_cos_arf_bb.c
@@ -14,7 +14,7 @@
 void arb_sin_cos_fmpz_div_2exp_bsplit(arb_t wsin, arb_t wcos,
     const fmpz_t x, flint_bitcnt_t r, slong prec);
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/arb/test/t-sin_cos_arf_generic.c
+++ b/src/arb/test/t-sin_cos_arf_generic.c
@@ -16,7 +16,7 @@
 void arb_sin_cos_arf_rs_generic(arb_t res_sin, arb_t res_cos, const arf_t x, slong prec);
 void arb_sin_cos_taylor_sum_rs(arb_t s, const arb_t x, slong N, int cosine, slong prec);
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/arb/test/t-sin_cos_generic.c
+++ b/src/arb/test/t-sin_cos_generic.c
@@ -13,7 +13,7 @@
 #include "fmpq.h"
 #include "arb.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/arb/test/t-sin_cos_pi.c
+++ b/src/arb/test/t-sin_cos_pi.c
@@ -11,7 +11,7 @@
 
 #include "arb.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/arb/test/t-sin_cos_pi_fmpq.c
+++ b/src/arb/test/t-sin_cos_pi_fmpq.c
@@ -12,7 +12,7 @@
 #include "fmpq.h"
 #include "arb.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/arb/test/t-sin_cos_pi_fmpq_algebraic.c
+++ b/src/arb/test/t-sin_cos_pi_fmpq_algebraic.c
@@ -12,7 +12,7 @@
 #include "ulong_extras.h"
 #include "arb.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/arb/test/t-sin_cos_tab.c
+++ b/src/arb/test/t-sin_cos_tab.c
@@ -12,7 +12,7 @@
 #include <mpfr.h>
 #include "arb.h"
 
-int main()
+int main(void)
 {
     slong i, which;
 

--- a/src/arb/test/t-sin_cos_taylor_rs.c
+++ b/src/arb/test/t-sin_cos_taylor_rs.c
@@ -12,7 +12,7 @@
 #include "mpn_extras.h"
 #include "arb.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/arb/test/t-sin_pi.c
+++ b/src/arb/test/t-sin_pi.c
@@ -11,7 +11,7 @@
 
 #include "arb.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/arb/test/t-sin_pi_fmpq.c
+++ b/src/arb/test/t-sin_pi_fmpq.c
@@ -12,7 +12,7 @@
 #include "fmpq.h"
 #include "arb.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/arb/test/t-sin_pi_fmpq_algebraic.c
+++ b/src/arb/test/t-sin_pi_fmpq_algebraic.c
@@ -12,7 +12,7 @@
 #include "ulong_extras.h"
 #include "arb.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/arb/test/t-sinc.c
+++ b/src/arb/test/t-sinc.c
@@ -11,7 +11,7 @@
 
 #include "arb.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/arb/test/t-sinc_pi.c
+++ b/src/arb/test/t-sinc_pi.c
@@ -11,7 +11,7 @@
 
 #include "arb.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/arb/test/t-sinh.c
+++ b/src/arb/test/t-sinh.c
@@ -13,7 +13,7 @@
 #include "fmpq.h"
 #include "arb.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/arb/test/t-sinh_cosh.c
+++ b/src/arb/test/t-sinh_cosh.c
@@ -13,7 +13,7 @@
 #include "fmpq.h"
 #include "arb.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/arb/test/t-special.c
+++ b/src/arb/test/t-special.c
@@ -13,7 +13,7 @@
 
 #define ASSERT(cond) if (!(cond)) { flint_printf("FAIL: %d\n", __LINE__); flint_abort(); }
 
-int main()
+int main(void)
 {
     arb_t zero, pos, neg, pos_inf, neg_inf, pos_inf_err, neg_inf_err,
       zero_pm_inf, pos_pm_inf, neg_pm_inf,

--- a/src/arb/test/t-sqrt.c
+++ b/src/arb/test/t-sqrt.c
@@ -11,7 +11,7 @@
 
 #include "arb.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/arb/test/t-sqrt1pm1.c
+++ b/src/arb/test/t-sqrt1pm1.c
@@ -11,7 +11,7 @@
 
 #include "arb.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/arb/test/t-sqrtpos.c
+++ b/src/arb/test/t-sqrtpos.c
@@ -11,7 +11,7 @@
 
 #include "arb.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/arb/test/t-sub.c
+++ b/src/arb/test/t-sub.c
@@ -12,7 +12,7 @@
 #include "fmpq.h"
 #include "arb.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/arb/test/t-sub_arf.c
+++ b/src/arb/test/t-sub_arf.c
@@ -11,7 +11,7 @@
 
 #include "arb.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/arb/test/t-sub_fmpz.c
+++ b/src/arb/test/t-sub_fmpz.c
@@ -11,7 +11,7 @@
 
 #include "arb.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/arb/test/t-sub_si.c
+++ b/src/arb/test/t-sub_si.c
@@ -12,7 +12,7 @@
 #include "arb.h"
 #include "long_extras.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/arb/test/t-sub_ui.c
+++ b/src/arb/test/t-sub_ui.c
@@ -12,7 +12,7 @@
 #include "arb.h"
 #include "ulong_extras.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/arb/test/t-submul.c
+++ b/src/arb/test/t-submul.c
@@ -63,7 +63,7 @@ arb_submul_naive(arb_t z, const arb_t x, const arb_t y, slong prec)
     arb_clear(t);
 }
 
-int main()
+int main(void)
 {
     slong iter, iter2;
     flint_rand_t state;

--- a/src/arb/test/t-submul_arf.c
+++ b/src/arb/test/t-submul_arf.c
@@ -11,7 +11,7 @@
 
 #include "arb.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/arb/test/t-submul_fmpz.c
+++ b/src/arb/test/t-submul_fmpz.c
@@ -11,7 +11,7 @@
 
 #include "arb.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/arb/test/t-submul_si.c
+++ b/src/arb/test/t-submul_si.c
@@ -12,7 +12,7 @@
 #include "arb.h"
 #include "long_extras.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/arb/test/t-submul_ui.c
+++ b/src/arb/test/t-submul_ui.c
@@ -12,7 +12,7 @@
 #include "arb.h"
 #include "ulong_extras.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/arb/test/t-tan_pi.c
+++ b/src/arb/test/t-tan_pi.c
@@ -11,7 +11,7 @@
 
 #include "arb.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/arb/test/t-tanh.c
+++ b/src/arb/test/t-tanh.c
@@ -11,7 +11,7 @@
 
 #include "arb.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/arb/test/t-trim.c
+++ b/src/arb/test/t-trim.c
@@ -11,7 +11,7 @@
 
 #include "arb.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/arb/test/t-ui_pow_ui.c
+++ b/src/arb/test/t-ui_pow_ui.c
@@ -11,7 +11,7 @@
 
 #include "arb.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/arb/test/t-union.c
+++ b/src/arb/test/t-union.c
@@ -11,7 +11,7 @@
 
 #include "arb.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/arb/test/t-urandom.c
+++ b/src/arb/test/t-urandom.c
@@ -13,7 +13,7 @@
 
 #define N 10000
 
-int main()
+int main(void)
 {
     slong iter;
     slong prec;

--- a/src/arb/test/t-zeta.c
+++ b/src/arb/test/t-zeta.c
@@ -11,7 +11,7 @@
 
 #include "arb.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/arb/test/t-zeta_ui.c
+++ b/src/arb/test/t-zeta_ui.c
@@ -12,7 +12,7 @@
 #include <mpfr.h>
 #include "arb.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/arb/test/t-zeta_ui_asymp.c
+++ b/src/arb/test/t-zeta_ui_asymp.c
@@ -12,7 +12,7 @@
 #include <mpfr.h>
 #include "arb.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/arb/test/t-zeta_ui_bernoulli.c
+++ b/src/arb/test/t-zeta_ui_bernoulli.c
@@ -12,7 +12,7 @@
 #include <mpfr.h>
 #include "arb.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/arb/test/t-zeta_ui_borwein_bsplit.c
+++ b/src/arb/test/t-zeta_ui_borwein_bsplit.c
@@ -12,7 +12,7 @@
 #include <mpfr.h>
 #include "arb.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/arb/test/t-zeta_ui_euler_product.c
+++ b/src/arb/test/t-zeta_ui_euler_product.c
@@ -12,7 +12,7 @@
 #include <mpfr.h>
 #include "arb.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/arb/test/t-zeta_ui_vec.c
+++ b/src/arb/test/t-zeta_ui_vec.c
@@ -12,7 +12,7 @@
 #include <mpfr.h>
 #include "arb.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/arb/test/t-zeta_ui_vec_borwein.c
+++ b/src/arb/test/t-zeta_ui_vec_borwein.c
@@ -12,7 +12,7 @@
 #include <mpfr.h>
 #include "arb.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/arb_calc/test/t-isolate_roots.c
+++ b/src/arb_calc/test/t-isolate_roots.c
@@ -33,7 +33,7 @@ sin_pi2_x(arb_ptr out, const arb_t inp, void * params, slong order, slong prec)
     return 0;
 }
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/arb_fmpz_poly/test/t-complex_roots.c
+++ b/src/arb_fmpz_poly/test/t-complex_roots.c
@@ -91,7 +91,7 @@ check_roots(const fmpz_poly_t poly, acb_srcptr roots, slong prec)
     arb_clear(lead);
 }
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/arb_fmpz_poly/test/t-evaluate_acb.c
+++ b/src/arb_fmpz_poly/test/t-evaluate_acb.c
@@ -12,7 +12,7 @@
 #include "acb.h"
 #include "arb_fmpz_poly.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/arb_fmpz_poly/test/t-evaluate_arb.c
+++ b/src/arb_fmpz_poly/test/t-evaluate_arb.c
@@ -12,7 +12,7 @@
 #include "arb.h"
 #include "arb_fmpz_poly.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/arb_fmpz_poly/test/t-gauss_period_minpoly.c
+++ b/src/arb_fmpz_poly/test/t-gauss_period_minpoly.c
@@ -12,7 +12,7 @@
 #include "arb_fmpz_poly.h"
 #include "acb_dirichlet.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/arb_fpwrap/test/t-fpwrap.c
+++ b/src/arb_fpwrap/test/t-fpwrap.c
@@ -37,7 +37,7 @@
     } while (0)
 
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/arb_hypgeom/test/t-1f1_integration.c
+++ b/src/arb_hypgeom/test/t-1f1_integration.c
@@ -11,7 +11,7 @@
 
 #include "arb_hypgeom.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/arb_hypgeom/test/t-2f1_integration.c
+++ b/src/arb_hypgeom/test/t-2f1_integration.c
@@ -11,7 +11,7 @@
 
 #include "arb_hypgeom.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/arb_hypgeom/test/t-airy_zero.c
+++ b/src/arb_hypgeom/test/t-airy_zero.c
@@ -11,7 +11,7 @@
 
 #include "arb_hypgeom.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/arb_hypgeom/test/t-bessel_i_integration.c
+++ b/src/arb_hypgeom/test/t-bessel_i_integration.c
@@ -11,7 +11,7 @@
 
 #include "arb_hypgeom.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/arb_hypgeom/test/t-bessel_j.c
+++ b/src/arb_hypgeom/test/t-bessel_j.c
@@ -11,7 +11,7 @@
 
 #include "arb_hypgeom.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/arb_hypgeom/test/t-bessel_k_integration.c
+++ b/src/arb_hypgeom/test/t-bessel_k_integration.c
@@ -11,7 +11,7 @@
 
 #include "arb_hypgeom.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/arb_hypgeom/test/t-bessel_y.c
+++ b/src/arb_hypgeom/test/t-bessel_y.c
@@ -11,7 +11,7 @@
 
 #include "arb_hypgeom.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/arb_hypgeom/test/t-central_bin_ui.c
+++ b/src/arb_hypgeom/test/t-central_bin_ui.c
@@ -11,7 +11,7 @@
 
 #include "arb_hypgeom.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/arb_hypgeom/test/t-ci.c
+++ b/src/arb_hypgeom/test/t-ci.c
@@ -11,7 +11,7 @@
 
 #include "arb_hypgeom.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/arb_hypgeom/test/t-coulomb_series.c
+++ b/src/arb_hypgeom/test/t-coulomb_series.c
@@ -13,7 +13,7 @@
 #include "arb_poly.h"
 #include "arb_hypgeom.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/arb_hypgeom/test/t-erf.c
+++ b/src/arb_hypgeom/test/t-erf.c
@@ -11,7 +11,7 @@
 
 #include "arb_hypgeom.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/arb_hypgeom/test/t-erfinv.c
+++ b/src/arb_hypgeom/test/t-erfinv.c
@@ -11,7 +11,7 @@
 
 #include "arb_hypgeom.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/arb_hypgeom/test/t-gamma_fmpq.c
+++ b/src/arb_hypgeom/test/t-gamma_fmpq.c
@@ -19,7 +19,7 @@
 # include <math.h>
 #endif
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/arb_hypgeom/test/t-gamma_lower_sum_rs.c
+++ b/src/arb_hypgeom/test/t-gamma_lower_sum_rs.c
@@ -12,7 +12,7 @@
 #include "fmpq.h"
 #include "arb_hypgeom.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/arb_hypgeom/test/t-gamma_stirling_sum.c
+++ b/src/arb_hypgeom/test/t-gamma_stirling_sum.c
@@ -11,7 +11,7 @@
 
 #include "arb_hypgeom.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/arb_hypgeom/test/t-gamma_taylor.c
+++ b/src/arb_hypgeom/test/t-gamma_taylor.c
@@ -11,7 +11,7 @@
 
 #include "arb_hypgeom.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/arb_hypgeom/test/t-gamma_taylor_tab.c
+++ b/src/arb_hypgeom/test/t-gamma_taylor_tab.c
@@ -12,7 +12,7 @@
 #include "arb_poly.h"
 #include "arb_hypgeom.h"
 
-int main()
+int main(void)
 {
     flint_rand_t state;
 

--- a/src/arb_hypgeom/test/t-gamma_upper_fmpq.c
+++ b/src/arb_hypgeom/test/t-gamma_upper_fmpq.c
@@ -12,7 +12,7 @@
 #include "fmpq.h"
 #include "arb_hypgeom.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/arb_hypgeom/test/t-gamma_upper_integration.c
+++ b/src/arb_hypgeom/test/t-gamma_upper_integration.c
@@ -11,7 +11,7 @@
 
 #include "arb_hypgeom.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/arb_hypgeom/test/t-gamma_upper_sum_rs.c
+++ b/src/arb_hypgeom/test/t-gamma_upper_sum_rs.c
@@ -12,7 +12,7 @@
 #include "fmpq.h"
 #include "arb_hypgeom.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/arb_hypgeom/test/t-legendre_p_ui.c
+++ b/src/arb_hypgeom/test/t-legendre_p_ui.c
@@ -11,7 +11,7 @@
 
 #include "arb_hypgeom.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/arb_hypgeom/test/t-legendre_p_ui_asymp.c
+++ b/src/arb_hypgeom/test/t-legendre_p_ui_asymp.c
@@ -11,7 +11,7 @@
 
 #include "arb_hypgeom.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/arb_hypgeom/test/t-legendre_p_ui_deriv_bound.c
+++ b/src/arb_hypgeom/test/t-legendre_p_ui_deriv_bound.c
@@ -11,7 +11,7 @@
 
 #include "arb_hypgeom.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/arb_hypgeom/test/t-legendre_p_ui_one.c
+++ b/src/arb_hypgeom/test/t-legendre_p_ui_one.c
@@ -11,7 +11,7 @@
 
 #include "arb_hypgeom.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/arb_hypgeom/test/t-legendre_p_ui_rec.c
+++ b/src/arb_hypgeom/test/t-legendre_p_ui_rec.c
@@ -11,7 +11,7 @@
 
 #include "arb_hypgeom.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/arb_hypgeom/test/t-legendre_p_ui_root.c
+++ b/src/arb_hypgeom/test/t-legendre_p_ui_root.c
@@ -14,7 +14,7 @@
 #include "arb_hypgeom.h"
 #include "arith.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/arb_hypgeom/test/t-legendre_p_ui_zero.c
+++ b/src/arb_hypgeom/test/t-legendre_p_ui_zero.c
@@ -11,7 +11,7 @@
 
 #include "arb_hypgeom.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/arb_hypgeom/test/t-lgamma.c
+++ b/src/arb_hypgeom/test/t-lgamma.c
@@ -11,7 +11,7 @@
 
 #include "arb_hypgeom.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/arb_hypgeom/test/t-rising_ui.c
+++ b/src/arb_hypgeom/test/t-rising_ui.c
@@ -33,7 +33,7 @@ rising_algorithm(arb_t res, const arb_t x, ulong n, ulong m, slong prec, int alg
         arb_hypgeom_rising_ui(res, x, n, prec);
 }
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/arb_hypgeom/test/t-rising_ui_jet.c
+++ b/src/arb_hypgeom/test/t-rising_ui_jet.c
@@ -25,7 +25,7 @@ rising_algorithm(arb_ptr res, const arb_t x, ulong n, ulong m, slong len, slong 
         arb_hypgeom_rising_ui_jet(res, x, n, len, prec);
 }
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/arb_hypgeom/test/t-si.c
+++ b/src/arb_hypgeom/test/t-si.c
@@ -11,7 +11,7 @@
 
 #include "arb_hypgeom.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/arb_hypgeom/test/t-sum_fmpq_arb.c
+++ b/src/arb_hypgeom/test/t-sum_fmpq_arb.c
@@ -13,7 +13,7 @@
 #include "fmpq_vec.h"
 #include "arb_hypgeom.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/arb_hypgeom/test/t-sum_fmpq_imag_arb.c
+++ b/src/arb_hypgeom/test/t-sum_fmpq_imag_arb.c
@@ -13,7 +13,7 @@
 #include "fmpq_vec.h"
 #include "arb_hypgeom.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/arb_hypgeom/test/t-u_integration.c
+++ b/src/arb_hypgeom/test/t-u_integration.c
@@ -11,7 +11,7 @@
 
 #include "arb_hypgeom.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/arb_hypgeom/test/t-wrappers.c
+++ b/src/arb_hypgeom/test/t-wrappers.c
@@ -23,7 +23,7 @@ TEST(const arb_t x1, const arb_t x2, const char * s)
     }
 }
 
-int main()
+int main(void)
 {
     flint_rand_t state;
 

--- a/src/arb_mat/test/t-addmul_rad_mag_fast.c
+++ b/src/arb_mat/test/t-addmul_rad_mag_fast.c
@@ -40,7 +40,7 @@ fallback(arb_mat_t C, mag_srcptr A, mag_srcptr B, slong ar, slong ac, slong bc)
     }
 }
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/arb_mat/test/t-cho.c
+++ b/src/arb_mat/test/t-cho.c
@@ -41,7 +41,7 @@ int fmpq_mat_is_invertible(const fmpq_mat_t A)
     return r;
 }
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/arb_mat/test/t-dct.c
+++ b/src/arb_mat/test/t-dct.c
@@ -11,7 +11,7 @@
 
 #include "arb_mat.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/arb_mat/test/t-det.c
+++ b/src/arb_mat/test/t-det.c
@@ -13,7 +13,7 @@
 #include "fmpq_mat.h"
 #include "arb_mat.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/arb_mat/test/t-det_precond.c
+++ b/src/arb_mat/test/t-det_precond.c
@@ -11,7 +11,7 @@
 
 #include "arb_mat.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/arb_mat/test/t-exp.c
+++ b/src/arb_mat/test/t-exp.c
@@ -34,7 +34,7 @@ _fmpq_mat_randtest_for_exp(fmpq_mat_t mat, flint_rand_t state, flint_bitcnt_t bi
     }
 }
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/arb_mat/test/t-exp_taylor_sum.c
+++ b/src/arb_mat/test/t-exp_taylor_sum.c
@@ -11,7 +11,7 @@
 
 #include "arb_mat.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/arb_mat/test/t-frobenius_norm.c
+++ b/src/arb_mat/test/t-frobenius_norm.c
@@ -27,7 +27,7 @@ _fmpq_mat_sum_of_squares(fmpq_t res, const fmpq_mat_t Q)
     }
 }
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/arb_mat/test/t-inv.c
+++ b/src/arb_mat/test/t-inv.c
@@ -12,7 +12,7 @@
 #include "fmpq_mat.h"
 #include "arb_mat.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/arb_mat/test/t-inv_cho_precomp.c
+++ b/src/arb_mat/test/t-inv_cho_precomp.c
@@ -53,7 +53,7 @@ _spd_inv(arb_mat_t X, const arb_mat_t A, slong prec)
     return result;
 }
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/arb_mat/test/t-inv_ldl_precomp.c
+++ b/src/arb_mat/test/t-inv_ldl_precomp.c
@@ -53,7 +53,7 @@ _spd_inv(arb_mat_t X, const arb_mat_t A, slong prec)
     return result;
 }
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/arb_mat/test/t-ldl.c
+++ b/src/arb_mat/test/t-ldl.c
@@ -41,7 +41,7 @@ int fmpq_mat_is_invertible(const fmpq_mat_t A)
     return r;
 }
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/arb_mat/test/t-lu.c
+++ b/src/arb_mat/test/t-lu.c
@@ -25,7 +25,7 @@ int fmpq_mat_is_invertible(const fmpq_mat_t A)
     return r;
 }
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/arb_mat/test/t-lu_recursive.c
+++ b/src/arb_mat/test/t-lu_recursive.c
@@ -25,7 +25,7 @@ int fmpq_mat_is_invertible(const fmpq_mat_t A)
     return r;
 }
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/arb_mat/test/t-mul.c
+++ b/src/arb_mat/test/t-mul.c
@@ -12,7 +12,7 @@
 #include "fmpq_mat.h"
 #include "arb_mat.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/arb_mat/test/t-mul_block.c
+++ b/src/arb_mat/test/t-mul_block.c
@@ -14,7 +14,7 @@
 
 FLINT_DLL extern slong arb_mat_mul_block_min_block_size;
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/arb_mat/test/t-mul_entrywise.c
+++ b/src/arb_mat/test/t-mul_entrywise.c
@@ -29,7 +29,7 @@ _fmpq_mat_mul_entrywise(fmpq_mat_t C, const fmpq_mat_t A, const fmpq_mat_t B)
     }
 }
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/arb_mat/test/t-mul_threaded.c
+++ b/src/arb_mat/test/t-mul_threaded.c
@@ -12,7 +12,7 @@
 #include "fmpq_mat.h"
 #include "arb_mat.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/arb_mat/test/t-pascal.c
+++ b/src/arb_mat/test/t-pascal.c
@@ -11,7 +11,7 @@
 
 #include "arb_mat.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/arb_mat/test/t-solve.c
+++ b/src/arb_mat/test/t-solve.c
@@ -12,7 +12,7 @@
 #include "fmpq_mat.h"
 #include "arb_mat.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/arb_mat/test/t-solve_cho_precomp.c
+++ b/src/arb_mat/test/t-solve_cho_precomp.c
@@ -56,7 +56,7 @@ _spd_solve(arb_mat_t X, const arb_mat_t A, const arb_mat_t B, slong prec)
 }
 
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/arb_mat/test/t-solve_ldl_precomp.c
+++ b/src/arb_mat/test/t-solve_ldl_precomp.c
@@ -56,7 +56,7 @@ _spd_solve(arb_mat_t X, const arb_mat_t A, const arb_mat_t B, slong prec)
 }
 
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/arb_mat/test/t-solve_lu.c
+++ b/src/arb_mat/test/t-solve_lu.c
@@ -12,7 +12,7 @@
 #include "fmpq_mat.h"
 #include "arb_mat.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/arb_mat/test/t-solve_preapprox.c
+++ b/src/arb_mat/test/t-solve_preapprox.c
@@ -68,7 +68,7 @@ _fmpq_mat_inf_norm(fmpq_t res, const fmpq_mat_t mat)
     fmpq_clear(q);
 }
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/arb_mat/test/t-solve_precond.c
+++ b/src/arb_mat/test/t-solve_precond.c
@@ -12,7 +12,7 @@
 #include "fmpq_mat.h"
 #include "arb_mat.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/arb_mat/test/t-solve_tril.c
+++ b/src/arb_mat/test/t-solve_tril.c
@@ -11,7 +11,7 @@
 
 #include "arb_mat.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/arb_mat/test/t-solve_triu.c
+++ b/src/arb_mat/test/t-solve_triu.c
@@ -11,7 +11,7 @@
 
 #include "arb_mat.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/arb_mat/test/t-spd_inv.c
+++ b/src/arb_mat/test/t-spd_inv.c
@@ -28,7 +28,7 @@ _fmpq_mat_randtest_positive_semidefinite(fmpq_mat_t mat, flint_rand_t state, fli
     fmpq_mat_clear(RT);
 }
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/arb_mat/test/t-spd_solve.c
+++ b/src/arb_mat/test/t-spd_solve.c
@@ -28,7 +28,7 @@ _fmpq_mat_randtest_positive_semidefinite(fmpq_mat_t mat, flint_rand_t state, fli
     fmpq_mat_clear(RT);
 }
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/arb_mat/test/t-sqr.c
+++ b/src/arb_mat/test/t-sqr.c
@@ -12,7 +12,7 @@
 #include "fmpq_mat.h"
 #include "arb_mat.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/arb_mat/test/t-stirling.c
+++ b/src/arb_mat/test/t-stirling.c
@@ -13,7 +13,7 @@
 #include "arb_mat.h"
 #include "arith.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/arb_mat/test/t-trace.c
+++ b/src/arb_mat/test/t-trace.c
@@ -13,7 +13,7 @@
 #include "fmpq_mat.h"
 #include "arb_mat.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/arb_mat/test/t-transpose.c
+++ b/src/arb_mat/test/t-transpose.c
@@ -11,7 +11,7 @@
 
 #include "arb_mat.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/arb_poly/test/t-acos_series.c
+++ b/src/arb_poly/test/t-acos_series.c
@@ -12,7 +12,7 @@
 #include "fmpq_poly.h"
 #include "arb_poly.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/arb_poly/test/t-add.c
+++ b/src/arb_poly/test/t-add.c
@@ -12,7 +12,7 @@
 #include "fmpq_poly.h"
 #include "arb_poly.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/arb_poly/test/t-add_series.c
+++ b/src/arb_poly/test/t-add_series.c
@@ -12,7 +12,7 @@
 #include "arb_poly.h"
 
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/arb_poly/test/t-add_si.c
+++ b/src/arb_poly/test/t-add_si.c
@@ -11,7 +11,7 @@
 
 #include "arb_poly.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/arb_poly/test/t-asin_series.c
+++ b/src/arb_poly/test/t-asin_series.c
@@ -12,7 +12,7 @@
 #include "fmpq_poly.h"
 #include "arb_poly.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/arb_poly/test/t-atan_series.c
+++ b/src/arb_poly/test/t-atan_series.c
@@ -12,7 +12,7 @@
 #include "fmpq_poly.h"
 #include "arb_poly.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/arb_poly/test/t-binomial_transform.c
+++ b/src/arb_poly/test/t-binomial_transform.c
@@ -11,7 +11,7 @@
 
 #include "arb_poly.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/arb_poly/test/t-binomial_transform_basecase.c
+++ b/src/arb_poly/test/t-binomial_transform_basecase.c
@@ -11,7 +11,7 @@
 
 #include "arb_poly.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/arb_poly/test/t-binomial_transform_convolution.c
+++ b/src/arb_poly/test/t-binomial_transform_convolution.c
@@ -11,7 +11,7 @@
 
 #include "arb_poly.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/arb_poly/test/t-borel_transform.c
+++ b/src/arb_poly/test/t-borel_transform.c
@@ -11,7 +11,7 @@
 
 #include "arb_poly.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/arb_poly/test/t-compose.c
+++ b/src/arb_poly/test/t-compose.c
@@ -12,7 +12,7 @@
 #include "fmpq_poly.h"
 #include "arb_poly.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/arb_poly/test/t-compose_series.c
+++ b/src/arb_poly/test/t-compose_series.c
@@ -12,7 +12,7 @@
 #include "fmpq_poly.h"
 #include "arb_poly.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/arb_poly/test/t-cos_pi_series.c
+++ b/src/arb_poly/test/t-cos_pi_series.c
@@ -11,7 +11,7 @@
 
 #include "arb_poly.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/arb_poly/test/t-cot_pi_series.c
+++ b/src/arb_poly/test/t-cot_pi_series.c
@@ -11,7 +11,7 @@
 
 #include "arb_poly.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/arb_poly/test/t-digamma_series.c
+++ b/src/arb_poly/test/t-digamma_series.c
@@ -11,7 +11,7 @@
 
 #include "arb_poly.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/arb_poly/test/t-div_series.c
+++ b/src/arb_poly/test/t-div_series.c
@@ -12,7 +12,7 @@
 #include "fmpq_poly.h"
 #include "arb_poly.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/arb_poly/test/t-divrem.c
+++ b/src/arb_poly/test/t-divrem.c
@@ -12,7 +12,7 @@
 #include "fmpq_poly.h"
 #include "arb_poly.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/arb_poly/test/t-evaluate.c
+++ b/src/arb_poly/test/t-evaluate.c
@@ -13,7 +13,7 @@
 #include "fmpq_poly.h"
 #include "arb_poly.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/arb_poly/test/t-evaluate2.c
+++ b/src/arb_poly/test/t-evaluate2.c
@@ -11,7 +11,7 @@
 
 #include "arb_poly.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/arb_poly/test/t-evaluate2_acb_rectangular.c
+++ b/src/arb_poly/test/t-evaluate2_acb_rectangular.c
@@ -12,7 +12,7 @@
 #include "acb.h"
 #include "arb_poly.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/arb_poly/test/t-evaluate2_horner.c
+++ b/src/arb_poly/test/t-evaluate2_horner.c
@@ -11,7 +11,7 @@
 
 #include "arb_poly.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/arb_poly/test/t-evaluate2_rectangular.c
+++ b/src/arb_poly/test/t-evaluate2_rectangular.c
@@ -11,7 +11,7 @@
 
 #include "arb_poly.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/arb_poly/test/t-evaluate_acb_rectangular.c
+++ b/src/arb_poly/test/t-evaluate_acb_rectangular.c
@@ -12,7 +12,7 @@
 #include "acb.h"
 #include "arb_poly.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/arb_poly/test/t-evaluate_horner.c
+++ b/src/arb_poly/test/t-evaluate_horner.c
@@ -13,7 +13,7 @@
 #include "fmpq_poly.h"
 #include "arb_poly.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/arb_poly/test/t-evaluate_rectangular.c
+++ b/src/arb_poly/test/t-evaluate_rectangular.c
@@ -11,7 +11,7 @@
 
 #include "arb_poly.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/arb_poly/test/t-evaluate_vec_fast.c
+++ b/src/arb_poly/test/t-evaluate_vec_fast.c
@@ -14,7 +14,7 @@
 #include "fmpq_poly.h"
 #include "arb_poly.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/arb_poly/test/t-evaluate_vec_iter.c
+++ b/src/arb_poly/test/t-evaluate_vec_iter.c
@@ -14,7 +14,7 @@
 #include "fmpq_poly.h"
 #include "arb_poly.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/arb_poly/test/t-exp_series.c
+++ b/src/arb_poly/test/t-exp_series.c
@@ -14,7 +14,7 @@
 
 FLINT_DLL extern slong arb_poly_newton_exp_cutoff;
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/arb_poly/test/t-exp_series_basecase.c
+++ b/src/arb_poly/test/t-exp_series_basecase.c
@@ -27,7 +27,7 @@ fmpq_poly_randtest_small(fmpq_poly_t A, flint_rand_t state, slong len, slong bit
     }
 }
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/arb_poly/test/t-gamma_series.c
+++ b/src/arb_poly/test/t-gamma_series.c
@@ -12,7 +12,7 @@
 #include "fmpq_poly.h"
 #include "arb_poly.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/arb_poly/test/t-get_unique_fmpz_poly.c
+++ b/src/arb_poly/test/t-get_unique_fmpz_poly.c
@@ -12,7 +12,7 @@
 #include "fmpz_poly.h"
 #include "arb_poly.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/arb_poly/test/t-graeffe_transform.c
+++ b/src/arb_poly/test/t-graeffe_transform.c
@@ -11,7 +11,7 @@
 
 #include "arb_poly.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/arb_poly/test/t-interpolate_barycentric.c
+++ b/src/arb_poly/test/t-interpolate_barycentric.c
@@ -13,7 +13,7 @@
 #include "fmpq_poly.h"
 #include "arb_poly.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/arb_poly/test/t-interpolate_fast.c
+++ b/src/arb_poly/test/t-interpolate_fast.c
@@ -13,7 +13,7 @@
 #include "fmpq_poly.h"
 #include "arb_poly.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/arb_poly/test/t-interpolate_newton.c
+++ b/src/arb_poly/test/t-interpolate_newton.c
@@ -13,7 +13,7 @@
 #include "fmpq_poly.h"
 #include "arb_poly.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/arb_poly/test/t-inv_series.c
+++ b/src/arb_poly/test/t-inv_series.c
@@ -12,7 +12,7 @@
 #include "fmpq_poly.h"
 #include "arb_poly.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/arb_poly/test/t-lambertw_series.c
+++ b/src/arb_poly/test/t-lambertw_series.c
@@ -11,7 +11,7 @@
 
 #include "arb_poly.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/arb_poly/test/t-lgamma_series.c
+++ b/src/arb_poly/test/t-lgamma_series.c
@@ -12,7 +12,7 @@
 #include "fmpq_poly.h"
 #include "arb_poly.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/arb_poly/test/t-log1p_series.c
+++ b/src/arb_poly/test/t-log1p_series.c
@@ -11,7 +11,7 @@
 
 #include "arb_poly.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/arb_poly/test/t-log_series.c
+++ b/src/arb_poly/test/t-log_series.c
@@ -12,7 +12,7 @@
 #include "fmpq_poly.h"
 #include "arb_poly.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/arb_poly/test/t-mul.c
+++ b/src/arb_poly/test/t-mul.c
@@ -12,7 +12,7 @@
 #include "fmpq_poly.h"
 #include "arb_poly.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/arb_poly/test/t-mullow.c
+++ b/src/arb_poly/test/t-mullow.c
@@ -12,7 +12,7 @@
 #include "fmpq_poly.h"
 #include "arb_poly.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/arb_poly/test/t-mullow_block.c
+++ b/src/arb_poly/test/t-mullow_block.c
@@ -12,7 +12,7 @@
 #include "fmpq_poly.h"
 #include "arb_poly.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/arb_poly/test/t-mullow_classical.c
+++ b/src/arb_poly/test/t-mullow_classical.c
@@ -12,7 +12,7 @@
 #include "fmpq_poly.h"
 #include "arb_poly.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/arb_poly/test/t-pow_arb_series.c
+++ b/src/arb_poly/test/t-pow_arb_series.c
@@ -11,7 +11,7 @@
 
 #include "arb_poly.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/arb_poly/test/t-pow_series.c
+++ b/src/arb_poly/test/t-pow_series.c
@@ -11,7 +11,7 @@
 
 #include "arb_poly.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/arb_poly/test/t-pow_ui.c
+++ b/src/arb_poly/test/t-pow_ui.c
@@ -12,7 +12,7 @@
 #include "fmpz_poly.h"
 #include "arb_poly.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/arb_poly/test/t-pow_ui_trunc_binexp.c
+++ b/src/arb_poly/test/t-pow_ui_trunc_binexp.c
@@ -12,7 +12,7 @@
 #include "fmpz_poly.h"
 #include "arb_poly.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/arb_poly/test/t-product_roots.c
+++ b/src/arb_poly/test/t-product_roots.c
@@ -11,7 +11,7 @@
 
 #include "arb_poly.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/arb_poly/test/t-product_roots_complex.c
+++ b/src/arb_poly/test/t-product_roots_complex.c
@@ -12,7 +12,7 @@
 #include "arb_poly.h"
 #include "acb_poly.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/arb_poly/test/t-revert_series.c
+++ b/src/arb_poly/test/t-revert_series.c
@@ -12,7 +12,7 @@
 #include "fmpq_poly.h"
 #include "arb_poly.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/arb_poly/test/t-revert_series_lagrange.c
+++ b/src/arb_poly/test/t-revert_series_lagrange.c
@@ -12,7 +12,7 @@
 #include "fmpq_poly.h"
 #include "arb_poly.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/arb_poly/test/t-revert_series_lagrange_fast.c
+++ b/src/arb_poly/test/t-revert_series_lagrange_fast.c
@@ -12,7 +12,7 @@
 #include "fmpq_poly.h"
 #include "arb_poly.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/arb_poly/test/t-revert_series_newton.c
+++ b/src/arb_poly/test/t-revert_series_newton.c
@@ -12,7 +12,7 @@
 #include "fmpq_poly.h"
 #include "arb_poly.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/arb_poly/test/t-rgamma_series.c
+++ b/src/arb_poly/test/t-rgamma_series.c
@@ -12,7 +12,7 @@
 #include "fmpq_poly.h"
 #include "arb_poly.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/arb_poly/test/t-riemann_siegel_theta_series.c
+++ b/src/arb_poly/test/t-riemann_siegel_theta_series.c
@@ -11,7 +11,7 @@
 
 #include "arb_poly.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/arb_poly/test/t-riemann_siegel_z_series.c
+++ b/src/arb_poly/test/t-riemann_siegel_z_series.c
@@ -11,7 +11,7 @@
 
 #include "arb_poly.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/arb_poly/test/t-rising_ui_series.c
+++ b/src/arb_poly/test/t-rising_ui_series.c
@@ -12,7 +12,7 @@
 #include "arb_poly.h"
 
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/arb_poly/test/t-root_bound_fujiwara.c
+++ b/src/arb_poly/test/t-root_bound_fujiwara.c
@@ -11,7 +11,7 @@
 
 #include "arb_poly.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/arb_poly/test/t-rsqrt_series.c
+++ b/src/arb_poly/test/t-rsqrt_series.c
@@ -12,7 +12,7 @@
 #include "fmpq_poly.h"
 #include "arb_poly.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/arb_poly/test/t-sin_cos_pi_series.c
+++ b/src/arb_poly/test/t-sin_cos_pi_series.c
@@ -12,7 +12,7 @@
 #include "fmpq_poly.h"
 #include "arb_poly.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/arb_poly/test/t-sin_cos_series.c
+++ b/src/arb_poly/test/t-sin_cos_series.c
@@ -12,7 +12,7 @@
 #include "fmpq_poly.h"
 #include "arb_poly.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/arb_poly/test/t-sin_pi_series.c
+++ b/src/arb_poly/test/t-sin_pi_series.c
@@ -11,7 +11,7 @@
 
 #include "arb_poly.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/arb_poly/test/t-sin_series_cos_series.c
+++ b/src/arb_poly/test/t-sin_series_cos_series.c
@@ -12,7 +12,7 @@
 #include "fmpq_poly.h"
 #include "arb_poly.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/arb_poly/test/t-sinc_pi_series.c
+++ b/src/arb_poly/test/t-sinc_pi_series.c
@@ -12,7 +12,7 @@
 
 #include "arb_poly.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/arb_poly/test/t-sinc_series.c
+++ b/src/arb_poly/test/t-sinc_series.c
@@ -11,7 +11,7 @@
 
 #include "arb_poly.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/arb_poly/test/t-sinh_cosh_series.c
+++ b/src/arb_poly/test/t-sinh_cosh_series.c
@@ -11,7 +11,7 @@
 
 #include "arb_poly.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/arb_poly/test/t-sqrt_series.c
+++ b/src/arb_poly/test/t-sqrt_series.c
@@ -12,7 +12,7 @@
 #include "fmpq_poly.h"
 #include "arb_poly.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/arb_poly/test/t-sub.c
+++ b/src/arb_poly/test/t-sub.c
@@ -12,7 +12,7 @@
 #include "fmpq_poly.h"
 #include "arb_poly.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/arb_poly/test/t-sub_series.c
+++ b/src/arb_poly/test/t-sub_series.c
@@ -11,7 +11,7 @@
 
 #include "arb_poly.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/arb_poly/test/t-swinnerton_dyer_ui.c
+++ b/src/arb_poly/test/t-swinnerton_dyer_ui.c
@@ -13,7 +13,7 @@
 #include "fmpz_poly.h"
 #include "arb_poly.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/arb_poly/test/t-tan_series.c
+++ b/src/arb_poly/test/t-tan_series.c
@@ -12,7 +12,7 @@
 #include "fmpq_poly.h"
 #include "arb_poly.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/arb_poly/test/t-taylor_shift.c
+++ b/src/arb_poly/test/t-taylor_shift.c
@@ -11,7 +11,7 @@
 
 #include "arb_poly.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/arb_poly/test/t-zeta_series.c
+++ b/src/arb_poly/test/t-zeta_series.c
@@ -11,7 +11,7 @@
 
 #include "arb_poly.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/arf/test/t-abs_bound_le_2exp_fmpz.c
+++ b/src/arf/test/t-abs_bound_le_2exp_fmpz.c
@@ -11,7 +11,7 @@
 
 #include "arf.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/arf/test/t-abs_bound_lt_2exp_fmpz.c
+++ b/src/arf/test/t-abs_bound_lt_2exp_fmpz.c
@@ -11,7 +11,7 @@
 
 #include "arf.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/arf/test/t-abs_bound_lt_2exp_si.c
+++ b/src/arf/test/t-abs_bound_lt_2exp_si.c
@@ -11,7 +11,7 @@
 
 #include "arf.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/arf/test/t-add.c
+++ b/src/arf/test/t-add.c
@@ -62,7 +62,7 @@ arf_add_naive(arf_t z, const arf_t x, const arf_t y, slong prec, arf_rnd_t rnd)
     }
 }
 
-int main()
+int main(void)
 {
     slong iter, iter2;
     flint_rand_t state;

--- a/src/arf/test/t-add_fmpz.c
+++ b/src/arf/test/t-add_fmpz.c
@@ -23,7 +23,7 @@ arf_add_fmpz_naive(arf_t z, const arf_t x, const fmpz_t y, slong prec, arf_rnd_t
     return r;
 }
 
-int main()
+int main(void)
 {
     slong iter, iter2;
     flint_rand_t state;

--- a/src/arf/test/t-add_fmpz_2exp.c
+++ b/src/arf/test/t-add_fmpz_2exp.c
@@ -24,7 +24,7 @@ arf_add_fmpz_2exp_naive(arf_t z, const arf_t x,
     return r;
 }
 
-int main()
+int main(void)
 {
     slong iter, iter2;
     flint_rand_t state;

--- a/src/arf/test/t-add_si.c
+++ b/src/arf/test/t-add_si.c
@@ -24,7 +24,7 @@ arf_add_si_naive(arf_t z, const arf_t x, slong y, slong prec, arf_rnd_t rnd)
     return r;
 }
 
-int main()
+int main(void)
 {
     slong iter, iter2;
     flint_rand_t state;

--- a/src/arf/test/t-add_ui.c
+++ b/src/arf/test/t-add_ui.c
@@ -24,7 +24,7 @@ arf_add_ui_naive(arf_t z, const arf_t x, ulong y, slong prec, arf_rnd_t rnd)
     return r;
 }
 
-int main()
+int main(void)
 {
     slong iter, iter2;
     flint_rand_t state;

--- a/src/arf/test/t-addmul.c
+++ b/src/arf/test/t-addmul.c
@@ -27,7 +27,7 @@ arf_addmul_naive(arf_t z, const arf_t x, const arf_t y, slong prec, arf_rnd_t rn
     return inexact;
 }
 
-int main()
+int main(void)
 {
     slong iter, iter2;
     flint_rand_t state;

--- a/src/arf/test/t-addmul_fmpz.c
+++ b/src/arf/test/t-addmul_fmpz.c
@@ -27,7 +27,7 @@ arf_addmul_fmpz_naive(arf_t z, const arf_t x, const fmpz_t y, slong prec, arf_rn
     return inexact;
 }
 
-int main()
+int main(void)
 {
     slong iter, iter2;
     flint_rand_t state;

--- a/src/arf/test/t-addmul_si.c
+++ b/src/arf/test/t-addmul_si.c
@@ -28,7 +28,7 @@ arf_addmul_si_naive(arf_t z, const arf_t x, slong y, slong prec, arf_rnd_t rnd)
     return inexact;
 }
 
-int main()
+int main(void)
 {
     slong iter, iter2;
     flint_rand_t state;

--- a/src/arf/test/t-addmul_ui.c
+++ b/src/arf/test/t-addmul_ui.c
@@ -27,7 +27,7 @@ arf_addmul_ui_naive(arf_t z, const arf_t x, ulong y, slong prec, arf_rnd_t rnd)
     return inexact;
 }
 
-int main()
+int main(void)
 {
     slong iter, iter2;
     flint_rand_t state;

--- a/src/arf/test/t-approx_dot.c
+++ b/src/arf/test/t-approx_dot.c
@@ -12,7 +12,7 @@
 #include "arf.h"
 #include "arb.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/arf/test/t-ceil.c
+++ b/src/arf/test/t-ceil.c
@@ -11,7 +11,7 @@
 
 #include "arf.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/arf/test/t-cmp.c
+++ b/src/arf/test/t-cmp.c
@@ -12,7 +12,7 @@
 #include <mpfr.h>
 #include "arf.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/arf/test/t-cmp_2exp_si.c
+++ b/src/arf/test/t-cmp_2exp_si.c
@@ -11,7 +11,7 @@
 
 #include "arf.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/arf/test/t-cmpabs.c
+++ b/src/arf/test/t-cmpabs.c
@@ -12,7 +12,7 @@
 #include <mpfr.h>
 #include "arf.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/arf/test/t-cmpabs_2exp_si.c
+++ b/src/arf/test/t-cmpabs_2exp_si.c
@@ -11,7 +11,7 @@
 
 #include "arf.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/arf/test/t-complex_mul.c
+++ b/src/arf/test/t-complex_mul.c
@@ -11,7 +11,7 @@
 
 #include "arf.h"
 
-int main()
+int main(void)
 {
     slong iter, iter2;
     flint_rand_t state;

--- a/src/arf/test/t-complex_sqr.c
+++ b/src/arf/test/t-complex_sqr.c
@@ -11,7 +11,7 @@
 
 #include "arf.h"
 
-int main()
+int main(void)
 {
     slong iter, iter2;
     flint_rand_t state;

--- a/src/arf/test/t-div.c
+++ b/src/arf/test/t-div.c
@@ -51,7 +51,7 @@ arf_div_naive(arf_t z, const arf_t x, const arf_t y, slong prec, arf_rnd_t rnd)
     return inexact;
 }
 
-int main()
+int main(void)
 {
     slong iter, iter2;
     flint_rand_t state;

--- a/src/arf/test/t-dump_file.c
+++ b/src/arf/test/t-dump_file.c
@@ -12,7 +12,7 @@
 #include <string.h>
 #include "arb.h"
 
-int main()
+int main(void)
 {
     flint_rand_t state;
     slong iter;

--- a/src/arf/test/t-dump_str.c
+++ b/src/arf/test/t-dump_str.c
@@ -12,7 +12,7 @@
 #include <string.h>
 #include "arf.h"
 
-int main()
+int main(void)
 {
     flint_rand_t state;
     slong iter;

--- a/src/arf/test/t-floor.c
+++ b/src/arf/test/t-floor.c
@@ -11,7 +11,7 @@
 
 #include "arf.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/arf/test/t-fma.c
+++ b/src/arf/test/t-fma.c
@@ -27,7 +27,7 @@ arf_fma_naive(arf_t res, const arf_t x, const arf_t y, const arf_t z, slong prec
     return inexact;
 }
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/arf/test/t-frexp.c
+++ b/src/arf/test/t-frexp.c
@@ -11,7 +11,7 @@
 
 #include "arf.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/arf/test/t-get_d.c
+++ b/src/arf/test/t-get_d.c
@@ -12,7 +12,7 @@
 #include "mpfr.h"
 #include "arf.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/arf/test/t-get_fmpz.c
+++ b/src/arf/test/t-get_fmpz.c
@@ -12,7 +12,7 @@
 #include <mpfr.h>
 #include "arf.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/arf/test/t-get_mpfr.c
+++ b/src/arf/test/t-get_mpfr.c
@@ -12,7 +12,7 @@
 #include <mpfr.h>
 #include "arf.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/arf/test/t-get_str.c
+++ b/src/arf/test/t-get_str.c
@@ -13,7 +13,7 @@
 #include "arf.h"
 #include "arb.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/arf/test/t-is_int_2exp_si.c
+++ b/src/arf/test/t-is_int_2exp_si.c
@@ -11,7 +11,7 @@
 
 #include "arf.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/arf/test/t-mul.c
+++ b/src/arf/test/t-mul.c
@@ -19,7 +19,7 @@ arf_mul_naive(arf_t z, const arf_t x, const arf_t y, slong prec, arf_rnd_t rnd)
     return arf_set_round(z, z, prec, rnd);
 }
 
-int main()
+int main(void)
 {
     slong iter, iter2;
     flint_rand_t state;

--- a/src/arf/test/t-mul_fmpz.c
+++ b/src/arf/test/t-mul_fmpz.c
@@ -23,7 +23,7 @@ arf_mul_fmpz_naive(arf_t z, const arf_t x, const fmpz_t y, slong prec, arf_rnd_t
     return r;
 }
 
-int main()
+int main(void)
 {
     slong iter, iter2;
     flint_rand_t state;

--- a/src/arf/test/t-mul_si.c
+++ b/src/arf/test/t-mul_si.c
@@ -24,7 +24,7 @@ arf_mul_si_naive(arf_t z, const arf_t x, slong y, slong prec, arf_rnd_t rnd)
     return r;
 }
 
-int main()
+int main(void)
 {
     slong iter, iter2;
     flint_rand_t state;

--- a/src/arf/test/t-mul_ui.c
+++ b/src/arf/test/t-mul_ui.c
@@ -24,7 +24,7 @@ arf_mul_ui_naive(arf_t z, const arf_t x, ulong y, slong prec, arf_rnd_t rnd)
     return r;
 }
 
-int main()
+int main(void)
 {
     slong iter, iter2;
     flint_rand_t state;

--- a/src/arf/test/t-mul_via_mpfr.c
+++ b/src/arf/test/t-mul_via_mpfr.c
@@ -20,7 +20,7 @@ arf_mul_naive(arf_t z, const arf_t x, const arf_t y, slong prec, arf_rnd_t rnd)
     return arf_set_round(z, z, prec, rnd);
 }
 
-int main()
+int main(void)
 {
     slong iter, iter2;
     flint_rand_t state;

--- a/src/arf/test/t-neg_round.c
+++ b/src/arf/test/t-neg_round.c
@@ -12,7 +12,7 @@
 #include <mpfr.h>
 #include "arf.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/arf/test/t-root.c
+++ b/src/arf/test/t-root.c
@@ -58,7 +58,7 @@ arf_root_naive(arf_t z, const arf_t x, int k, slong prec, arf_rnd_t rnd)
     return res;
 }
 
-int main()
+int main(void)
 {
     slong iter, iter2;
     flint_rand_t state;

--- a/src/arf/test/t-rsqrt.c
+++ b/src/arf/test/t-rsqrt.c
@@ -36,7 +36,7 @@ arf_rsqrt_naive(arf_t z, const arf_t x, slong prec, arf_rnd_t rnd)
     }
 }
 
-int main()
+int main(void)
 {
     slong iter, iter2;
     flint_rand_t state;

--- a/src/arf/test/t-set_d.c
+++ b/src/arf/test/t-set_d.c
@@ -13,7 +13,7 @@
 #include "double_extras.h"
 #include "arf.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/arf/test/t-set_fmpq.c
+++ b/src/arf/test/t-set_fmpq.c
@@ -12,7 +12,7 @@
 #include "fmpq.h"
 #include "arf.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/arf/test/t-set_fmpz_2exp.c
+++ b/src/arf/test/t-set_fmpz_2exp.c
@@ -11,7 +11,7 @@
 
 #include "arf.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/arf/test/t-set_round.c
+++ b/src/arf/test/t-set_round.c
@@ -12,7 +12,7 @@
 #include <mpfr.h>
 #include "arf.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/arf/test/t-set_round_fmpz.c
+++ b/src/arf/test/t-set_round_fmpz.c
@@ -12,7 +12,7 @@
 #include <mpfr.h>
 #include "arf.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/arf/test/t-set_round_mpz.c
+++ b/src/arf/test/t-set_round_mpz.c
@@ -12,7 +12,7 @@
 #include <mpfr.h>
 #include "arf.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/arf/test/t-set_round_ui.c
+++ b/src/arf/test/t-set_round_ui.c
@@ -11,7 +11,7 @@
 
 #include "arf.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/arf/test/t-set_round_uiui.c
+++ b/src/arf/test/t-set_round_uiui.c
@@ -11,7 +11,7 @@
 
 #include "arf.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/arf/test/t-sosq.c
+++ b/src/arf/test/t-sosq.c
@@ -24,7 +24,7 @@ arf_sosq_naive(arf_t z, const arf_t x, const arf_t y, slong prec, arf_rnd_t rnd)
     return inexact;
 }
 
-int main()
+int main(void)
 {
     slong iter, iter2;
     flint_rand_t state;

--- a/src/arf/test/t-sqrt.c
+++ b/src/arf/test/t-sqrt.c
@@ -37,7 +37,7 @@ arf_sqrt_naive(arf_t z, const arf_t x, slong prec, arf_rnd_t rnd)
     }
 }
 
-int main()
+int main(void)
 {
     slong iter, iter2;
     flint_rand_t state;

--- a/src/arf/test/t-sub.c
+++ b/src/arf/test/t-sub.c
@@ -23,7 +23,7 @@ arf_sub_naive(arf_t z, const arf_t x, const arf_t y, slong prec, arf_rnd_t rnd)
     return r;
 }
 
-int main()
+int main(void)
 {
     slong iter, iter2;
     flint_rand_t state;

--- a/src/arf/test/t-sub_fmpz.c
+++ b/src/arf/test/t-sub_fmpz.c
@@ -23,7 +23,7 @@ arf_sub_fmpz_naive(arf_t z, const arf_t x, const fmpz_t y, slong prec, arf_rnd_t
     return r;
 }
 
-int main()
+int main(void)
 {
     slong iter, iter2;
     flint_rand_t state;

--- a/src/arf/test/t-sub_si.c
+++ b/src/arf/test/t-sub_si.c
@@ -24,7 +24,7 @@ arf_sub_si_naive(arf_t z, const arf_t x, slong y, slong prec, arf_rnd_t rnd)
     return r;
 }
 
-int main()
+int main(void)
 {
     slong iter, iter2;
     flint_rand_t state;

--- a/src/arf/test/t-sub_ui.c
+++ b/src/arf/test/t-sub_ui.c
@@ -24,7 +24,7 @@ arf_sub_ui_naive(arf_t z, const arf_t x, ulong y, slong prec, arf_rnd_t rnd)
     return r;
 }
 
-int main()
+int main(void)
 {
     slong iter, iter2;
     flint_rand_t state;

--- a/src/arf/test/t-submul.c
+++ b/src/arf/test/t-submul.c
@@ -27,7 +27,7 @@ arf_submul_naive(arf_t z, const arf_t x, const arf_t y, slong prec, arf_rnd_t rn
     return inexact;
 }
 
-int main()
+int main(void)
 {
     slong iter, iter2;
     flint_rand_t state;

--- a/src/arf/test/t-submul_fmpz.c
+++ b/src/arf/test/t-submul_fmpz.c
@@ -27,7 +27,7 @@ arf_submul_fmpz_naive(arf_t z, const arf_t x, const fmpz_t y, slong prec, arf_rn
     return inexact;
 }
 
-int main()
+int main(void)
 {
     slong iter, iter2;
     flint_rand_t state;

--- a/src/arf/test/t-submul_si.c
+++ b/src/arf/test/t-submul_si.c
@@ -28,7 +28,7 @@ arf_submul_si_naive(arf_t z, const arf_t x, slong y, slong prec, arf_rnd_t rnd)
     return inexact;
 }
 
-int main()
+int main(void)
 {
     slong iter, iter2;
     flint_rand_t state;

--- a/src/arf/test/t-submul_ui.c
+++ b/src/arf/test/t-submul_ui.c
@@ -27,7 +27,7 @@ arf_submul_ui_naive(arf_t z, const arf_t x, ulong y, slong prec, arf_rnd_t rnd)
     return inexact;
 }
 
-int main()
+int main(void)
 {
     slong iter, iter2;
     flint_rand_t state;

--- a/src/arf/test/t-sum.c
+++ b/src/arf/test/t-sum.c
@@ -11,7 +11,7 @@
 
 #include "arf.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/arith/test/t-bernoulli_number.c
+++ b/src/arith/test/t-bernoulli_number.c
@@ -14,7 +14,7 @@
 #include "fmpq.h"
 #include "arith.h"
 
-int main()
+int main(void)
 {
     fmpz * num1;
     fmpz * den1;

--- a/src/arith/test/t-bernoulli_number_denom.c
+++ b/src/arith/test/t-bernoulli_number_denom.c
@@ -13,7 +13,7 @@
 #include "fmpz.h"
 #include "arith.h"
 
-int main()
+int main(void)
 {
     fmpz_t s, t;
     slong n;

--- a/src/arith/test/t-bernoulli_number_vec.c
+++ b/src/arith/test/t-bernoulli_number_vec.c
@@ -13,7 +13,7 @@
 #include "fmpz_vec.h"
 #include "arith.h"
 
-int main()
+int main(void)
 {
     fmpz * num1;
     fmpz * num2;

--- a/src/arith/test/t-bernoulli_polynomial.c
+++ b/src/arith/test/t-bernoulli_polynomial.c
@@ -13,7 +13,7 @@
 #include "fmpq_poly.h"
 #include "arith.h"
 
-int main()
+int main(void)
 {
     fmpq_poly_t P, Q;
     fmpz_t t;

--- a/src/arith/test/t-chebyshev_t_polynomial.c
+++ b/src/arith/test/t-chebyshev_t_polynomial.c
@@ -12,7 +12,7 @@
 #include "fmpz_poly.h"
 #include "arith.h"
 
-int main()
+int main(void)
 {
     fmpz_poly_t T0, T1, T2, t;
     slong n;

--- a/src/arith/test/t-chebyshev_u_polynomial.c
+++ b/src/arith/test/t-chebyshev_u_polynomial.c
@@ -12,7 +12,7 @@
 #include "fmpz_poly.h"
 #include "arith.h"
 
-int main()
+int main(void)
 {
     fmpz_poly_t T, U;
 

--- a/src/arith/test/t-euler_number_vec.c
+++ b/src/arith/test/t-euler_number_vec.c
@@ -13,7 +13,7 @@
 #include "fmpz_vec.h"
 #include "arith.h"
 
-int main()
+int main(void)
 {
     fmpz * r;
     fmpz_t s, t;

--- a/src/arith/test/t-euler_number_zeta.c
+++ b/src/arith/test/t-euler_number_zeta.c
@@ -13,7 +13,7 @@
 #include "fmpz_vec.h"
 #include "arith.h"
 
-int main()
+int main(void)
 {
     fmpz * ress;
     fmpz_t res;

--- a/src/arith/test/t-euler_polynomial.c
+++ b/src/arith/test/t-euler_polynomial.c
@@ -13,7 +13,7 @@
 #include "fmpq_poly.h"
 #include "arith.h"
 
-int main()
+int main(void)
 {
     fmpq_poly_t P, Q;
     fmpz_t t;

--- a/src/arith/test/t-swinnerton_dyer_polynomial.c
+++ b/src/arith/test/t-swinnerton_dyer_polynomial.c
@@ -27,7 +27,7 @@ static const mp_limb_t known_values[] =
     UWORD(394942914)
 };
 
-int main()
+int main(void)
 {
     fmpz_poly_t S;
     mp_limb_t r;

--- a/src/bernoulli/test/t-bound_2exp_si.c
+++ b/src/bernoulli/test/t-bound_2exp_si.c
@@ -18,7 +18,7 @@ double log2bern_approx(double n)
     return 1 + ((n+0.5)*log(n) - n - (n-0.5)*log(2*3.14159265358979323)) * (1. / log(2));
 }
 
-int main()
+int main(void)
 {
     slong i, bound;
     double a, b;

--- a/src/bernoulli/test/t-fmpq_ui.c
+++ b/src/bernoulli/test/t-fmpq_ui.c
@@ -15,7 +15,7 @@
 #include "arith.h"
 #include "bernoulli.h"
 
-int main()
+int main(void)
 {
     fmpz * num1;
     fmpz * den1;

--- a/src/bernoulli/test/t-fmpq_ui_multi_mod.c
+++ b/src/bernoulli/test/t-fmpq_ui_multi_mod.c
@@ -15,7 +15,7 @@
 #include "arith.h"
 #include "bernoulli.h"
 
-int main()
+int main(void)
 {
     flint_rand_t state;
     fmpz * num1;

--- a/src/bernoulli/test/t-fmpq_vec.c
+++ b/src/bernoulli/test/t-fmpq_vec.c
@@ -15,7 +15,7 @@
 #include "fmpq_vec.h"
 #include "bernoulli.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/bernoulli/test/t-mod_p_harvey.c
+++ b/src/bernoulli/test/t-mod_p_harvey.c
@@ -43,7 +43,7 @@ void test_bern_modp_pow2(ulong p, ulong k)
     }
 }
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/bernoulli/test/t-rev.c
+++ b/src/bernoulli/test/t-rev.c
@@ -15,7 +15,7 @@
 #include "fmpz_extras.h"
 #include "bernoulli.h"
 
-int main()
+int main(void)
 {
     flint_rand_t state;
     slong nmax, n, bound, count;

--- a/src/bool_mat/test/t-all_pairs_longest_walk.c
+++ b/src/bool_mat/test/t-all_pairs_longest_walk.c
@@ -134,7 +134,7 @@ _brute_force_all_pairs_longest_walk(fmpz_mat_t B, const bool_mat_t A)
 }
 
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/bool_mat/test/t-complement.c
+++ b/src/bool_mat/test/t-complement.c
@@ -11,7 +11,7 @@
 
 #include "bool_mat.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/bool_mat/test/t-is_diagonal.c
+++ b/src/bool_mat/test/t-is_diagonal.c
@@ -11,7 +11,7 @@
 
 #include "bool_mat.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/bool_mat/test/t-is_nilpotent.c
+++ b/src/bool_mat/test/t-is_nilpotent.c
@@ -11,7 +11,7 @@
 
 #include "bool_mat.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/bool_mat/test/t-is_transitive.c
+++ b/src/bool_mat/test/t-is_transitive.c
@@ -11,7 +11,7 @@
 
 #include "bool_mat.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/bool_mat/test/t-mul.c
+++ b/src/bool_mat/test/t-mul.c
@@ -11,7 +11,7 @@
 
 #include "bool_mat.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/bool_mat/test/t-nilpotency_degree.c
+++ b/src/bool_mat/test/t-nilpotency_degree.c
@@ -11,7 +11,7 @@
 
 #include "bool_mat.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/bool_mat/test/t-trace.c
+++ b/src/bool_mat/test/t-trace.c
@@ -11,7 +11,7 @@
 
 #include "bool_mat.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/bool_mat/test/t-transitive_closure.c
+++ b/src/bool_mat/test/t-transitive_closure.c
@@ -47,7 +47,7 @@ _bool_mat_transitive_closure_powering(bool_mat_t B, const bool_mat_t A)
     bool_mat_clear(T);
 }
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/bool_mat/test/t-transpose.c
+++ b/src/bool_mat/test/t-transpose.c
@@ -11,7 +11,7 @@
 
 #include "bool_mat.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/ca/test/t-acos.c
+++ b/src/ca/test/t-acos.c
@@ -11,7 +11,7 @@
 
 #include "ca.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/ca/test/t-add.c
+++ b/src/ca/test/t-add.c
@@ -11,7 +11,7 @@
 
 #include "ca.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/ca/test/t-asin.c
+++ b/src/ca/test/t-asin.c
@@ -11,7 +11,7 @@
 
 #include "ca.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/ca/test/t-atan.c
+++ b/src/ca/test/t-atan.c
@@ -11,7 +11,7 @@
 
 #include "ca.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/ca/test/t-conj.c
+++ b/src/ca/test/t-conj.c
@@ -11,7 +11,7 @@
 
 #include "ca.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/ca/test/t-ctx_init_clear.c
+++ b/src/ca/test/t-ctx_init_clear.c
@@ -11,7 +11,7 @@
 
 #include "ca.h"
 
-int main()
+int main(void)
 {
     flint_rand_t state;
     ca_ctx_t ctx;

--- a/src/ca/test/t-div.c
+++ b/src/ca/test/t-div.c
@@ -11,7 +11,7 @@
 
 #include "ca.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/ca/test/t-erf.c
+++ b/src/ca/test/t-erf.c
@@ -34,7 +34,7 @@ ca_randtest_zero(ca_t x, flint_rand_t state, ca_ctx_t ctx)
     }
 }
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/ca/test/t-exp.c
+++ b/src/ca/test/t-exp.c
@@ -11,7 +11,7 @@
 
 #include "ca.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/ca/test/t-field_init_clear.c
+++ b/src/ca/test/t-field_init_clear.c
@@ -13,7 +13,7 @@
 #include "ca_ext.h"
 #include "ca_field.h"
 
-int main()
+int main(void)
 {
     flint_rand_t state;
 

--- a/src/ca/test/t-fmpz_mpoly_evaluate.c
+++ b/src/ca/test/t-fmpz_mpoly_evaluate.c
@@ -12,7 +12,7 @@
 #include "ca.h"
 #include "ca_vec.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/ca/test/t-gamma.c
+++ b/src/ca/test/t-gamma.c
@@ -11,7 +11,7 @@
 
 #include "ca.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/ca/test/t-get_fexpr.c
+++ b/src/ca/test/t-get_fexpr.c
@@ -11,7 +11,7 @@
 
 #include "ca.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/ca/test/t-get_str.c
+++ b/src/ca/test/t-get_str.c
@@ -36,7 +36,7 @@ int main(void)
         ca_randtest_special(x, state, 10, 100, ctx);
         s = ca_get_str(x, ctx);
         slen = strlen(s);
-        slen = slen;
+        (void)slen;
         flint_free(s);
 
         ca_clear(x, ctx);

--- a/src/ca/test/t-get_str.c
+++ b/src/ca/test/t-get_str.c
@@ -12,7 +12,7 @@
 #include <string.h>
 #include "ca.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/ca/test/t-init_clear.c
+++ b/src/ca/test/t-init_clear.c
@@ -11,7 +11,7 @@
 
 #include "ca.h"
 
-int main()
+int main(void)
 {
     flint_rand_t state;
 

--- a/src/ca/test/t-log.c
+++ b/src/ca/test/t-log.c
@@ -11,7 +11,7 @@
 
 #include "ca.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/ca/test/t-log_identities.c
+++ b/src/ca/test/t-log_identities.c
@@ -111,7 +111,7 @@ slong hyperbolic_machin_formulas[NUM_FORMULAS2][4][2] = {
 
 
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/ca/test/t-mul.c
+++ b/src/ca/test/t-mul.c
@@ -11,7 +11,7 @@
 
 #include "ca.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/ca/test/t-neg.c
+++ b/src/ca/test/t-neg.c
@@ -11,7 +11,7 @@
 
 #include "ca.h"
 
-int main()
+int main(void)
 {
     flint_rand_t state;
 

--- a/src/ca/test/t-pow.c
+++ b/src/ca/test/t-pow.c
@@ -11,7 +11,7 @@
 
 #include "ca.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/ca/test/t-pow_si_arithmetic.c
+++ b/src/ca/test/t-pow_si_arithmetic.c
@@ -11,7 +11,7 @@
 
 #include "ca.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/ca/test/t-properties.c
+++ b/src/ca/test/t-properties.c
@@ -11,7 +11,7 @@
 
 #include "ca.h"
 
-int main()
+int main(void)
 {
     flint_rand_t state;
 

--- a/src/ca/test/t-re_im.c
+++ b/src/ca/test/t-re_im.c
@@ -11,7 +11,7 @@
 
 #include "ca.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/ca/test/t-sin_cos.c
+++ b/src/ca/test/t-sin_cos.c
@@ -11,7 +11,7 @@
 
 #include "ca.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/ca/test/t-sqrt.c
+++ b/src/ca/test/t-sqrt.c
@@ -11,7 +11,7 @@
 
 #include "ca.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/ca/test/t-sqrt_factor.c
+++ b/src/ca/test/t-sqrt_factor.c
@@ -11,7 +11,7 @@
 
 #include "ca.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/ca/test/t-sub.c
+++ b/src/ca/test/t-sub.c
@@ -11,7 +11,7 @@
 
 #include "ca.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/ca/test/t-tan.c
+++ b/src/ca/test/t-tan.c
@@ -11,7 +11,7 @@
 
 #include "ca.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/ca/test/t-transfer.c
+++ b/src/ca/test/t-transfer.c
@@ -11,7 +11,7 @@
 
 #include "ca.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/ca_ext/test/t-cache_insert.c
+++ b/src/ca_ext/test/t-cache_insert.c
@@ -12,7 +12,7 @@
 #include "ca.h"
 #include "ca_ext.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/ca_field/test/t-cache_insert.c
+++ b/src/ca_field/test/t-cache_insert.c
@@ -27,7 +27,7 @@ static int _ca_field_equal_ext(const ca_field_t K, ca_ext_struct ** x, slong len
     return 1;
 }
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/ca_mat/test/t-adjugate.c
+++ b/src/ca_mat/test/t-adjugate.c
@@ -11,7 +11,7 @@
 
 #include "ca_mat.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/ca_mat/test/t-ca_poly_evaluate.c
+++ b/src/ca_mat/test/t-ca_poly_evaluate.c
@@ -11,7 +11,7 @@
 
 #include "ca_mat.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/ca_mat/test/t-charpoly.c
+++ b/src/ca_mat/test/t-charpoly.c
@@ -11,7 +11,7 @@
 
 #include "ca_mat.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/ca_mat/test/t-charpoly_danilevsky.c
+++ b/src/ca_mat/test/t-charpoly_danilevsky.c
@@ -11,7 +11,7 @@
 
 #include "ca_mat.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/ca_mat/test/t-companion.c
+++ b/src/ca_mat/test/t-companion.c
@@ -11,7 +11,7 @@
 
 #include "ca_mat.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/ca_mat/test/t-det.c
+++ b/src/ca_mat/test/t-det.c
@@ -11,7 +11,7 @@
 
 #include "ca_mat.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/ca_mat/test/t-dft.c
+++ b/src/ca_mat/test/t-dft.c
@@ -11,7 +11,7 @@
 
 #include "ca_mat.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/ca_mat/test/t-diagonalization.c
+++ b/src/ca_mat/test/t-diagonalization.c
@@ -11,7 +11,7 @@
 
 #include "ca_mat.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/ca_mat/test/t-exp.c
+++ b/src/ca_mat/test/t-exp.c
@@ -11,7 +11,7 @@
 
 #include "ca_mat.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/ca_mat/test/t-inv.c
+++ b/src/ca_mat/test/t-inv.c
@@ -11,7 +11,7 @@
 
 #include "ca_mat.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/ca_mat/test/t-jordan_blocks.c
+++ b/src/ca_mat/test/t-jordan_blocks.c
@@ -62,7 +62,7 @@ check_jordan_forms(ca_vec_t lambda1, slong num_blocks1, slong * block_lambda1, s
     return result;
 }
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/ca_mat/test/t-jordan_form.c
+++ b/src/ca_mat/test/t-jordan_form.c
@@ -11,7 +11,7 @@
 
 #include "ca_mat.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/ca_mat/test/t-lu.c
+++ b/src/ca_mat/test/t-lu.c
@@ -94,7 +94,7 @@ ca_mat_randrank(ca_mat_t mat, flint_rand_t state, slong rank, slong bits, ca_ctx
     fmpz_mat_clear(A);
 }
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/ca_mat/test/t-lu_classical.c
+++ b/src/ca_mat/test/t-lu_classical.c
@@ -94,7 +94,7 @@ ca_mat_randrank(ca_mat_t mat, flint_rand_t state, slong rank, slong bits, ca_ctx
     fmpz_mat_clear(A);
 }
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/ca_mat/test/t-lu_recursive.c
+++ b/src/ca_mat/test/t-lu_recursive.c
@@ -94,7 +94,7 @@ ca_mat_randrank(ca_mat_t mat, flint_rand_t state, slong rank, slong bits, ca_ctx
     fmpz_mat_clear(A);
 }
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/ca_mat/test/t-mul.c
+++ b/src/ca_mat/test/t-mul.c
@@ -11,7 +11,7 @@
 
 #include "ca_mat.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/ca_mat/test/t-mul_same_nf.c
+++ b/src/ca_mat/test/t-mul_same_nf.c
@@ -27,7 +27,7 @@ ca_mat_randtest_same_nf(ca_mat_t res, flint_rand_t state, const ca_t x, slong bi
     fmpz_clear(t);
 }
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/ca_mat/test/t-nonsingular_solve.c
+++ b/src/ca_mat/test/t-nonsingular_solve.c
@@ -11,7 +11,7 @@
 
 #include "ca_mat.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/ca_mat/test/t-nonsingular_solve_adjugate.c
+++ b/src/ca_mat/test/t-nonsingular_solve_adjugate.c
@@ -11,7 +11,7 @@
 
 #include "ca_mat.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/ca_mat/test/t-nonsingular_solve_fflu.c
+++ b/src/ca_mat/test/t-nonsingular_solve_fflu.c
@@ -11,7 +11,7 @@
 
 #include "ca_mat.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/ca_mat/test/t-nonsingular_solve_lu.c
+++ b/src/ca_mat/test/t-nonsingular_solve_lu.c
@@ -11,7 +11,7 @@
 
 #include "ca_mat.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/ca_mat/test/t-rank.c
+++ b/src/ca_mat/test/t-rank.c
@@ -11,7 +11,7 @@
 
 #include "ca_mat.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/ca_mat/test/t-right_kernel.c
+++ b/src/ca_mat/test/t-right_kernel.c
@@ -11,7 +11,7 @@
 
 #include "ca_mat.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/ca_mat/test/t-rref.c
+++ b/src/ca_mat/test/t-rref.c
@@ -35,7 +35,7 @@ ca_mat_randrowops(ca_mat_t mat, flint_rand_t state, slong count, ca_ctx_t ctx)
     }
 }
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/ca_mat/test/t-rref_fflu.c
+++ b/src/ca_mat/test/t-rref_fflu.c
@@ -35,7 +35,7 @@ ca_mat_randrowops(ca_mat_t mat, flint_rand_t state, slong count, ca_ctx_t ctx)
     }
 }
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/ca_mat/test/t-rref_lu.c
+++ b/src/ca_mat/test/t-rref_lu.c
@@ -35,7 +35,7 @@ ca_mat_randrowops(ca_mat_t mat, flint_rand_t state, slong count, ca_ctx_t ctx)
     }
 }
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/ca_mat/test/t-solve_tril.c
+++ b/src/ca_mat/test/t-solve_tril.c
@@ -11,7 +11,7 @@
 
 #include "ca_mat.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/ca_mat/test/t-solve_triu.c
+++ b/src/ca_mat/test/t-solve_triu.c
@@ -11,7 +11,7 @@
 
 #include "ca_mat.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/ca_poly/test/t-compose.c
+++ b/src/ca_poly/test/t-compose.c
@@ -11,7 +11,7 @@
 
 #include "ca_poly.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/ca_poly/test/t-div_series.c
+++ b/src/ca_poly/test/t-div_series.c
@@ -43,7 +43,7 @@ ca_poly_truncate(ca_poly_t poly, slong newlen, ca_ctx_t ctx)
     }
 }
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/ca_poly/test/t-divrem.c
+++ b/src/ca_poly/test/t-divrem.c
@@ -11,7 +11,7 @@
 
 #include "ca_poly.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/ca_poly/test/t-evaluate.c
+++ b/src/ca_poly/test/t-evaluate.c
@@ -11,7 +11,7 @@
 
 #include "ca_poly.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/ca_poly/test/t-evaluate_horner.c
+++ b/src/ca_poly/test/t-evaluate_horner.c
@@ -11,7 +11,7 @@
 
 #include "ca_poly.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/ca_poly/test/t-exp_series.c
+++ b/src/ca_poly/test/t-exp_series.c
@@ -43,7 +43,7 @@ ca_poly_truncate(ca_poly_t poly, slong newlen, ca_ctx_t ctx)
     }
 }
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/ca_poly/test/t-factor_squarefree.c
+++ b/src/ca_poly/test/t-factor_squarefree.c
@@ -11,7 +11,7 @@
 
 #include "ca_poly.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/ca_poly/test/t-gcd.c
+++ b/src/ca_poly/test/t-gcd.c
@@ -11,7 +11,7 @@
 
 #include "ca_poly.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/ca_poly/test/t-gcd_euclidean.c
+++ b/src/ca_poly/test/t-gcd_euclidean.c
@@ -11,7 +11,7 @@
 
 #include "ca_poly.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/ca_poly/test/t-inv_series.c
+++ b/src/ca_poly/test/t-inv_series.c
@@ -43,7 +43,7 @@ ca_poly_truncate(ca_poly_t poly, slong newlen, ca_ctx_t ctx)
     }
 }
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/ca_poly/test/t-log_series.c
+++ b/src/ca_poly/test/t-log_series.c
@@ -25,7 +25,7 @@ ca_poly_truncate(ca_poly_t poly, slong newlen, ca_ctx_t ctx)
     }
 }
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/ca_poly/test/t-mul.c
+++ b/src/ca_poly/test/t-mul.c
@@ -29,7 +29,7 @@ ca_poly_randtest_same_nf(ca_poly_t res, flint_rand_t state, const ca_t x, slong 
     fmpz_clear(t);
 }
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/ca_poly/test/t-pow_ui.c
+++ b/src/ca_poly/test/t-pow_ui.c
@@ -11,7 +11,7 @@
 
 #include "ca_poly.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/ca_poly/test/t-roots.c
+++ b/src/ca_poly/test/t-roots.c
@@ -11,7 +11,7 @@
 
 #include "ca_poly.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/ca_poly/test/t-squarefree_part.c
+++ b/src/ca_poly/test/t-squarefree_part.c
@@ -11,7 +11,7 @@
 
 #include "ca_poly.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/dirichlet/test/t-chars.c
+++ b/src/dirichlet/test/t-chars.c
@@ -12,7 +12,7 @@
 #include "dirichlet.h"
 #include "arb.h" /* for test_multiplier */
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/dirichlet/test/t-properties.c
+++ b/src/dirichlet/test/t-properties.c
@@ -35,7 +35,7 @@ random_divisor(flint_rand_t state, const dirichlet_group_t G)
     return d;
 }
 
-int main()
+int main(void)
 {
     slong iter, bits;
     flint_rand_t state;

--- a/src/dirichlet/test/t-vec.c
+++ b/src/dirichlet/test/t-vec.c
@@ -21,7 +21,7 @@ vec_diff(ulong * v, ulong * ref, ulong nv)
     return 0;
 }
 
-int main()
+int main(void)
 {
     ulong q;
 

--- a/src/dlog/test/t-dlog.c
+++ b/src/dlog/test/t-dlog.c
@@ -12,7 +12,7 @@
 #include "nmod.h"
 #include "dlog.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/dlog/test/t-modpe.c
+++ b/src/dlog/test/t-modpe.c
@@ -18,7 +18,7 @@
 #define LIM UWORD(1000000000)
 #endif
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/dlog/test/t-vec.c
+++ b/src/dlog/test/t-vec.c
@@ -38,7 +38,7 @@ dlog_vec_diff(ulong * v, ulong * ref, ulong nv)
     return 0;
 }
 
-int main()
+int main(void)
 {
     slong bits, nv, iter;
     flint_rand_t state;

--- a/src/dlog/vec_pindex_factorgcd.c
+++ b/src/dlog/vec_pindex_factorgcd.c
@@ -35,7 +35,7 @@ factor_until(ulong * n, ulong nlim, const ulong * p, ulong pmax, ulong * fp, int
 ulong
 dlog_vec_pindex_factorgcd(ulong * v, ulong nv, ulong p, nmod_t mod, ulong a, ulong na, ulong loga, ulong logm1, nmod_t order, int maxtry)
 {
-    int nm = 0, ng = 0;
+    int nm = 0;
     ulong pm, logm, pmax;
     ulong u[2], r[2], t;
     ulong up[15], rp[15];
@@ -64,7 +64,6 @@ dlog_vec_pindex_factorgcd(ulong * v, ulong nv, ulong p, nmod_t mod, ulong a, ulo
         i = 1; j = 0; /* flip flap */
         while (r[i] > u[i])
         {
-            ng++;
             if (r[i] < nv && v[r[i]] != DLOG_NOT_FOUND && u[i] < nv && v[u[i]] != DLOG_NOT_FOUND)
             {
                 /* early smooth detection: occurs for primes < 30 bits */

--- a/src/dlog/vec_sieve_precomp.c
+++ b/src/dlog/vec_sieve_precomp.c
@@ -25,11 +25,13 @@
 void
 dlog_vec_sieve_precomp(ulong *v, ulong nv, dlog_precomp_t pre,  ulong a, ulong va, nmod_t mod, ulong na, nmod_t order)
 {
+#if vbs
     ulong smooth = 0, sievecount = 0, logcount = 0, missed = 0;
-    ulong logcost;
+#endif
 #if 0
     ulong limcount;
 #endif
+    ulong logcost;
     ulong k, p, pmax, logm1;
     n_primes_t iter;
     ulong X, aX, vaX;
@@ -69,23 +71,29 @@ dlog_vec_sieve_precomp(ulong *v, ulong nv, dlog_precomp_t pre,  ulong a, ulong v
             continue; /* won't be attained another time */
         cost = log(mod.n)/log(p);
         cost = pow(cost,cost);
+#if vbs
         sievecount++;
+#endif
         /* if (p < p1 || (wp = logp_sieve(w, nv, p, mod.n, logm1, order, logcost)) == NOT_FOUND) */
         /* if (smooth < limcount || (wp = logp_sieve_factor(w, nv, p, mod.n, a, na, va, logm1, order, logcost)) == NOT_FOUND)*/
         if (logcost < cost || (vp = dlog_vec_pindex_factorgcd(v, nv, p, mod, aX, na, vaX, logm1, order, cost)) == DLOG_NOT_FOUND)
         {
+#if vbs
             if (logcost < cost)
                 sievecount--;
             else
                 missed++;
             logcount++;
+#endif
             vp = nmod_mul(dlog_precomp(pre, p), va, order);
         }
         for (k = p, m = 1; k < nv; k += p, m++)
         {
             if (v[m] == DLOG_NOT_FOUND)
                 continue;
+#if vbs
             smooth++;
+#endif
             v[k] = nmod_add(v[m],  vp, order);
         }
     }

--- a/src/double_extras/test/t-lambertw.c
+++ b/src/double_extras/test/t-lambertw.c
@@ -17,7 +17,7 @@
 #define ONE_OVER_E ldexp(6627126856707895.0, -54)
 
 int
-main()
+main(void)
 {
     double x, w, tol;
     slong iter, prec = 70;

--- a/src/double_interval/test/t-fast_add.c
+++ b/src/double_interval/test/t-fast_add.c
@@ -12,7 +12,7 @@
 #include "arf.h"
 #include "double_interval.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/double_interval/test/t-fast_div.c
+++ b/src/double_interval/test/t-fast_div.c
@@ -34,7 +34,7 @@ arf_max2(arf_t res, const arf_t x, const arf_t y)
         arf_max(res, x, y);
 }
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/double_interval/test/t-fast_mul.c
+++ b/src/double_interval/test/t-fast_mul.c
@@ -34,7 +34,7 @@ arf_max2(arf_t res, const arf_t x, const arf_t y)
         arf_max(res, x, y);
 }
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/fexpr/test/t-builtins.c
+++ b/src/fexpr/test/t-builtins.c
@@ -19,7 +19,7 @@
 # include <string.h>
 #endif
 
-int main()
+int main(void)
 {
     flint_rand_t state;
 

--- a/src/fexpr/test/t-call_vec.c
+++ b/src/fexpr/test/t-call_vec.c
@@ -12,7 +12,7 @@
 #include "calcium.h"
 #include "fexpr.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/fexpr/test/t-replace.c
+++ b/src/fexpr/test/t-replace.c
@@ -134,7 +134,7 @@ fexpr_replace_vec_naive(fexpr_t res, const fexpr_t expr, const fexpr_vec_t xs, c
 }
 
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/fexpr/test/t-set_fmpz.c
+++ b/src/fexpr/test/t-set_fmpz.c
@@ -12,7 +12,7 @@
 #include "calcium.h"
 #include "fexpr.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/fexpr/test/t-write_latex.c
+++ b/src/fexpr/test/t-write_latex.c
@@ -90,7 +90,7 @@ fexpr_randtest_gibberish(fexpr_t expr, flint_rand_t state, slong max_leaves, slo
     }
 }
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/fexpr/test/t-write_latex.c
+++ b/src/fexpr/test/t-write_latex.c
@@ -121,7 +121,7 @@ int main(void)
 
         s = fexpr_get_str_latex(expr, flags);
         len = strlen(s);
-        len = len;
+        (void)len;
         flint_free(s);
 
         fexpr_clear(expr);

--- a/src/flint.h
+++ b/src/flint.h
@@ -216,7 +216,7 @@ void _flint_set_num_workers(int num_workers);
 int flint_set_num_workers(int num_workers);
 void flint_reset_num_workers(int max_workers);
 int flint_set_thread_affinity(int * cpus, slong length);
-int flint_restore_thread_affinity();
+int flint_restore_thread_affinity(void);
 
 FLINT_CONST double flint_test_multiplier(void);
 

--- a/src/fmpq_poly/test/t-gegenbauer_c.c
+++ b/src/fmpq_poly/test/t-gegenbauer_c.c
@@ -15,7 +15,7 @@
 
 #define NRATS 20
 
-int main()
+int main(void)
 {
     fmpq_poly_t T0, T1, T2, t, tt;
     fmpq_t a, rat;

--- a/src/fmpq_poly/test/t-laguerre_l.c
+++ b/src/fmpq_poly/test/t-laguerre_l.c
@@ -11,7 +11,7 @@
 
 #include "fmpq_poly.h"
 
-int main()
+int main(void)
 {
     fmpq_poly_t T0, T1, T2, t, tt;
     slong n;

--- a/src/fmpq_poly/test/t-legendre_p.c
+++ b/src/fmpq_poly/test/t-legendre_p.c
@@ -12,7 +12,7 @@
 #include "fmpq_poly.h"
 
 
-int main()
+int main(void)
 {
     fmpq_poly_t Pn, Pn1, Pn2, R;
 

--- a/src/fmpq_vec/test/t-get_set_fmpz_vec.c
+++ b/src/fmpq_vec/test/t-get_set_fmpz_vec.c
@@ -13,7 +13,7 @@
 #include "fmpq.h"
 #include "fmpq_vec.h"
 
-int main()
+int main(void)
 {
     int iter;
     FLINT_TEST_INIT(state);

--- a/src/fmpq_vec/test/t-randtest_uniq_sorted.c
+++ b/src/fmpq_vec/test/t-randtest_uniq_sorted.c
@@ -13,7 +13,7 @@
 #include "fmpq.h"
 #include "fmpq_vec.h"
 
-int main()
+int main(void)
 {
     int iter;
     FLINT_TEST_INIT(state);

--- a/src/fmpz/link/fmpz_single.c
+++ b/src/fmpz/link/fmpz_single.c
@@ -50,7 +50,7 @@ static slong flint_page_size;
 static slong flint_mpz_structs_per_block;
 static slong flint_page_mask;
 
-slong flint_get_page_size()
+slong flint_get_page_size(void)
 {
 #if defined(__unix__)
    return sysconf(_SC_PAGESIZE);

--- a/src/fmpz/test/t-comb_init_clear.c
+++ b/src/fmpz/test/t-comb_init_clear.c
@@ -15,7 +15,7 @@
 #include "fmpz.h"
 
 
-int main()
+int main(void)
 {
     slong i, j;
     mp_limb_t n;

--- a/src/fmpz/test/t-crt.c
+++ b/src/fmpz/test/t-crt.c
@@ -15,7 +15,7 @@
 #include "ulong_extras.h"
 
 
-int main()
+int main(void)
 {
     slong i, j;
     int sign;

--- a/src/fmpz/test/t-crt_ui.c
+++ b/src/fmpz/test/t-crt_ui.c
@@ -14,7 +14,7 @@
 #include "ulong_extras.h"
 
 
-int main()
+int main(void)
 {
     slong i, j;
     int sign;

--- a/src/fmpz/test/t-get_mpn.c
+++ b/src/fmpz/test/t-get_mpn.c
@@ -14,7 +14,7 @@
 #include "mpn_extras.h"
 #include "fmpz.h"
 
-int main()
+int main(void)
 {
 
     fmpz_t a, b, mmin;

--- a/src/fmpz/test/t-multi_CRT_ui.c
+++ b/src/fmpz/test/t-multi_CRT_ui.c
@@ -16,7 +16,7 @@
 #include "fmpz_vec.h"
 
 
-int main()
+int main(void)
 {
     fmpz_t input, temp, prod;
     mp_limb_t * output;

--- a/src/fmpz_extras/test/t-add2_fmpz_si_inline.c
+++ b/src/fmpz_extras/test/t-add2_fmpz_si_inline.c
@@ -11,7 +11,7 @@
 
 #include "fmpz_extras.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/fmpz_extras/test/t-add_inline.c
+++ b/src/fmpz_extras/test/t-add_inline.c
@@ -11,7 +11,7 @@
 
 #include "fmpz_extras.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/fmpz_extras/test/t-add_si_inline.c
+++ b/src/fmpz_extras/test/t-add_si_inline.c
@@ -11,7 +11,7 @@
 
 #include "fmpz_extras.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/fmpz_extras/test/t-add_ui_inline.c
+++ b/src/fmpz_extras/test/t-add_ui_inline.c
@@ -11,7 +11,7 @@
 
 #include "fmpz_extras.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/fmpz_extras/test/t-lshift_mpn.c
+++ b/src/fmpz_extras/test/t-lshift_mpn.c
@@ -11,7 +11,7 @@
 
 #include "fmpz_extras.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/fmpz_extras/test/t-sub_si_inline.c
+++ b/src/fmpz_extras/test/t-sub_si_inline.c
@@ -11,7 +11,7 @@
 
 #include "fmpz_extras.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/fmpz_lll/babai.c
+++ b/src/fmpz_lll/babai.c
@@ -639,7 +639,7 @@ FUNC_HEAD
 
 #else
 
-void osxdummy18464823876() /* OSX doesn't like empty files */
+void osxdummy18464823876(void) /* OSX doesn't like empty files */
 {
 }
 

--- a/src/fmpz_lll/d_lll.c
+++ b/src/fmpz_lll/d_lll.c
@@ -743,7 +743,7 @@ FUNC_HEAD
 
 #else
 
-void osxdummy29398462983() /* OSX doesn't like empty files */
+void osxdummy29398462983(void) /* OSX doesn't like empty files */
 {
 }
 

--- a/src/fmpz_lll/mpf2_lll.c
+++ b/src/fmpz_lll/mpf2_lll.c
@@ -612,7 +612,7 @@ FUNC_HEAD
 
 #else
 
-void osxdummy9283479238479() /* OSX doesn't like empty files */
+void osxdummy9283479238479(void) /* OSX doesn't like empty files */
 {
 }
 

--- a/src/fmpz_mat/test/t-content.c
+++ b/src/fmpz_mat/test/t-content.c
@@ -12,7 +12,7 @@
 #include "fmpz.h"
 #include "fmpz_mat.h"
 
-int main()
+int main(void)
 {
 	int i;
 	fmpz_mat_t A,B;

--- a/src/fmpz_mpoly_factor/test/t-factor_squarefree.c
+++ b/src/fmpz_mpoly_factor/test/t-factor_squarefree.c
@@ -92,7 +92,6 @@ main(void)
 
     for (i = 0; i < tmul * flint_test_multiplier(); i++)
     {
-        slong lower;
         fmpz_mpoly_ctx_t ctx;
         fmpz_mpoly_t a, t;
         flint_bitcnt_t coeff_bits;
@@ -109,7 +108,6 @@ main(void)
         powbound = 1 + n_randint(state, 5);
         expbound = 2 + 50/nfacs/n/powbound;
 
-        lower = 0;
         fmpz_mpoly_one(a, ctx);
         for (j = 0; j < nfacs; j++)
         {
@@ -119,8 +117,6 @@ main(void)
             if (fmpz_mpoly_is_zero(t, ctx))
                 fmpz_mpoly_one(t, ctx);
             pow = 1 + n_randint(state, powbound);
-            if (!fmpz_mpoly_is_fmpz(t, ctx))
-                lower += pow;
             fmpz_mpoly_pow_ui(t, t, pow, ctx);
             fmpz_mpoly_mul(a, a, t, ctx);
         }

--- a/src/fmpz_mpoly_q/test/t-add.c
+++ b/src/fmpz_mpoly_q/test/t-add.c
@@ -12,7 +12,7 @@
 #include "calcium.h"
 #include "fmpz_mpoly_q.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/fmpz_mpoly_q/test/t-add_fmpq.c
+++ b/src/fmpz_mpoly_q/test/t-add_fmpq.c
@@ -12,7 +12,7 @@
 #include "calcium.h"
 #include "fmpz_mpoly_q.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/fmpz_mpoly_q/test/t-add_fmpz.c
+++ b/src/fmpz_mpoly_q/test/t-add_fmpz.c
@@ -12,7 +12,7 @@
 #include "calcium.h"
 #include "fmpz_mpoly_q.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/fmpz_mpoly_q/test/t-div.c
+++ b/src/fmpz_mpoly_q/test/t-div.c
@@ -12,7 +12,7 @@
 #include "calcium.h"
 #include "fmpz_mpoly_q.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/fmpz_mpoly_q/test/t-div_fmpq.c
+++ b/src/fmpz_mpoly_q/test/t-div_fmpq.c
@@ -12,7 +12,7 @@
 #include "calcium.h"
 #include "fmpz_mpoly_q.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/fmpz_mpoly_q/test/t-div_fmpz.c
+++ b/src/fmpz_mpoly_q/test/t-div_fmpz.c
@@ -12,7 +12,7 @@
 #include "calcium.h"
 #include "fmpz_mpoly_q.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/fmpz_mpoly_q/test/t-inv.c
+++ b/src/fmpz_mpoly_q/test/t-inv.c
@@ -12,7 +12,7 @@
 #include "calcium.h"
 #include "fmpz_mpoly_q.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/fmpz_mpoly_q/test/t-mul.c
+++ b/src/fmpz_mpoly_q/test/t-mul.c
@@ -12,7 +12,7 @@
 #include "calcium.h"
 #include "fmpz_mpoly_q.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/fmpz_mpoly_q/test/t-mul_fmpq.c
+++ b/src/fmpz_mpoly_q/test/t-mul_fmpq.c
@@ -12,7 +12,7 @@
 #include "calcium.h"
 #include "fmpz_mpoly_q.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/fmpz_mpoly_q/test/t-mul_fmpz.c
+++ b/src/fmpz_mpoly_q/test/t-mul_fmpz.c
@@ -12,7 +12,7 @@
 #include "calcium.h"
 #include "fmpz_mpoly_q.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/fmpz_mpoly_q/test/t-randtest.c
+++ b/src/fmpz_mpoly_q/test/t-randtest.c
@@ -12,7 +12,7 @@
 #include "calcium.h"
 #include "fmpz_mpoly_q.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/fmpz_mpoly_q/test/t-sub.c
+++ b/src/fmpz_mpoly_q/test/t-sub.c
@@ -12,7 +12,7 @@
 #include "calcium.h"
 #include "fmpz_mpoly_q.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/fmpz_mpoly_q/test/t-sub_fmpq.c
+++ b/src/fmpz_mpoly_q/test/t-sub_fmpq.c
@@ -12,7 +12,7 @@
 #include "calcium.h"
 #include "fmpz_mpoly_q.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/fmpz_mpoly_q/test/t-sub_fmpz.c
+++ b/src/fmpz_mpoly_q/test/t-sub_fmpz.c
@@ -12,7 +12,7 @@
 #include "calcium.h"
 #include "fmpz_mpoly_q.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/fmpz_poly/test/t-chebyshev_t.c
+++ b/src/fmpz_poly/test/t-chebyshev_t.c
@@ -11,7 +11,7 @@
 
 #include "fmpz_poly.h"
 
-int main()
+int main(void)
 {
     fmpz_poly_t T0, T1, T2, t;
     slong n;

--- a/src/fmpz_poly/test/t-chebyshev_u.c
+++ b/src/fmpz_poly/test/t-chebyshev_u.c
@@ -11,7 +11,7 @@
 
 #include "fmpz_poly.h"
 
-int main()
+int main(void)
 {
     fmpz_poly_t T, U;
 

--- a/src/fmpz_poly/test/t-cos_minpoly.c
+++ b/src/fmpz_poly/test/t-cos_minpoly.c
@@ -52,7 +52,7 @@ static const short testdata[] = {
 };
 
 
-int main()
+int main(void)
 {
     fmpz_poly_t p;
     slong n;

--- a/src/fmpz_poly/test/t-cyclotomic.c
+++ b/src/fmpz_poly/test/t-cyclotomic.c
@@ -52,7 +52,7 @@ void cyclotomic_naive(fmpz_poly_t poly, ulong n)
     fmpz_poly_clear(t);
 }
 
-int main()
+int main(void)
 {
     fmpz_poly_t A, B;
     slong n;

--- a/src/fmpz_poly/test/t-eulerian_polynomial.c
+++ b/src/fmpz_poly/test/t-eulerian_polynomial.c
@@ -13,7 +13,7 @@
 #include "fmpz.h"
 #include "fmpz_poly.h"
 
-int main()
+int main(void)
 {
     ulong n, ix, mx;
     fmpz_t sum, fac;

--- a/src/fmpz_poly/test/t-hermite_h.c
+++ b/src/fmpz_poly/test/t-hermite_h.c
@@ -12,7 +12,7 @@
 #include "fmpz_poly.h"
 
 int
-main()
+main(void)
 {
     fmpz_poly_t T0, T1, t1, t2;
     slong n;

--- a/src/fmpz_poly/test/t-hermite_he.c
+++ b/src/fmpz_poly/test/t-hermite_he.c
@@ -12,7 +12,7 @@
 #include "fmpz_poly.h"
 
 int
-main()
+main(void)
 {
     fmpz_poly_t T0, T1, t1, t2;
     slong n;

--- a/src/fmpz_poly/test/t-legendre_pt.c
+++ b/src/fmpz_poly/test/t-legendre_pt.c
@@ -11,7 +11,7 @@
 
 #include "fmpz_poly.h"
 
-int main()
+int main(void)
 {
     fmpz_poly_t T0, T1, T2, t, tt;
     slong n;

--- a/src/fmpz_poly/test/t-num_real_roots.c
+++ b/src/fmpz_poly/test/t-num_real_roots.c
@@ -12,7 +12,7 @@
 #include "flint.h"
 #include "fmpz_poly.h"
 
-int main()
+int main(void)
 {
     int iter;
 

--- a/src/fmpz_poly/test/t-num_real_roots_sturm.c
+++ b/src/fmpz_poly/test/t-num_real_roots_sturm.c
@@ -13,7 +13,7 @@
 #include "fmpq.h"
 #include "fmpq_vec.h"
 
-int main()
+int main(void)
 {
     int iter;
 

--- a/src/fmpz_poly/test/t-product_roots_fmpq_vec.c
+++ b/src/fmpz_poly/test/t-product_roots_fmpq_vec.c
@@ -13,7 +13,7 @@
 #include "fmpq.h"
 #include "fmpq_vec.h"
 
-int main()
+int main(void)
 {
     slong iter;
 

--- a/src/fmpz_poly/test/t-randtest_no_real_root.c
+++ b/src/fmpz_poly/test/t-randtest_no_real_root.c
@@ -12,7 +12,7 @@
 #include "fmpz.h"
 #include "fmpz_poly.h"
 
-int main()
+int main(void)
 {
     int iter;
     FLINT_TEST_INIT(state);

--- a/src/fmpz_poly/test/t-remove_content_2exp.c
+++ b/src/fmpz_poly/test/t-remove_content_2exp.c
@@ -11,7 +11,7 @@
 
 #include "fmpz_poly.h"
 
-int main()
+int main(void)
 {
     int iter;
     FLINT_TEST_INIT(state);

--- a/src/fmpz_poly/test/t-scale_2exp.c
+++ b/src/fmpz_poly/test/t-scale_2exp.c
@@ -12,7 +12,7 @@
 #include "fmpz.h"
 #include "fmpz_poly.h"
 
-int main()
+int main(void)
 {
     int iter;
     FLINT_TEST_INIT(state);

--- a/src/fmpz_poly/test/t-swinnerton_dyer.c
+++ b/src/fmpz_poly/test/t-swinnerton_dyer.c
@@ -26,7 +26,7 @@ static const mp_limb_t known_values[] =
     UWORD(394942914)
 };
 
-int main()
+int main(void)
 {
     fmpz_poly_t S;
     mp_limb_t r;

--- a/src/fmpzi/test/t-add_sub.c
+++ b/src/fmpzi/test/t-add_sub.c
@@ -12,7 +12,7 @@
 #include "fmpz_extras.h"
 #include "fmpzi.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/fmpzi/test/t-divexact.c
+++ b/src/fmpzi/test/t-divexact.c
@@ -12,7 +12,7 @@
 #include "fmpz_extras.h"
 #include "fmpzi.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/fmpzi/test/t-divrem.c
+++ b/src/fmpzi/test/t-divrem.c
@@ -62,7 +62,7 @@ fmpzi_divrem_ref(fmpzi_t q, fmpzi_t r, const fmpzi_t x, const fmpzi_t y)
 }
 
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/fmpzi/test/t-divrem_approx.c
+++ b/src/fmpzi/test/t-divrem_approx.c
@@ -12,7 +12,7 @@
 #include "fmpz_extras.h"
 #include "fmpzi.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/fmpzi/test/t-gcd.c
+++ b/src/fmpzi/test/t-gcd.c
@@ -12,7 +12,7 @@
 #include "fmpz_extras.h"
 #include "fmpzi.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/fmpzi/test/t-gcd_binary.c
+++ b/src/fmpzi/test/t-gcd_binary.c
@@ -12,7 +12,7 @@
 #include "fmpz_extras.h"
 #include "fmpzi.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/fmpzi/test/t-gcd_euclidean.c
+++ b/src/fmpzi/test/t-gcd_euclidean.c
@@ -12,7 +12,7 @@
 #include "fmpz_extras.h"
 #include "fmpzi.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/fmpzi/test/t-gcd_euclidean_improved.c
+++ b/src/fmpzi/test/t-gcd_euclidean_improved.c
@@ -12,7 +12,7 @@
 #include "fmpz_extras.h"
 #include "fmpzi.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/fmpzi/test/t-gcd_shortest.c
+++ b/src/fmpzi/test/t-gcd_shortest.c
@@ -12,7 +12,7 @@
 #include "fmpz_extras.h"
 #include "fmpzi.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/fmpzi/test/t-mul.c
+++ b/src/fmpzi/test/t-mul.c
@@ -12,7 +12,7 @@
 #include "fmpz_extras.h"
 #include "fmpzi.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/fmpzi/test/t-pow_ui.c
+++ b/src/fmpzi/test/t-pow_ui.c
@@ -12,7 +12,7 @@
 #include "fmpz_extras.h"
 #include "fmpzi.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/fmpzi/test/t-remove_one_plus_i.c
+++ b/src/fmpzi/test/t-remove_one_plus_i.c
@@ -12,7 +12,7 @@
 #include "fmpz_extras.h"
 #include "fmpzi.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/fq_poly_templates/get_str.c
+++ b/src/fq_poly_templates/get_str.c
@@ -22,7 +22,7 @@ char *_TEMPLATE(T, poly_get_str) (const TEMPLATE(T, struct) * poly, slong len,
 {
     char *str, **coeffstrs;
     size_t off;
-    slong i, bound, nz;
+    slong i, bound;
 
     if (len == 0)
     {
@@ -34,7 +34,6 @@ char *_TEMPLATE(T, poly_get_str) (const TEMPLATE(T, struct) * poly, slong len,
 
     coeffstrs = (char **)flint_malloc(len * sizeof(char *));
 
-    nz = 0;
     bound = (slong) (ceil(log10((double)(len + 1)))) + 2;
     for (i = 0; i < len; i++)
     {
@@ -42,7 +41,6 @@ char *_TEMPLATE(T, poly_get_str) (const TEMPLATE(T, struct) * poly, slong len,
         {
             coeffstrs[i] = TEMPLATE(T, get_str) (poly + i, ctx);
             bound += 1 + strlen(coeffstrs[i]);
-            nz++;
         }
         else
         {

--- a/src/generic_files/exception.c
+++ b/src/generic_files/exception.c
@@ -20,7 +20,7 @@
 static pthread_once_t abort_func_init = PTHREAD_ONCE_INIT;
 pthread_mutex_t abort_func_lock;
 
-void __flint_set_abort_init()
+void __flint_set_abort_init(void)
 {
    pthread_mutex_init(&abort_func_lock, NULL);
 }
@@ -42,7 +42,7 @@ void flint_set_abort(FLINT_NORETURN void (*func)(void))
 #endif
 }
 
-FLINT_NORETURN void flint_abort()
+FLINT_NORETURN void flint_abort(void)
 {
     fflush(stdout);
     fflush(stderr);

--- a/src/generic_files/memory_manager.c
+++ b/src/generic_files/memory_manager.c
@@ -40,7 +40,7 @@ pthread_mutex_t register_lock;
 static pthread_once_t alloc_func_init = PTHREAD_ONCE_INIT;
 pthread_mutex_t alloc_func_lock;
 
-void __flint_set_memory_functions_init()
+void __flint_set_memory_functions_init(void)
 {
    pthread_mutex_init(&alloc_func_lock, NULL);
 }
@@ -186,7 +186,7 @@ FLINT_TLS_PREFIX size_t flint_num_cleanup_functions = 0;
 FLINT_TLS_PREFIX flint_cleanup_function_t * flint_cleanup_functions = NULL;
 
 #if FLINT_REENTRANT && !FLINT_USES_TLS
-void register_init()
+void register_init(void)
 {
    pthread_mutex_init(&register_lock, NULL);
 }
@@ -211,9 +211,9 @@ void flint_register_cleanup_function(flint_cleanup_function_t cleanup_function)
 #endif
 }
 
-void _fmpz_cleanup();
+void _fmpz_cleanup(void);
 
-void _flint_cleanup()
+void _flint_cleanup(void)
 {
     size_t i;
 
@@ -237,14 +237,14 @@ void _flint_cleanup()
 
 }
 
-void flint_cleanup()
+void flint_cleanup(void)
 {
 #if !FLINT_REENTRANT || FLINT_USES_TLS
    _flint_cleanup();
 #endif
 }
 
-void flint_cleanup_master()
+void flint_cleanup_master(void)
 {
     if (global_thread_pool_initialized)
     {

--- a/src/generic_files/test_helpers.c
+++ b/src/generic_files/test_helpers.c
@@ -14,7 +14,7 @@
 
 double _flint_test_multiplier = -1.0;
 
-double flint_test_multiplier()
+double flint_test_multiplier(void)
 {
     if (_flint_test_multiplier == -1.0)
     {

--- a/src/gr.h
+++ b/src/gr.h
@@ -753,7 +753,7 @@ typedef gr_ctx_struct gr_ctx_t[1];
 GR_INLINE void * gr_ctx_data_ptr(gr_ctx_t ctx) { return (void *) ctx->data; }
 GR_INLINE void * gr_ctx_data_as_ptr(gr_ctx_t ctx) { return (void *) GR_CTX_DATA_AS_PTR(ctx); }
 
-GR_INLINE slong gr_ctx_sizeof_ctx()
+GR_INLINE slong gr_ctx_sizeof_ctx(void)
 {
     return sizeof(gr_ctx_struct);
 }

--- a/src/gr/test/t-acb.c
+++ b/src/gr/test/t-acb.c
@@ -1,6 +1,6 @@
 #include "gr.h"
 
-int main()
+int main(void)
 {
     gr_ctx_t CC;
     int flags = 0;

--- a/src/gr/test/t-arb.c
+++ b/src/gr/test/t-arb.c
@@ -1,6 +1,6 @@
 #include "gr.h"
 
-int main()
+int main(void)
 {
     gr_ctx_t RR;
     int flags = 0;

--- a/src/gr/test/t-ca.c
+++ b/src/gr/test/t-ca.c
@@ -1,6 +1,6 @@
 #include "gr.h"
 
-int main()
+int main(void)
 {
     gr_ctx_t RR, CC, QQbar_real, QQbar;
     int flags = 0;

--- a/src/gr/test/t-dirichlet.c
+++ b/src/gr/test/t-dirichlet.c
@@ -1,7 +1,7 @@
 #include "ulong_extras.h"
 #include "gr.h"
 
-int main()
+int main(void)
 {
     gr_ctx_t G;
     int flags = GR_TEST_ALWAYS_ABLE;

--- a/src/gr/test/t-fmpq.c
+++ b/src/gr/test/t-fmpq.c
@@ -1,6 +1,6 @@
 #include "gr.h"
 
-int main()
+int main(void)
 {
     gr_ctx_t QQ;
     int flags = GR_TEST_ALWAYS_ABLE;

--- a/src/gr/test/t-fmpz.c
+++ b/src/gr/test/t-fmpz.c
@@ -1,7 +1,7 @@
 #include "fmpz.h"
 #include "gr.h"
 
-int main()
+int main(void)
 {
     gr_ctx_t ZZ;
     int flags = GR_TEST_ALWAYS_ABLE;

--- a/src/gr/test/t-fmpz_mod.c
+++ b/src/gr/test/t-fmpz_mod.c
@@ -1,7 +1,7 @@
 #include "fmpz.h"
 #include "gr.h"
 
-int main()
+int main(void)
 {
     gr_ctx_t ZZn;
     fmpz_t n;

--- a/src/gr/test/t-fmpz_mpoly_evaluate.c
+++ b/src/gr/test/t-fmpz_mpoly_evaluate.c
@@ -13,7 +13,7 @@
 #include "gr.h"
 #include "gr_vec.h"
 
-int main()
+int main(void)
 {
     slong iter;
     slong count_success = 0, count_unable = 0, count_domain = 0;

--- a/src/gr/test/t-fmpz_poly.c
+++ b/src/gr/test/t-fmpz_poly.c
@@ -1,6 +1,6 @@
 #include "gr.h"
 
-int main()
+int main(void)
 {
     gr_ctx_t ZZx;
     int flags = GR_TEST_ALWAYS_ABLE;

--- a/src/gr/test/t-fmpz_poly_evaluate.c
+++ b/src/gr/test/t-fmpz_poly_evaluate.c
@@ -46,7 +46,7 @@ evaluate(flint_rand_t state, gr_ptr res, const fmpz_poly_t f, gr_srcptr x, gr_ct
     return status;
 }
 
-int main()
+int main(void)
 {
     slong iter;
     slong count_success = 0, count_unable = 0, count_domain = 0;

--- a/src/gr/test/t-fmpzi.c
+++ b/src/gr/test/t-fmpzi.c
@@ -1,6 +1,6 @@
 #include "gr.h"
 
-int main()
+int main(void)
 {
     gr_ctx_t ZZi;
     int flags = GR_TEST_ALWAYS_ABLE;

--- a/src/gr/test/t-fq.c
+++ b/src/gr/test/t-fq.c
@@ -1,7 +1,7 @@
 #include "fmpz.h"
 #include "gr.h"
 
-int main()
+int main(void)
 {
     gr_ctx_t Fq;
     fmpz_t p;

--- a/src/gr/test/t-fq_nmod.c
+++ b/src/gr/test/t-fq_nmod.c
@@ -1,7 +1,7 @@
 #include "fmpz.h"
 #include "gr.h"
 
-int main()
+int main(void)
 {
     gr_ctx_t Fq;
     fmpz_t p;

--- a/src/gr/test/t-fq_zech.c
+++ b/src/gr/test/t-fq_zech.c
@@ -1,7 +1,7 @@
 #include "fmpz.h"
 #include "gr.h"
 
-int main()
+int main(void)
 {
     gr_ctx_t Fq;
     fmpz_t p;

--- a/src/gr/test/t-matrix_acb.c
+++ b/src/gr/test/t-matrix_acb.c
@@ -1,6 +1,6 @@
 #include "gr.h"
 
-int main()
+int main(void)
 {
     gr_ctx_t CC, MatCC;
     slong n;

--- a/src/gr/test/t-matrix_arb.c
+++ b/src/gr/test/t-matrix_arb.c
@@ -1,6 +1,6 @@
 #include "gr.h"
 
-int main()
+int main(void)
 {
     gr_ctx_t RR, MatRR;
     slong n;

--- a/src/gr/test/t-matrix_fmpq.c
+++ b/src/gr/test/t-matrix_fmpq.c
@@ -1,6 +1,6 @@
 #include "gr.h"
 
-int main()
+int main(void)
 {
     gr_ctx_t QQ, MatQQ;
     slong n;

--- a/src/gr/test/t-matrix_fmpz.c
+++ b/src/gr/test/t-matrix_fmpz.c
@@ -1,6 +1,6 @@
 #include "gr.h"
 
-int main()
+int main(void)
 {
     gr_ctx_t ZZ, MatZZ;
     slong n;

--- a/src/gr/test/t-matrix_nmod8.c
+++ b/src/gr/test/t-matrix_nmod8.c
@@ -1,7 +1,7 @@
 #include "ulong_extras.h"
 #include "gr.h"
 
-int main()
+int main(void)
 {
     gr_ctx_t ZZn, MatZZn;
     slong iter, n;

--- a/src/gr/test/t-mpoly_nmod8.c
+++ b/src/gr/test/t-mpoly_nmod8.c
@@ -1,7 +1,7 @@
 #include "mpoly.h"
 #include "gr.h"
 
-int main()
+int main(void)
 {
     gr_ctx_t ZZn, ZZnx;
     slong iter;

--- a/src/gr/test/t-nmod.c
+++ b/src/gr/test/t-nmod.c
@@ -1,7 +1,7 @@
 #include "ulong_extras.h"
 #include "gr.h"
 
-int main()
+int main(void)
 {
     gr_ctx_t ZZn;
     int flags = GR_TEST_ALWAYS_ABLE;

--- a/src/gr/test/t-nmod8.c
+++ b/src/gr/test/t-nmod8.c
@@ -1,6 +1,6 @@
 #include "gr.h"
 
-int main()
+int main(void)
 {
     gr_ctx_t ZZn;
     int flags = GR_TEST_ALWAYS_ABLE;

--- a/src/gr/test/t-perm.c
+++ b/src/gr/test/t-perm.c
@@ -1,6 +1,6 @@
 #include "gr.h"
 
-int main()
+int main(void)
 {
     gr_ctx_t G;
     int flags = GR_TEST_ALWAYS_ABLE;

--- a/src/gr/test/t-polynomial_acb.c
+++ b/src/gr/test/t-polynomial_acb.c
@@ -1,6 +1,6 @@
 #include "gr.h"
 
-int main()
+int main(void)
 {
     gr_ctx_t CC, CCx;
     int flags = 0;

--- a/src/gr/test/t-polynomial_arb.c
+++ b/src/gr/test/t-polynomial_arb.c
@@ -1,6 +1,6 @@
 #include "gr.h"
 
-int main()
+int main(void)
 {
     gr_ctx_t RR, RRx;
     int flags = 0;

--- a/src/gr/test/t-polynomial_fmpq.c
+++ b/src/gr/test/t-polynomial_fmpq.c
@@ -1,6 +1,6 @@
 #include "gr.h"
 
-int main()
+int main(void)
 {
     gr_ctx_t QQ, QQx;
     int flags = 0;

--- a/src/gr/test/t-polynomial_fmpz.c
+++ b/src/gr/test/t-polynomial_fmpz.c
@@ -1,6 +1,6 @@
 #include "gr.h"
 
-int main()
+int main(void)
 {
     gr_ctx_t ZZ, ZZx;
     int flags = 0;

--- a/src/gr/test/t-polynomial_nmod8.c
+++ b/src/gr/test/t-polynomial_nmod8.c
@@ -1,7 +1,7 @@
 #include "ulong_extras.h"
 #include "gr.h"
 
-int main()
+int main(void)
 {
     gr_ctx_t ZZn, ZZnx;
     slong iter;

--- a/src/gr/test/t-psl2z.c
+++ b/src/gr/test/t-psl2z.c
@@ -1,6 +1,6 @@
 #include "gr.h"
 
-int main()
+int main(void)
 {
     gr_ctx_t PSL2Z;
     int flags = GR_TEST_ALWAYS_ABLE;

--- a/src/gr/test/t-qqbar.c
+++ b/src/gr/test/t-qqbar.c
@@ -1,6 +1,6 @@
 #include "gr.h"
 
-int main()
+int main(void)
 {
     gr_ctx_t QQbar_real, QQbar;
     int flags = GR_TEST_ALWAYS_ABLE;

--- a/src/gr/test/t-series_acb.c
+++ b/src/gr/test/t-series_acb.c
@@ -1,7 +1,7 @@
 #include "ulong_extras.h"
 #include "gr.h"
 
-int main()
+int main(void)
 {
     gr_ctx_t CCn, CCnx;
     int flags = 0;

--- a/src/gr/test/t-series_arb.c
+++ b/src/gr/test/t-series_arb.c
@@ -1,7 +1,7 @@
 #include "ulong_extras.h"
 #include "gr.h"
 
-int main()
+int main(void)
 {
     gr_ctx_t RRn, RRnx;
     int flags = 0;

--- a/src/gr/test/t-series_fmpq.c
+++ b/src/gr/test/t-series_fmpq.c
@@ -1,6 +1,6 @@
 #include "gr.h"
 
-int main()
+int main(void)
 {
     gr_ctx_t QQ, QQx;
     int flags = 0;

--- a/src/gr/test/t-series_fmpz.c
+++ b/src/gr/test/t-series_fmpz.c
@@ -1,6 +1,6 @@
 #include "gr.h"
 
-int main()
+int main(void)
 {
     gr_ctx_t ZZ, ZZx;
     int flags = 0;

--- a/src/gr/test/t-series_nmod8.c
+++ b/src/gr/test/t-series_nmod8.c
@@ -1,7 +1,7 @@
 #include "ulong_extras.h"
 #include "gr.h"
 
-int main()
+int main(void)
 {
     gr_ctx_t ZZn, ZZnx;
     int flags = 0;

--- a/src/gr_mat/test/t-adjugate.c
+++ b/src/gr_mat/test/t-adjugate.c
@@ -14,7 +14,7 @@
 
 FLINT_DLL extern gr_static_method_table _ca_methods;
 
-int main()
+int main(void)
 {
     slong iter;
     slong count_success = 0, count_unable = 0, count_domain = 0;

--- a/src/gr_mat/test/t-charpoly_danilevsky.c
+++ b/src/gr_mat/test/t-charpoly_danilevsky.c
@@ -14,7 +14,7 @@
 
 FLINT_DLL extern gr_static_method_table _ca_methods;
 
-int main()
+int main(void)
 {
     slong iter;
     slong count_success = 0, count_unable = 0, count_domain = 0;

--- a/src/gr_mat/test/t-charpoly_faddeev.c
+++ b/src/gr_mat/test/t-charpoly_faddeev.c
@@ -14,7 +14,7 @@
 
 FLINT_DLL extern gr_static_method_table _ca_methods;
 
-int main()
+int main(void)
 {
     slong iter;
     slong count_success = 0, count_unable = 0, count_domain = 0;

--- a/src/gr_mat/test/t-charpoly_faddeev_bsgs.c
+++ b/src/gr_mat/test/t-charpoly_faddeev_bsgs.c
@@ -14,7 +14,7 @@
 
 FLINT_DLL extern gr_static_method_table _ca_methods;
 
-int main()
+int main(void)
 {
     slong iter;
     slong count_success = 0, count_unable = 0, count_domain = 0;

--- a/src/gr_mat/test/t-charpoly_gauss.c
+++ b/src/gr_mat/test/t-charpoly_gauss.c
@@ -14,7 +14,7 @@
 
 FLINT_DLL extern gr_static_method_table _ca_methods;
 
-int main()
+int main(void)
 {
     slong iter;
     slong count_success = 0, count_unable = 0, count_domain = 0;

--- a/src/gr_mat/test/t-charpoly_householder.c
+++ b/src/gr_mat/test/t-charpoly_householder.c
@@ -14,7 +14,7 @@
 
 FLINT_DLL extern gr_static_method_table _ca_methods;
 
-int main()
+int main(void)
 {
     slong iter;
     slong count_success = 0, count_unable = 0, count_domain = 0;

--- a/src/gr_mat/test/t-concat_horizontal.c
+++ b/src/gr_mat/test/t-concat_horizontal.c
@@ -11,7 +11,7 @@
 
 #include "gr_mat.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/gr_mat/test/t-concat_vertical.c
+++ b/src/gr_mat/test/t-concat_vertical.c
@@ -11,7 +11,7 @@
 
 #include "gr_mat.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/gr_mat/test/t-det_berkowitz.c
+++ b/src/gr_mat/test/t-det_berkowitz.c
@@ -14,7 +14,7 @@
 
 FLINT_DLL extern gr_static_method_table _ca_methods;
 
-int main()
+int main(void)
 {
     slong iter;
     slong count_success = 0, count_unable = 0, count_domain = 0;

--- a/src/gr_mat/test/t-det_cofactor.c
+++ b/src/gr_mat/test/t-det_cofactor.c
@@ -14,7 +14,7 @@
 
 FLINT_DLL extern gr_static_method_table _ca_methods;
 
-int main()
+int main(void)
 {
     slong iter;
     slong count_success = 0, count_unable = 0, count_domain = 0;

--- a/src/gr_mat/test/t-det_fflu.c
+++ b/src/gr_mat/test/t-det_fflu.c
@@ -14,7 +14,7 @@
 
 FLINT_DLL extern gr_static_method_table _ca_methods;
 
-int main()
+int main(void)
 {
     slong iter;
     slong count_success = 0, count_unable = 0, count_domain = 0;

--- a/src/gr_mat/test/t-det_lu.c
+++ b/src/gr_mat/test/t-det_lu.c
@@ -14,7 +14,7 @@
 
 FLINT_DLL extern gr_static_method_table _ca_methods;
 
-int main()
+int main(void)
 {
     slong iter;
     slong count_success = 0, count_unable = 0, count_domain = 0;

--- a/src/gr_mat/test/t-diagonalization.c
+++ b/src/gr_mat/test/t-diagonalization.c
@@ -2,7 +2,7 @@
 #include "gr_vec.h"
 #include "gr_mat.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/gr_mat/test/t-hadamard.c
+++ b/src/gr_mat/test/t-hadamard.c
@@ -1,7 +1,7 @@
 
 #include "gr_mat.h"
 
-int main()
+int main(void)
 {
     slong iter;
     slong count_success = 0, count_unable = 0, count_domain = 0;

--- a/src/gr_mat/test/t-hessenberg.c
+++ b/src/gr_mat/test/t-hessenberg.c
@@ -14,7 +14,7 @@
 
 FLINT_DLL extern gr_static_method_table _ca_methods;
 
-int main()
+int main(void)
 {
     slong iter;
     slong count_success = 0, count_unable = 0, count_domain = 0;

--- a/src/gr_mat/test/t-hessenberg_gauss.c
+++ b/src/gr_mat/test/t-hessenberg_gauss.c
@@ -14,7 +14,7 @@
 
 FLINT_DLL extern gr_static_method_table _ca_methods;
 
-int main()
+int main(void)
 {
     slong iter;
     slong count_success = 0, count_unable = 0, count_domain = 0;

--- a/src/gr_mat/test/t-hessenberg_householder.c
+++ b/src/gr_mat/test/t-hessenberg_householder.c
@@ -14,7 +14,7 @@
 
 FLINT_DLL extern gr_static_method_table _ca_methods;
 
-int main()
+int main(void)
 {
     slong iter;
     slong count_success = 0, count_unable = 0, count_domain = 0;

--- a/src/gr_mat/test/t-inv.c
+++ b/src/gr_mat/test/t-inv.c
@@ -14,7 +14,7 @@
 
 FLINT_DLL extern gr_static_method_table _ca_methods;
 
-int main()
+int main(void)
 {
     slong iter;
     slong count_success = 0, count_unable = 0, count_domain = 0;

--- a/src/gr_mat/test/t-invert_rows_cols.c
+++ b/src/gr_mat/test/t-invert_rows_cols.c
@@ -1,7 +1,7 @@
 
 #include "gr_mat.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/gr_mat/test/t-lu.c
+++ b/src/gr_mat/test/t-lu.c
@@ -86,7 +86,7 @@ _gr_mat_randrank(gr_mat_t mat, flint_rand_t state, slong rank, slong bits, gr_ct
     fmpz_mat_clear(A);
 }
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/gr_mat/test/t-lu_classical.c
+++ b/src/gr_mat/test/t-lu_classical.c
@@ -86,7 +86,7 @@ _gr_mat_randrank(gr_mat_t mat, flint_rand_t state, slong rank, slong bits, gr_ct
     fmpz_mat_clear(A);
 }
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/gr_mat/test/t-lu_recursive.c
+++ b/src/gr_mat/test/t-lu_recursive.c
@@ -86,7 +86,7 @@ _gr_mat_randrank(gr_mat_t mat, flint_rand_t state, slong rank, slong bits, gr_ct
     fmpz_mat_clear(A);
 }
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/gr_mat/test/t-minpoly_field.c
+++ b/src/gr_mat/test/t-minpoly_field.c
@@ -18,7 +18,7 @@
 
 FLINT_DLL extern gr_static_method_table _ca_methods;
 
-int main()
+int main(void)
 {
     slong iter;
     slong count_success = 0, count_unable = 0, count_domain = 0;

--- a/src/gr_mat/test/t-nullspace.c
+++ b/src/gr_mat/test/t-nullspace.c
@@ -1,7 +1,7 @@
 
 #include "gr_mat.h"
 
-int main()
+int main(void)
 {
     slong iter;
     slong count_success = 0, count_unable = 0, count_domain = 0;

--- a/src/gr_mat/test/t-properties.c
+++ b/src/gr_mat/test/t-properties.c
@@ -11,7 +11,7 @@
 
 #include "gr_mat.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/gr_mat/test/t-randrank.c
+++ b/src/gr_mat/test/t-randrank.c
@@ -1,7 +1,7 @@
 
 #include "gr_mat.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/gr_mat/test/t-rank.c
+++ b/src/gr_mat/test/t-rank.c
@@ -1,7 +1,7 @@
 
 #include "gr_mat.h"
 
-int main()
+int main(void)
 {
     slong iter;
     slong count_success = 0, count_unable = 0, count_domain = 0;

--- a/src/gr_mat/test/t-rank_fflu.c
+++ b/src/gr_mat/test/t-rank_fflu.c
@@ -1,7 +1,7 @@
 
 #include "gr_mat.h"
 
-int main()
+int main(void)
 {
     slong iter;
     slong count_success = 0, count_unable = 0, count_domain = 0;

--- a/src/gr_mat/test/t-rank_lu.c
+++ b/src/gr_mat/test/t-rank_lu.c
@@ -1,7 +1,7 @@
 
 #include "gr_mat.h"
 
-int main()
+int main(void)
 {
     slong iter;
     slong count_success = 0, count_unable = 0, count_domain = 0;

--- a/src/gr_mat/test/t-rref_den_fflu.c
+++ b/src/gr_mat/test/t-rref_den_fflu.c
@@ -29,7 +29,7 @@ gr_mat_randrowops(gr_mat_t mat, flint_rand_t state, slong count, gr_ctx_t ctx)
     return status;
 }
 
-int main()
+int main(void)
 {
     slong iter;
     slong count_success = 0, count_unable = 0, count_domain = 0;

--- a/src/gr_mat/test/t-rref_fflu.c
+++ b/src/gr_mat/test/t-rref_fflu.c
@@ -29,7 +29,7 @@ gr_mat_randrowops(gr_mat_t mat, flint_rand_t state, slong count, gr_ctx_t ctx)
     return status;
 }
 
-int main()
+int main(void)
 {
     slong iter;
     slong count_success = 0, count_unable = 0, count_domain = 0;

--- a/src/gr_mat/test/t-rref_lu.c
+++ b/src/gr_mat/test/t-rref_lu.c
@@ -29,7 +29,7 @@ gr_mat_randrowops(gr_mat_t mat, flint_rand_t state, slong count, gr_ctx_t ctx)
     return status;
 }
 
-int main()
+int main(void)
 {
     slong iter;
     slong count_success = 0, count_unable = 0, count_domain = 0;

--- a/src/gr_mat/test/t-solve.c
+++ b/src/gr_mat/test/t-solve.c
@@ -14,7 +14,7 @@
 
 FLINT_DLL extern gr_static_method_table _ca_methods;
 
-int main()
+int main(void)
 {
     slong iter;
     slong count_success = 0, count_unable = 0, count_domain = 0;

--- a/src/gr_mat/test/t-solve_den.c
+++ b/src/gr_mat/test/t-solve_den.c
@@ -14,7 +14,7 @@
 
 FLINT_DLL extern gr_static_method_table _ca_methods;
 
-int main()
+int main(void)
 {
     slong iter;
     slong count_success = 0, count_unable = 0, count_domain = 0;

--- a/src/gr_mat/test/t-solve_den_fflu.c
+++ b/src/gr_mat/test/t-solve_den_fflu.c
@@ -14,7 +14,7 @@
 
 FLINT_DLL extern gr_static_method_table _ca_methods;
 
-int main()
+int main(void)
 {
     slong iter;
     slong count_success = 0, count_unable = 0, count_domain = 0;

--- a/src/gr_mat/test/t-solve_fflu.c
+++ b/src/gr_mat/test/t-solve_fflu.c
@@ -14,7 +14,7 @@
 
 FLINT_DLL extern gr_static_method_table _ca_methods;
 
-int main()
+int main(void)
 {
     slong iter;
     slong count_success = 0, count_unable = 0, count_domain = 0;

--- a/src/gr_mat/test/t-solve_lu.c
+++ b/src/gr_mat/test/t-solve_lu.c
@@ -14,7 +14,7 @@
 
 FLINT_DLL extern gr_static_method_table _ca_methods;
 
-int main()
+int main(void)
 {
     slong iter;
     slong count_success = 0, count_unable = 0, count_domain = 0;

--- a/src/gr_mat/test/t-solve_tril.c
+++ b/src/gr_mat/test/t-solve_tril.c
@@ -14,7 +14,7 @@
 
 FLINT_DLL extern gr_static_method_table _ca_methods;
 
-int main()
+int main(void)
 {
     slong iter;
     slong count_success = 0, count_unable = 0, count_domain = 0;

--- a/src/gr_mat/test/t-solve_triu.c
+++ b/src/gr_mat/test/t-solve_triu.c
@@ -14,7 +14,7 @@
 
 FLINT_DLL extern gr_static_method_table _ca_methods;
 
-int main()
+int main(void)
 {
     slong iter;
     slong count_success = 0, count_unable = 0, count_domain = 0;

--- a/src/gr_mat/test/t-window_init_clear.c
+++ b/src/gr_mat/test/t-window_init_clear.c
@@ -11,7 +11,7 @@
 
 #include "gr_mat.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/gr_poly/test/t-atan_series.c
+++ b/src/gr_poly/test/t-atan_series.c
@@ -102,7 +102,7 @@ test_atan_series(flint_rand_t state, int which)
     return status;
 }
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/gr_poly/test/t-compose.c
+++ b/src/gr_poly/test/t-compose.c
@@ -14,7 +14,7 @@
 
 FLINT_DLL extern gr_static_method_table _ca_methods;
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/gr_poly/test/t-compose_divconquer.c
+++ b/src/gr_poly/test/t-compose_divconquer.c
@@ -14,7 +14,7 @@
 
 FLINT_DLL extern gr_static_method_table _ca_methods;
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/gr_poly/test/t-compose_horner.c
+++ b/src/gr_poly/test/t-compose_horner.c
@@ -14,7 +14,7 @@
 
 FLINT_DLL extern gr_static_method_table _ca_methods;
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/gr_poly/test/t-compose_series.c
+++ b/src/gr_poly/test/t-compose_series.c
@@ -142,7 +142,7 @@ test_compose_series(flint_rand_t state, int which)
     return status;
 }
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/gr_poly/test/t-div.c
+++ b/src/gr_poly/test/t-div.c
@@ -12,7 +12,7 @@
 #include "ulong_extras.h"
 #include "gr_poly.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/gr_poly/test/t-div_basecase.c
+++ b/src/gr_poly/test/t-div_basecase.c
@@ -12,7 +12,7 @@
 #include "ulong_extras.h"
 #include "gr_poly.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/gr_poly/test/t-div_divconquer.c
+++ b/src/gr_poly/test/t-div_divconquer.c
@@ -12,7 +12,7 @@
 #include "ulong_extras.h"
 #include "gr_poly.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/gr_poly/test/t-div_newton.c
+++ b/src/gr_poly/test/t-div_newton.c
@@ -12,7 +12,7 @@
 #include "ulong_extras.h"
 #include "gr_poly.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/gr_poly/test/t-div_series.c
+++ b/src/gr_poly/test/t-div_series.c
@@ -126,7 +126,7 @@ test_div_series(flint_rand_t state, int which)
     return status;
 }
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/gr_poly/test/t-divrem.c
+++ b/src/gr_poly/test/t-divrem.c
@@ -12,7 +12,7 @@
 #include "ulong_extras.h"
 #include "gr_poly.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/gr_poly/test/t-divrem_basecase.c
+++ b/src/gr_poly/test/t-divrem_basecase.c
@@ -12,7 +12,7 @@
 #include "ulong_extras.h"
 #include "gr_poly.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/gr_poly/test/t-divrem_divconquer.c
+++ b/src/gr_poly/test/t-divrem_divconquer.c
@@ -12,7 +12,7 @@
 #include "ulong_extras.h"
 #include "gr_poly.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/gr_poly/test/t-divrem_newton.c
+++ b/src/gr_poly/test/t-divrem_newton.c
@@ -12,7 +12,7 @@
 #include "ulong_extras.h"
 #include "gr_poly.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/gr_poly/test/t-evaluate.c
+++ b/src/gr_poly/test/t-evaluate.c
@@ -12,7 +12,7 @@
 #include "ulong_extras.h"
 #include "gr_poly.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/gr_poly/test/t-evaluate_horner.c
+++ b/src/gr_poly/test/t-evaluate_horner.c
@@ -12,7 +12,7 @@
 #include "ulong_extras.h"
 #include "gr_poly.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/gr_poly/test/t-evaluate_other.c
+++ b/src/gr_poly/test/t-evaluate_other.c
@@ -12,7 +12,7 @@
 #include "ulong_extras.h"
 #include "gr_poly.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/gr_poly/test/t-evaluate_other_rectangular.c
+++ b/src/gr_poly/test/t-evaluate_other_rectangular.c
@@ -12,7 +12,7 @@
 #include "ulong_extras.h"
 #include "gr_poly.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/gr_poly/test/t-evaluate_rectangular.c
+++ b/src/gr_poly/test/t-evaluate_rectangular.c
@@ -12,7 +12,7 @@
 #include "ulong_extras.h"
 #include "gr_poly.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/gr_poly/test/t-evaluate_vec_fast.c
+++ b/src/gr_poly/test/t-evaluate_vec_fast.c
@@ -13,7 +13,7 @@
 #include "gr_vec.h"
 #include "gr_poly.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/gr_poly/test/t-exp_series.c
+++ b/src/gr_poly/test/t-exp_series.c
@@ -149,7 +149,7 @@ test_exp_series(flint_rand_t state)
     return status;
 }
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/gr_poly/test/t-factor_squarefree.c
+++ b/src/gr_poly/test/t-factor_squarefree.c
@@ -15,7 +15,7 @@
 
 FLINT_DLL extern gr_static_method_table _ca_methods;
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/gr_poly/test/t-gcd.c
+++ b/src/gr_poly/test/t-gcd.c
@@ -12,7 +12,7 @@
 #include "ulong_extras.h"
 #include "gr_poly.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/gr_poly/test/t-gcd_euclidean.c
+++ b/src/gr_poly/test/t-gcd_euclidean.c
@@ -12,7 +12,7 @@
 #include "ulong_extras.h"
 #include "gr_poly.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/gr_poly/test/t-gcd_hgcd.c
+++ b/src/gr_poly/test/t-gcd_hgcd.c
@@ -12,7 +12,7 @@
 #include "ulong_extras.h"
 #include "gr_poly.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/gr_poly/test/t-hgcd.c
+++ b/src/gr_poly/test/t-hgcd.c
@@ -37,7 +37,7 @@ do {                                                            \
     }                                                           \
 } while (0)
 
-int main()
+int main(void)
 {
     int i, result;
     flint_rand_t state;

--- a/src/gr_poly/test/t-integral.c
+++ b/src/gr_poly/test/t-integral.c
@@ -12,7 +12,7 @@
 #include "ulong_extras.h"
 #include "gr_poly.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/gr_poly/test/t-inv_series.c
+++ b/src/gr_poly/test/t-inv_series.c
@@ -91,7 +91,7 @@ test_inv_series(flint_rand_t state, int which)
     return status;
 }
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/gr_poly/test/t-log_series.c
+++ b/src/gr_poly/test/t-log_series.c
@@ -101,7 +101,7 @@ test_log_series(flint_rand_t state)
     return status;
 }
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/gr_poly/test/t-make_monic.c
+++ b/src/gr_poly/test/t-make_monic.c
@@ -12,7 +12,7 @@
 #include "ulong_extras.h"
 #include "gr_poly.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/gr_poly/test/t-pow_series_fmpq.c
+++ b/src/gr_poly/test/t-pow_series_fmpq.c
@@ -141,7 +141,7 @@ test(flint_rand_t state, int which)
     return status;
 }
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/gr_poly/test/t-pow_series_ui.c
+++ b/src/gr_poly/test/t-pow_series_ui.c
@@ -78,7 +78,7 @@ test(flint_rand_t state, int which)
     return status;
 }
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/gr_poly/test/t-pow_ui.c
+++ b/src/gr_poly/test/t-pow_ui.c
@@ -76,7 +76,7 @@ test(flint_rand_t state, int which)
     return status;
 }
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/gr_poly/test/t-rem.c
+++ b/src/gr_poly/test/t-rem.c
@@ -12,7 +12,7 @@
 #include "ulong_extras.h"
 #include "gr_poly.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/gr_poly/test/t-resultant.c
+++ b/src/gr_poly/test/t-resultant.c
@@ -14,7 +14,7 @@
 #include "ulong_extras.h"
 #include "gr_poly.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/gr_poly/test/t-resultant_euclidean.c
+++ b/src/gr_poly/test/t-resultant_euclidean.c
@@ -14,7 +14,7 @@
 #include "ulong_extras.h"
 #include "gr_poly.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/gr_poly/test/t-resultant_hgcd.c
+++ b/src/gr_poly/test/t-resultant_hgcd.c
@@ -14,7 +14,7 @@
 #include "ulong_extras.h"
 #include "gr_poly.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/gr_poly/test/t-resultant_sylvester.c
+++ b/src/gr_poly/test/t-resultant_sylvester.c
@@ -14,7 +14,7 @@
 #include "ulong_extras.h"
 #include "gr_poly.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/gr_poly/test/t-roots.c
+++ b/src/gr_poly/test/t-roots.c
@@ -14,7 +14,7 @@
 #include "gr_vec.h"
 #include "gr_poly.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/gr_poly/test/t-roots_other.c
+++ b/src/gr_poly/test/t-roots_other.c
@@ -14,7 +14,7 @@
 #include "gr_vec.h"
 #include "gr_poly.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/gr_poly/test/t-rsqrt_series.c
+++ b/src/gr_poly/test/t-rsqrt_series.c
@@ -102,7 +102,7 @@ test_rsqrt_series(flint_rand_t state, int which)
     return status;
 }
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/gr_poly/test/t-sqrt_series.c
+++ b/src/gr_poly/test/t-sqrt_series.c
@@ -98,7 +98,7 @@ test_sqrt_series(flint_rand_t state, int which)
     return status;
 }
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/gr_poly/test/t-squarefree_part.c
+++ b/src/gr_poly/test/t-squarefree_part.c
@@ -15,7 +15,7 @@
 
 FLINT_DLL extern gr_static_method_table _ca_methods;
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/gr_poly/test/t-taylor_shift.c
+++ b/src/gr_poly/test/t-taylor_shift.c
@@ -12,7 +12,7 @@
 #include "ulong_extras.h"
 #include "gr_poly.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/gr_poly/test/t-taylor_shift_convolution.c
+++ b/src/gr_poly/test/t-taylor_shift_convolution.c
@@ -12,7 +12,7 @@
 #include "ulong_extras.h"
 #include "gr_poly.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/gr_poly/test/t-taylor_shift_divconquer.c
+++ b/src/gr_poly/test/t-taylor_shift_divconquer.c
@@ -12,7 +12,7 @@
 #include "ulong_extras.h"
 #include "gr_poly.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/gr_poly/test/t-taylor_shift_horner.c
+++ b/src/gr_poly/test/t-taylor_shift_horner.c
@@ -12,7 +12,7 @@
 #include "ulong_extras.h"
 #include "gr_poly.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/gr_special/test/t-chebyshev.c
+++ b/src/gr_special/test/t-chebyshev.c
@@ -77,7 +77,7 @@ test_chebyshev_fmpz_rec1(flint_rand_t state)
     return status;
 }
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/gr_special/test/t-fac.c
+++ b/src/gr_special/test/t-fac.c
@@ -222,7 +222,7 @@ test_fac_vec(flint_rand_t state, int which)
     return status;
 }
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/gr_special/test/t-fib.c
+++ b/src/gr_special/test/t-fib.c
@@ -148,7 +148,7 @@ test_fib_vec(flint_rand_t state)
     return status;
 }
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/gr_vec/test/t-product.c
+++ b/src/gr_vec/test/t-product.c
@@ -64,7 +64,7 @@ test_product(flint_rand_t state, int which)
     return status;
 }
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/gr_vec/test/t-sum.c
+++ b/src/gr_vec/test/t-sum.c
@@ -64,7 +64,7 @@ test_sum(flint_rand_t state, int which)
     return status;
 }
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/gr_vec/write.c
+++ b/src/gr_vec/write.c
@@ -26,7 +26,7 @@ _gr_vec_write(gr_stream_t out, gr_srcptr vec, slong len, gr_ctx_t ctx)
             gr_stream_write(out, ", ");
     }
     gr_stream_write(out, "]");
-    return GR_SUCCESS;
+    return status;
 }
 
 int

--- a/src/mag/test/t-add.c
+++ b/src/mag/test/t-add.c
@@ -12,7 +12,7 @@
 #include "arf.h"
 #include "mag.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/mag/test/t-add_2exp_fmpz.c
+++ b/src/mag/test/t-add_2exp_fmpz.c
@@ -12,7 +12,7 @@
 #include "arf.h"
 #include "mag.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/mag/test/t-addmul.c
+++ b/src/mag/test/t-addmul.c
@@ -12,7 +12,7 @@
 #include "arf.h"
 #include "mag.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/mag/test/t-atan.c
+++ b/src/mag/test/t-atan.c
@@ -19,7 +19,7 @@ arf_atan(arf_t y, const arf_t x, slong prec, arf_rnd_t rnd)
     _arf_call_mpfr_func(y, NULL, (int (*)(void)) mpfr_atan, x, NULL, prec, rnd);
 }
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/mag/test/t-bin_uiui.c
+++ b/src/mag/test/t-bin_uiui.c
@@ -12,7 +12,7 @@
 #include "arf.h"
 #include "mag.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/mag/test/t-binpow_uiui.c
+++ b/src/mag/test/t-binpow_uiui.c
@@ -80,7 +80,7 @@ arf_pow_binexp_si(arf_t y, const arf_t b, slong e, slong prec, arf_rnd_t rnd)
 }
 
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/mag/test/t-cmp.c
+++ b/src/mag/test/t-cmp.c
@@ -12,7 +12,7 @@
 #include "arf.h"
 #include "mag.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/mag/test/t-cmp_2exp_si.c
+++ b/src/mag/test/t-cmp_2exp_si.c
@@ -13,7 +13,7 @@
 #include "mag.h"
 #include "long_extras.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/mag/test/t-cosh.c
+++ b/src/mag/test/t-cosh.c
@@ -19,7 +19,7 @@ arf_cosh(arf_t y, const arf_t x, slong prec, arf_rnd_t rnd)
     _arf_call_mpfr_func(y, NULL, (int (*)(void)) mpfr_cosh, x, NULL, prec, rnd);
 }
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/mag/test/t-d_log_lower_bound.c
+++ b/src/mag/test/t-d_log_lower_bound.c
@@ -42,7 +42,7 @@ d_randtest2(flint_rand_t state)
     return t;
 }
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/mag/test/t-d_log_upper_bound.c
+++ b/src/mag/test/t-d_log_upper_bound.c
@@ -42,7 +42,7 @@ d_randtest2(flint_rand_t state)
     return t;
 }
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/mag/test/t-div.c
+++ b/src/mag/test/t-div.c
@@ -12,7 +12,7 @@
 #include "arf.h"
 #include "mag.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/mag/test/t-div_lower.c
+++ b/src/mag/test/t-div_lower.c
@@ -12,7 +12,7 @@
 #include "arf.h"
 #include "mag.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/mag/test/t-dump_file.c
+++ b/src/mag/test/t-dump_file.c
@@ -12,7 +12,7 @@
 #include <string.h>
 #include "arb.h"
 
-int main()
+int main(void)
 {
     flint_rand_t state;
     slong iter;

--- a/src/mag/test/t-dump_str.c
+++ b/src/mag/test/t-dump_str.c
@@ -12,7 +12,7 @@
 #include <string.h>
 #include "mag.h"
 
-int main()
+int main(void)
 {
     flint_rand_t state;
     slong iter;

--- a/src/mag/test/t-exp.c
+++ b/src/mag/test/t-exp.c
@@ -19,7 +19,7 @@ arf_exp(arf_t y, const arf_t x, slong prec, arf_rnd_t rnd)
     _arf_call_mpfr_func(y, NULL, (int (*)(void)) mpfr_exp, x, NULL, prec, rnd);
 }
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/mag/test/t-exp_tail.c
+++ b/src/mag/test/t-exp_tail.c
@@ -79,7 +79,7 @@ arf_pow_binexp_si(arf_t y, const arf_t b, slong e, slong prec, arf_rnd_t rnd)
     fmpz_clear(f);
 }
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/mag/test/t-expinv.c
+++ b/src/mag/test/t-expinv.c
@@ -18,7 +18,7 @@ arf_exp(arf_t y, const arf_t x, slong prec, arf_rnd_t rnd)
 {
     _arf_call_mpfr_func(y, NULL, (int (*)(void)) mpfr_exp, x, NULL, prec, rnd);
 }
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/mag/test/t-expm1.c
+++ b/src/mag/test/t-expm1.c
@@ -19,7 +19,7 @@ arf_expm1(arf_t y, const arf_t x, slong prec, arf_rnd_t rnd)
     _arf_call_mpfr_func(y, NULL, (int (*)(void)) mpfr_expm1, x, NULL, prec, rnd);
 }
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/mag/test/t-fac_ui.c
+++ b/src/mag/test/t-fac_ui.c
@@ -12,7 +12,7 @@
 #include "arf.h"
 #include "mag.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/mag/test/t-fast_add_2exp_si.c
+++ b/src/mag/test/t-fast_add_2exp_si.c
@@ -12,7 +12,7 @@
 #include "arf.h"
 #include "mag.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/mag/test/t-fast_addmul.c
+++ b/src/mag/test/t-fast_addmul.c
@@ -12,7 +12,7 @@
 #include "arf.h"
 #include "mag.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/mag/test/t-fast_mul.c
+++ b/src/mag/test/t-fast_mul.c
@@ -12,7 +12,7 @@
 #include "arf.h"
 #include "mag.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/mag/test/t-fast_mul_2exp_si.c
+++ b/src/mag/test/t-fast_mul_2exp_si.c
@@ -12,7 +12,7 @@
 #include "arf.h"
 #include "mag.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/mag/test/t-geom_series.c
+++ b/src/mag/test/t-geom_series.c
@@ -79,7 +79,7 @@ arf_pow_binexp_si(arf_t y, const arf_t b, slong e, slong prec, arf_rnd_t rnd)
     fmpz_clear(f);
 }
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/mag/test/t-get_d.c
+++ b/src/mag/test/t-get_d.c
@@ -13,7 +13,7 @@
 #include "double_extras.h"
 #include "mag.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/mag/test/t-hurwitz_zeta_uiui.c
+++ b/src/mag/test/t-hurwitz_zeta_uiui.c
@@ -13,7 +13,7 @@
 #include "mag.h"
 #include "arb.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/mag/test/t-log.c
+++ b/src/mag/test/t-log.c
@@ -19,7 +19,7 @@ arf_log(arf_t y, const arf_t x, slong prec, arf_rnd_t rnd)
     _arf_call_mpfr_func(y, NULL, (int (*)(void)) mpfr_log, x, NULL, prec, rnd);
 }
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/mag/test/t-log1p.c
+++ b/src/mag/test/t-log1p.c
@@ -19,7 +19,7 @@ arf_log1p(arf_t y, const arf_t x, slong prec, arf_rnd_t rnd)
     _arf_call_mpfr_func(y, NULL, (int (*)(void)) mpfr_log1p, x, NULL, prec, rnd);
 }
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/mag/test/t-mul.c
+++ b/src/mag/test/t-mul.c
@@ -12,7 +12,7 @@
 #include "arf.h"
 #include "mag.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/mag/test/t-mul_2exp_fmpz.c
+++ b/src/mag/test/t-mul_2exp_fmpz.c
@@ -12,7 +12,7 @@
 #include "arf.h"
 #include "mag.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/mag/test/t-mul_2exp_si.c
+++ b/src/mag/test/t-mul_2exp_si.c
@@ -13,7 +13,7 @@
 #include "mag.h"
 #include "long_extras.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/mag/test/t-mul_lower.c
+++ b/src/mag/test/t-mul_lower.c
@@ -12,7 +12,7 @@
 #include "arf.h"
 #include "mag.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/mag/test/t-neg_log.c
+++ b/src/mag/test/t-neg_log.c
@@ -19,7 +19,7 @@ arf_log(arf_t y, const arf_t x, slong prec, arf_rnd_t rnd)
     _arf_call_mpfr_func(y, NULL, (int (*)(void)) mpfr_log, x, NULL, prec, rnd);
 }
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/mag/test/t-polylog_tail.c
+++ b/src/mag/test/t-polylog_tail.c
@@ -12,7 +12,7 @@
 #include "mag.h"
 #include "arb.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/mag/test/t-pow_fmpz.c
+++ b/src/mag/test/t-pow_fmpz.c
@@ -79,7 +79,7 @@ arf_pow_binexp_si(arf_t y, const arf_t b, slong e, slong prec, arf_rnd_t rnd)
     fmpz_clear(f);
 }
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/mag/test/t-pow_ui.c
+++ b/src/mag/test/t-pow_ui.c
@@ -79,7 +79,7 @@ arf_pow_binexp_si(arf_t y, const arf_t b, slong e, slong prec, arf_rnd_t rnd)
     fmpz_clear(f);
 }
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/mag/test/t-rfac_ui.c
+++ b/src/mag/test/t-rfac_ui.c
@@ -12,7 +12,7 @@
 #include "arf.h"
 #include "mag.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/mag/test/t-root.c
+++ b/src/mag/test/t-root.c
@@ -12,7 +12,7 @@
 #include "arf.h"
 #include "mag.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/mag/test/t-rsqrt.c
+++ b/src/mag/test/t-rsqrt.c
@@ -12,7 +12,7 @@
 #include "arf.h"
 #include "mag.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/mag/test/t-rsqrt_lower.c
+++ b/src/mag/test/t-rsqrt_lower.c
@@ -12,7 +12,7 @@
 #include "arf.h"
 #include "mag.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/mag/test/t-set_d.c
+++ b/src/mag/test/t-set_d.c
@@ -42,7 +42,7 @@ d_randtest2(flint_rand_t state)
     return t;
 }
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/mag/test/t-set_d_2exp_fmpz.c
+++ b/src/mag/test/t-set_d_2exp_fmpz.c
@@ -42,7 +42,7 @@ d_randtest2(flint_rand_t state)
     return t;
 }
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/mag/test/t-set_ui.c
+++ b/src/mag/test/t-set_ui.c
@@ -12,7 +12,7 @@
 #include "arf.h"
 #include "mag.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/mag/test/t-set_ui_lower.c
+++ b/src/mag/test/t-set_ui_lower.c
@@ -12,7 +12,7 @@
 #include "arf.h"
 #include "mag.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/mag/test/t-sinh.c
+++ b/src/mag/test/t-sinh.c
@@ -19,7 +19,7 @@ arf_sinh(arf_t y, const arf_t x, slong prec, arf_rnd_t rnd)
     _arf_call_mpfr_func(y, NULL, (int (*)(void)) mpfr_sinh, x, NULL, prec, rnd);
 }
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/mag/test/t-sqrt.c
+++ b/src/mag/test/t-sqrt.c
@@ -12,7 +12,7 @@
 #include "arf.h"
 #include "mag.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/mag/test/t-sqrt_lower.c
+++ b/src/mag/test/t-sqrt_lower.c
@@ -12,7 +12,7 @@
 #include "arf.h"
 #include "mag.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/mag/test/t-sub.c
+++ b/src/mag/test/t-sub.c
@@ -12,7 +12,7 @@
 #include "arf.h"
 #include "mag.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/mag/test/t-sub_lower.c
+++ b/src/mag/test/t-sub_lower.c
@@ -12,7 +12,7 @@
 #include "arf.h"
 #include "mag.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/nmod_mat/test/t-pow.c
+++ b/src/nmod_mat/test/t-pow.c
@@ -13,7 +13,7 @@
 #include "nmod_mat.h"
 
 int
-main()
+main(void)
 {
     slong i;
     FLINT_TEST_INIT(state);

--- a/src/nmod_poly_factor/test/t-factor_cantor_zassenhaus.c
+++ b/src/nmod_poly_factor/test/t-factor_cantor_zassenhaus.c
@@ -34,7 +34,7 @@ main(void)
         nmod_poly_factor_t res;
         mp_limb_t modulus, lead;
         slong i, j, length, num;
-        slong prod1, exp[5];
+        slong exp[5];
 
         modulus = n_randtest_prime(state, 0);
 
@@ -57,7 +57,6 @@ main(void)
         while ((poly->length < 2) || (!nmod_poly_is_irreducible(poly)));
 
         exp[0] = n_randint(state, 30) + 1;
-        prod1 = exp[0];
         for (i = 0; i < exp[0]; i++)
             nmod_poly_mul(pol1, pol1, poly);
 
@@ -79,7 +78,6 @@ main(void)
                 (rem->length == 0));
 
             exp[i] = n_randint(state, 30) + 1;
-            prod1 *= exp[i];
             for (j = 0; j < exp[i]; j++)
                 nmod_poly_mul(pol1, pol1, poly);
         }

--- a/src/qqbar/test/t-abs.c
+++ b/src/qqbar/test/t-abs.c
@@ -11,7 +11,7 @@
 
 #include "qqbar.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/qqbar/test/t-abs2.c
+++ b/src/qqbar/test/t-abs2.c
@@ -11,7 +11,7 @@
 
 #include "qqbar.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/qqbar/test/t-acos_pi.c
+++ b/src/qqbar/test/t-acos_pi.c
@@ -12,7 +12,7 @@
 #include "ulong_extras.h"
 #include "qqbar.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/qqbar/test/t-acot_pi.c
+++ b/src/qqbar/test/t-acot_pi.c
@@ -12,7 +12,7 @@
 #include "ulong_extras.h"
 #include "qqbar.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/qqbar/test/t-acsc_pi.c
+++ b/src/qqbar/test/t-acsc_pi.c
@@ -12,7 +12,7 @@
 #include "ulong_extras.h"
 #include "qqbar.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/qqbar/test/t-add.c
+++ b/src/qqbar/test/t-add.c
@@ -11,7 +11,7 @@
 
 #include "qqbar.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/qqbar/test/t-asec_pi.c
+++ b/src/qqbar/test/t-asec_pi.c
@@ -12,7 +12,7 @@
 #include "ulong_extras.h"
 #include "qqbar.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/qqbar/test/t-asin_pi.c
+++ b/src/qqbar/test/t-asin_pi.c
@@ -12,7 +12,7 @@
 #include "ulong_extras.h"
 #include "qqbar.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/qqbar/test/t-atan_pi.c
+++ b/src/qqbar/test/t-atan_pi.c
@@ -12,7 +12,7 @@
 #include "ulong_extras.h"
 #include "qqbar.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/qqbar/test/t-ceil.c
+++ b/src/qqbar/test/t-ceil.c
@@ -12,7 +12,7 @@
 #include "fmpq.h"
 #include "qqbar.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/qqbar/test/t-cmp_im.c
+++ b/src/qqbar/test/t-cmp_im.c
@@ -11,7 +11,7 @@
 
 #include "qqbar.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/qqbar/test/t-cmp_re.c
+++ b/src/qqbar/test/t-cmp_re.c
@@ -11,7 +11,7 @@
 
 #include "qqbar.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/qqbar/test/t-cmpabs.c
+++ b/src/qqbar/test/t-cmpabs.c
@@ -11,7 +11,7 @@
 
 #include "qqbar.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/qqbar/test/t-cmpabs_im.c
+++ b/src/qqbar/test/t-cmpabs_im.c
@@ -11,7 +11,7 @@
 
 #include "qqbar.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/qqbar/test/t-cmpabs_re.c
+++ b/src/qqbar/test/t-cmpabs_re.c
@@ -11,7 +11,7 @@
 
 #include "qqbar.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/qqbar/test/t-conjugates.c
+++ b/src/qqbar/test/t-conjugates.c
@@ -12,7 +12,7 @@
 #include "fmpq.h"
 #include "qqbar.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/qqbar/test/t-cos_pi.c
+++ b/src/qqbar/test/t-cos_pi.c
@@ -12,7 +12,7 @@
 #include "fmpq.h"
 #include "qqbar.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/qqbar/test/t-cot_pi.c
+++ b/src/qqbar/test/t-cot_pi.c
@@ -12,7 +12,7 @@
 #include "fmpq.h"
 #include "qqbar.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/qqbar/test/t-csc_pi.c
+++ b/src/qqbar/test/t-csc_pi.c
@@ -12,7 +12,7 @@
 #include "fmpq.h"
 #include "qqbar.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/qqbar/test/t-csgn.c
+++ b/src/qqbar/test/t-csgn.c
@@ -11,7 +11,7 @@
 
 #include "qqbar.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/qqbar/test/t-div.c
+++ b/src/qqbar/test/t-div.c
@@ -11,7 +11,7 @@
 
 #include "qqbar.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/qqbar/test/t-equal_fmpq_poly_val.c
+++ b/src/qqbar/test/t-equal_fmpq_poly_val.c
@@ -24,7 +24,7 @@ qqbar_equal_fmpq_poly_val2(const qqbar_t x, const fmpq_poly_t f, const qqbar_t y
     return found;
 }
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/qqbar/test/t-evaluate_fmpq_poly.c
+++ b/src/qqbar/test/t-evaluate_fmpq_poly.c
@@ -12,7 +12,7 @@
 #include "fmpq_poly.h"
 #include "qqbar.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/qqbar/test/t-evaluate_fmpz_mpoly.c
+++ b/src/qqbar/test/t-evaluate_fmpz_mpoly.c
@@ -12,7 +12,7 @@
 #include "fmpz_mpoly.h"
 #include "qqbar.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/qqbar/test/t-exp_pi_i.c
+++ b/src/qqbar/test/t-exp_pi_i.c
@@ -12,7 +12,7 @@
 #include "fmpq.h"
 #include "qqbar.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/qqbar/test/t-express_in_field.c
+++ b/src/qqbar/test/t-express_in_field.c
@@ -13,7 +13,7 @@
 #include "fmpq_poly.h"
 #include "qqbar.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/qqbar/test/t-floor.c
+++ b/src/qqbar/test/t-floor.c
@@ -12,7 +12,7 @@
 #include "fmpq.h"
 #include "qqbar.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/qqbar/test/t-fmpz_poly_composed_op.c
+++ b/src/qqbar/test/t-fmpz_poly_composed_op.c
@@ -15,7 +15,7 @@
 #include "fmpq_poly.h"
 #include "qqbar.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/qqbar/test/t-get_acb.c
+++ b/src/qqbar/test/t-get_acb.c
@@ -11,7 +11,7 @@
 
 #include "qqbar.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/qqbar/test/t-get_fexpr.c
+++ b/src/qqbar/test/t-get_fexpr.c
@@ -12,7 +12,7 @@
 #include "fexpr.h"
 #include "qqbar.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/qqbar/test/t-get_fexpr_formula.c
+++ b/src/qqbar/test/t-get_fexpr_formula.c
@@ -14,7 +14,7 @@
 #include "fexpr.h"
 #include "qqbar.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/qqbar/test/t-get_quadratic.c
+++ b/src/qqbar/test/t-get_quadratic.c
@@ -11,7 +11,7 @@
 
 #include "qqbar.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/qqbar/test/t-guess.c
+++ b/src/qqbar/test/t-guess.c
@@ -11,7 +11,7 @@
 
 #include "qqbar.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/qqbar/test/t-inv.c
+++ b/src/qqbar/test/t-inv.c
@@ -11,7 +11,7 @@
 
 #include "qqbar.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/qqbar/test/t-log_pi_i.c
+++ b/src/qqbar/test/t-log_pi_i.c
@@ -12,7 +12,7 @@
 #include "ulong_extras.h"
 #include "qqbar.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/qqbar/test/t-mul.c
+++ b/src/qqbar/test/t-mul.c
@@ -11,7 +11,7 @@
 
 #include "qqbar.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/qqbar/test/t-mul_2exp_si.c
+++ b/src/qqbar/test/t-mul_2exp_si.c
@@ -11,7 +11,7 @@
 
 #include "qqbar.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/qqbar/test/t-pow.c
+++ b/src/qqbar/test/t-pow.c
@@ -11,7 +11,7 @@
 
 #include "qqbar.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/qqbar/test/t-pow_fmpq.c
+++ b/src/qqbar/test/t-pow_fmpq.c
@@ -12,7 +12,7 @@
 #include "fmpq.h"
 #include "qqbar.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/qqbar/test/t-pow_fmpz.c
+++ b/src/qqbar/test/t-pow_fmpz.c
@@ -11,7 +11,7 @@
 
 #include "qqbar.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/qqbar/test/t-pow_si.c
+++ b/src/qqbar/test/t-pow_si.c
@@ -11,7 +11,7 @@
 
 #include "qqbar.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/qqbar/test/t-pow_ui.c
+++ b/src/qqbar/test/t-pow_ui.c
@@ -11,7 +11,7 @@
 
 #include "qqbar.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/qqbar/test/t-randtest.c
+++ b/src/qqbar/test/t-randtest.c
@@ -11,7 +11,7 @@
 
 #include "qqbar.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/qqbar/test/t-re_im.c
+++ b/src/qqbar/test/t-re_im.c
@@ -11,7 +11,7 @@
 
 #include "qqbar.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/qqbar/test/t-root_of_unity.c
+++ b/src/qqbar/test/t-root_of_unity.c
@@ -12,7 +12,7 @@
 #include "ulong_extras.h"
 #include "qqbar.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/qqbar/test/t-root_ui.c
+++ b/src/qqbar/test/t-root_ui.c
@@ -11,7 +11,7 @@
 
 #include "qqbar.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/qqbar/test/t-roots_fmpz_poly.c
+++ b/src/qqbar/test/t-roots_fmpz_poly.c
@@ -12,7 +12,7 @@
 #include "arb_fmpz_poly.h"
 #include "qqbar.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/qqbar/test/t-sec_pi.c
+++ b/src/qqbar/test/t-sec_pi.c
@@ -12,7 +12,7 @@
 #include "fmpq.h"
 #include "qqbar.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/qqbar/test/t-set_d.c
+++ b/src/qqbar/test/t-set_d.c
@@ -12,7 +12,7 @@
 #include "double_extras.h"
 #include "qqbar.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/qqbar/test/t-set_re_im_d.c
+++ b/src/qqbar/test/t-set_re_im_d.c
@@ -12,7 +12,7 @@
 #include "double_extras.h"
 #include "qqbar.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/qqbar/test/t-sgn.c
+++ b/src/qqbar/test/t-sgn.c
@@ -11,7 +11,7 @@
 
 #include "qqbar.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/qqbar/test/t-sgn_re.c
+++ b/src/qqbar/test/t-sgn_re.c
@@ -11,7 +11,7 @@
 
 #include "qqbar.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/qqbar/test/t-sin_pi.c
+++ b/src/qqbar/test/t-sin_pi.c
@@ -12,7 +12,7 @@
 #include "fmpq.h"
 #include "qqbar.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/qqbar/test/t-sub.c
+++ b/src/qqbar/test/t-sub.c
@@ -11,7 +11,7 @@
 
 #include "qqbar.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/qqbar/test/t-tan_pi.c
+++ b/src/qqbar/test/t-tan_pi.c
@@ -12,7 +12,7 @@
 #include "fmpq.h"
 #include "qqbar.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/qsieve/block_lanczos.c
+++ b/src/qsieve/block_lanczos.c
@@ -72,10 +72,12 @@ void reduce_matrix(qs_t qs_inf, slong *nrows, slong *ncols, la_col_t *cols) {
 	   outright  */
 
 	slong r, c, i, j, k;
-	slong passes;
 	slong *counts;
 	slong reduced_rows;
 	slong reduced_cols;
+#if QS_DEBUG
+	slong passes = 0;
+#endif
 
 	/* count the number of nonzero entries in each row */
 
@@ -87,7 +89,6 @@ void reduce_matrix(qs_t qs_inf, slong *nrows, slong *ncols, la_col_t *cols) {
 
 	reduced_rows = *nrows;
 	reduced_cols = *ncols;
-	passes = 0;
 
 	do {
 		r = reduced_rows;
@@ -155,8 +156,9 @@ void reduce_matrix(qs_t qs_inf, slong *nrows, slong *ncols, la_col_t *cols) {
 		   then the matrix is less dense and more columns
 		   can be deleted; iterate until no further deletions
 		   are possible */
-
+#if QS_DEBUG
 		passes++;
+#endif
 
 	} while (r != reduced_rows);
 
@@ -717,7 +719,7 @@ uint64_t * block_lanczos(flint_rand_t state, slong nrows,
 	uint64_t *d, *e, *f, *f2;
 	uint64_t *tmp;
 	slong s[2][64];
-	slong i, iter;
+	slong i;
 	slong n = ncols;
 	slong dim0, dim1;
 	uint64_t mask0, mask1;
@@ -771,7 +773,10 @@ uint64_t * block_lanczos(flint_rand_t state, slong nrows,
 	dim0 = 0;
 	dim1 = 64;
 	mask1 = (uint64_t)(-1);
-	iter = 0;
+	
+#if QS_DEBUG
+	slong iter = 0;
+#endif
 
 	/* The computed solution 'x' starts off random,
 	   and v[0] starts off as B*x. This initial copy
@@ -792,7 +797,9 @@ uint64_t * block_lanczos(flint_rand_t state, slong nrows,
 	/* perform the iteration */
 
 	while (1) {
+#if QS_DEBUG
 		iter++;
+#endif
 
 		/* multiply the current v[0] by a symmetrized
 		   version of B, or B'B (apostrophe means

--- a/src/qsieve/large_prime_variant.c
+++ b/src/qsieve/large_prime_variant.c
@@ -492,7 +492,7 @@ int qsieve_process_relation(qs_t qs_inf)
 {
     char buf[1024];
     char * str;
-    slong i, num_relations = 0, num_relations2, full = 0;
+    slong i, num_relations = 0, num_relations2;
     slong rel_list_length;
     slong rlist_length;
     mp_limb_t prime;
@@ -551,7 +551,6 @@ int qsieve_process_relation(qs_t qs_inf)
         if (rel_list[i].lp == UWORD(1))
         {
             rlist[rlist_length++] = rel_list[i];
-            full++;
         }
         else
         {

--- a/src/thread_support/thread_support.c
+++ b/src/thread_support/thread_support.c
@@ -17,7 +17,7 @@
 /* Automatically initialised to zero when threads are started */
 FLINT_TLS_PREFIX int _flint_num_workers = 0;
 
-int flint_get_num_threads()
+int flint_get_num_threads(void)
 {
     return _flint_num_workers + 1;
 }
@@ -78,7 +78,7 @@ int flint_set_thread_affinity(int * cpus, slong length)
 }
 
 /* return zero for success, nonzero for error */
-int flint_restore_thread_affinity()
+int flint_restore_thread_affinity(void)
 {
     if (!global_thread_pool_initialized)
         return 1;

--- a/src/ulong_extras/cleanup_primes.c
+++ b/src/ulong_extras/cleanup_primes.c
@@ -13,7 +13,7 @@
 #include "ulong_extras.h"
 
 void
-n_cleanup_primes()
+n_cleanup_primes(void)
 {
     int i;
 

--- a/src/ulong_extras/test/t-compute_primes.c
+++ b/src/ulong_extras/test/t-compute_primes.c
@@ -13,7 +13,7 @@
 #include "flint.h"
 #include "ulong_extras.h"
 
-int main()
+int main(void)
 {
     slong i, lim = 1000000;
     n_primes_t pg;

--- a/src/utils_flint/test/t-fmpz_mpoly_buchberger_naive.c
+++ b/src/utils_flint/test/t-fmpz_mpoly_buchberger_naive.c
@@ -12,7 +12,7 @@
 #include "calcium.h"
 #include "utils_flint.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/utils_flint/test/t-fmpz_mpoly_set_gen_fmpz_poly.c
+++ b/src/utils_flint/test/t-fmpz_mpoly_set_gen_fmpz_poly.c
@@ -13,7 +13,7 @@
 #include "calcium.h"
 #include "utils_flint.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/utils_flint/test/t-fmpz_mpoly_symmetric.c
+++ b/src/utils_flint/test/t-fmpz_mpoly_symmetric.c
@@ -12,7 +12,7 @@
 #include "calcium.h"
 #include "utils_flint.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;

--- a/src/utils_flint/test/t-fmpz_mpoly_vec_autoreduction.c
+++ b/src/utils_flint/test/t-fmpz_mpoly_vec_autoreduction.c
@@ -12,7 +12,7 @@
 #include "calcium.h"
 #include "utils_flint.h"
 
-int main()
+int main(void)
 {
     slong iter;
     flint_rand_t state;


### PR DESCRIPTION
Fix ```-Wstrict-prototypes```, ```-Wunused-but-set-variable``` and ```-Wself-assign``` warnings.

Most of this was done by replacing ```main()``` by ```main(void)``` with sed. The rest was done by hand.