### PR TITLE
Use fft_small in flint_mpn_mul and friends

### DIFF
--- a/examples/bernoulli.c
+++ b/examples/bernoulli.c
@@ -2,6 +2,7 @@
 
 #include <string.h>
 #include <stdlib.h>
+#include "fmpq.h"
 #include "arb.h"
 #include "bernoulli.h"
 #include "profiler.h"

--- a/examples/fmpz_mod_poly.c
+++ b/examples/fmpz_mod_poly.c
@@ -16,8 +16,9 @@
 #include <stdlib.h>
 #include <stdio.h>
 #include <gmp.h>
-
 #include "flint.h"
+#include "fmpz.h"
+#include "fmpz_mod.h"
 #include "fmpz_mod_poly.h"
 
 int main(int argc, char* argv[])

--- a/examples/fmpz_poly_factor_zassenhaus.c
+++ b/examples/fmpz_poly_factor_zassenhaus.c
@@ -18,6 +18,7 @@
 
 #include "flint.h"
 #include "fmpz_poly.h"
+#include "fmpz_poly_factor.h"
 #include "nmod_poly.h"
 #include "ulong_extras.h"
 

--- a/examples/fq_poly.c
+++ b/examples/fq_poly.c
@@ -16,6 +16,7 @@
 
 #include <time.h>
 #include <stdlib.h>
+#include "fmpz.h"
 #include "fq.h"
 #include "fq_poly.h"
 
@@ -30,10 +31,6 @@ int main(void)
 
     FLINT_TEST_INIT(state);
 
-    fq_poly_init(f, ctx);
-    fq_poly_init(g, ctx);
-    fq_poly_init(h, ctx);
-
     printf("Polynomial multiplication over GF(q)\n");
     printf("------------------------------------\n");
 
@@ -43,6 +40,10 @@ int main(void)
         fmpz_init_set_ui(p, 3);
         d = 2;
         fq_ctx_init_conway(ctx, p, d, "X");
+
+        fq_poly_init(f, ctx);
+        fq_poly_init(g, ctx);
+        fq_poly_init(h, ctx);
 
         fq_poly_randtest(g, state, 10000, ctx);
         fq_poly_randtest(h, state, 10000, ctx);
@@ -67,6 +68,10 @@ int main(void)
         c  = (double) (c1 - c0) / CLOCKS_PER_SEC;
         printf("KS: %fms\n", 10 * c);
 
+        fq_poly_clear(f, ctx);
+        fq_poly_clear(g, ctx);
+        fq_poly_clear(h, ctx);
+
         fq_ctx_clear(ctx);
         fmpz_clear(p);
     }
@@ -76,6 +81,10 @@ int main(void)
         fmpz_init_set_ui(p, 3);
         d = 263;
         fq_ctx_init_conway(ctx, p, d, "X");
+
+        fq_poly_init(f, ctx);
+        fq_poly_init(g, ctx);
+        fq_poly_init(h, ctx);
 
         fq_poly_randtest(g, state, 500, ctx);
         fq_poly_randtest(h, state, 500, ctx);
@@ -99,6 +108,10 @@ int main(void)
         c  = (double) (c1 - c0) / CLOCKS_PER_SEC;
         printf("KS: %fms\n", 10 * c);
 
+        fq_poly_clear(f, ctx);
+        fq_poly_clear(g, ctx);
+        fq_poly_clear(h, ctx);
+
         fq_ctx_clear(ctx);
         fmpz_clear(p);
     }
@@ -108,6 +121,10 @@ int main(void)
         fmpz_init_set_ui(p, 109987);
         d = 4;
         fq_ctx_init_conway(ctx, p, d, "X");
+
+        fq_poly_init(f, ctx);
+        fq_poly_init(g, ctx);
+        fq_poly_init(h, ctx);
 
         fq_poly_randtest(g, state, 4, ctx);
         fq_poly_randtest(h, state, 4, ctx);
@@ -132,6 +149,10 @@ int main(void)
         c1 = clock();
         c  = (double) (c1 - c0) / CLOCKS_PER_SEC;
         printf("KS: %f\xb5s\n", 10 * c);
+
+        fq_poly_clear(f, ctx);
+        fq_poly_clear(g, ctx);
+        fq_poly_clear(h, ctx);
 
         fq_ctx_clear(ctx);
         fmpz_clear(p);

--- a/examples/functions_benchmark.c
+++ b/examples/functions_benchmark.c
@@ -1,6 +1,7 @@
 /* This file is public domain. Author: Fredrik Johansson. */
 
 #include "profiler.h"
+#include "fmpq.h"
 #include "arb.h"
 #include "arb_hypgeom.h"
 #include "acb.h"

--- a/examples/poly_roots.c
+++ b/examples/poly_roots.c
@@ -3,6 +3,7 @@
 #include <string.h>
 #include <ctype.h>
 #include <stdlib.h>
+#include "fmpz_poly_factor.h"
 #include "fmpq_poly.h"
 #include "acb.h"
 #include "arb_fmpz_poly.h"

--- a/examples/radix.c
+++ b/examples/radix.c
@@ -19,8 +19,9 @@
 #include <stdio.h>
 #include <time.h>
 #include <gmp.h>
-
 #include "flint.h"
+#include "fmpz.h"
+#include "fmpz_mod.h"
 #include "fmpz_mod_poly.h"
 
 int main(void)

--- a/src/arf.h
+++ b/src/arf.h
@@ -723,7 +723,12 @@ void arf_randtest_special(arf_t x, flint_rand_t state, slong bits, slong mag_bit
 void arf_urandom(arf_t x, flint_rand_t state, slong bits, arf_rnd_t rnd);
 
 #define MUL_MPFR_MIN_LIMBS 25
+
+#ifdef FLINT_HAVE_FFT_SMALL
+#define MUL_MPFR_MAX_LIMBS 800
+#else
 #define MUL_MPFR_MAX_LIMBS 10000
+#endif
 
 #define ARF_MUL_STACK_ALLOC 40
 #define ARF_MUL_TLS_ALLOC 1000

--- a/src/arf/mul_rnd_any.c
+++ b/src/arf/mul_rnd_any.c
@@ -56,9 +56,9 @@ arf_mul_rnd_any(arf_ptr z, arf_srcptr x, arf_srcptr y,
         {
             tmp[zn - 1] = mpn_mul_1(tmp, xptr, xn, yptr[0]);
         }
-        else if ((yn) >= FLINT_FFT_MUL_THRESHOLD)
+        else if (yn >= FLINT_MPN_MUL_THRESHOLD)
         {
-            flint_mpn_mul_fft_main(tmp, xptr, xn, yptr, yn);
+            flint_mpn_mul_large(tmp, xptr, xn, yptr, yn);
         }
         else if (xn == yn)
         {

--- a/src/arf/mul_rnd_down.c
+++ b/src/arf/mul_rnd_down.c
@@ -195,9 +195,9 @@ arf_mul_rnd_down(arf_ptr z, arf_srcptr x, arf_srcptr y, slong prec)
         alloc = zn = xn + yn;
         ARF_MUL_TMP_ALLOC(tmp, alloc)
 
-        if (yn >= FLINT_FFT_MUL_THRESHOLD)
+        if (yn >= FLINT_MPN_MUL_THRESHOLD)
         {
-            flint_mpn_mul_fft_main(tmp, xptr, xn, yptr, yn);
+            flint_mpn_mul_large(tmp, xptr, xn, yptr, yn);
         }
         else if (xn == yn)
         {

--- a/src/fft_small/mpn_mul.c
+++ b/src/fft_small/mpn_mul.c
@@ -1169,6 +1169,33 @@ void sd_fft_lctx_point_mul(
     }
 }
 
+void sd_fft_lctx_point_sqr(
+    const sd_fft_lctx_t Q,
+    double* a,
+    ulong m_,
+    ulong depth)
+{
+    vec8d m = vec8d_set_d(vec1d_reduce_0n_to_pmhn((slong)m_, Q->p));
+    vec8d n    = vec8d_set_d(Q->p);
+    vec8d ninv = vec8d_set_d(Q->pinv);
+    FLINT_ASSERT(depth >= LG_BLK_SZ);
+
+    for (ulong I = 0; I < n_pow2(depth - LG_BLK_SZ); I++)
+    {
+        double* ax = a + sd_fft_ctx_blk_offset(I);
+        ulong j = 0; do {
+            vec8d x0, x1;
+            x0 = vec8d_load(ax+j+0);
+            x1 = vec8d_load(ax+j+8);
+            x0 = vec8d_mulmod(x0, x0, n, ninv);
+            x1 = vec8d_mulmod(x1, x1, n, ninv);
+            x0 = vec8d_mulmod(x0, m, n, ninv);
+            x1 = vec8d_mulmod(x1, m, n, ninv);
+            vec8d_store(ax+j+0, x0);
+            vec8d_store(ax+j+8, x1);
+        } while (j += 16, j < BLK_SZ);
+    }
+}
 
 typedef struct {
     to_ffts_func to_ffts;
@@ -1191,6 +1218,7 @@ typedef struct {
     ulong b_stop_easy;
     ulong b_start_hard;
     ulong b_stop_hard;
+    int squaring;
 } mod_worker_struct;
 
 void mod_worker_func(void* varg)
@@ -1200,8 +1228,11 @@ void mod_worker_func(void* varg)
     X->to_ffts(X->ffts, X->abuf, X->stride, X->a, X->an, X->atrunc, X->two_pow_tab,
              X->a_start_easy, X->a_stop_easy, X->a_start_hard, X->a_stop_hard);
 
-    X->to_ffts(X->ffts, X->bbuf, X->stride, X->b, X->bn, X->btrunc, X->two_pow_tab,
-             X->b_start_easy, X->b_stop_easy, X->b_start_hard, X->b_stop_hard);
+    if (!X->squaring)
+    {
+        X->to_ffts(X->ffts, X->bbuf, X->stride, X->b, X->bn, X->btrunc, X->two_pow_tab,
+                 X->b_start_easy, X->b_stop_easy, X->b_start_hard, X->b_stop_hard);
+    }
 }
 
 typedef struct fft_worker_struct {
@@ -1214,6 +1245,7 @@ typedef struct fft_worker_struct {
     double* bbuf;
     ulong btrunc;
     struct fft_worker_struct* next;
+    int squaring;
 } fft_worker_struct;
 
 void fft_worker_func(void* varg)
@@ -1224,11 +1256,19 @@ void fft_worker_func(void* varg)
 
     do {
         sd_fft_lctx_init(Q, X->fctx, X->depth);
-        sd_fft_lctx_fft_trunc(Q, X->bbuf, X->depth, X->btrunc, X->ztrunc);
+
+        if (!X->squaring)
+            sd_fft_lctx_fft_trunc(Q, X->bbuf, X->depth, X->btrunc, X->ztrunc);
+
         sd_fft_lctx_fft_trunc(Q, X->abuf, X->depth, X->atrunc, X->ztrunc);
         NMOD_RED2(m, X->cop >> (64 - X->depth), X->cop << X->depth, X->fctx->mod);
         m = nmod_inv(m, X->fctx->mod);
-        sd_fft_lctx_point_mul(Q, X->abuf, X->bbuf, m, X->depth);
+
+        if (X->squaring)
+            sd_fft_lctx_point_sqr(Q, X->abuf, m, X->depth);
+        else
+            sd_fft_lctx_point_mul(Q, X->abuf, X->bbuf, m, X->depth);
+
         sd_fft_lctx_ifft_trunc(Q, X->abuf, X->depth, X->ztrunc);
         sd_fft_lctx_clear(Q, X->fctx);
     } while (X = X->next, X != NULL);
@@ -1250,6 +1290,7 @@ typedef struct mod_fft_worker_struct {
     double* bbuf;
     ulong btrunc;
     struct mod_fft_worker_struct* next;
+    int squaring;
 } mod_fft_worker_struct;
 
 void mod_fft_worker_func(void* varg)
@@ -1260,13 +1301,24 @@ void mod_fft_worker_func(void* varg)
 
     do {
         sd_fft_lctx_init(Q, X->fctx, X->depth);
-        slow_mpn_to_fft(Q, X->bbuf, X->btrunc, X->b, X->bn, X->bits, X->two_pow_tab);
-        sd_fft_lctx_fft_trunc(Q, X->bbuf, X->depth, X->btrunc, X->ztrunc);
+
+        if (!X->squaring)
+        {
+            slow_mpn_to_fft(Q, X->bbuf, X->btrunc, X->b, X->bn, X->bits, X->two_pow_tab);
+            sd_fft_lctx_fft_trunc(Q, X->bbuf, X->depth, X->btrunc, X->ztrunc);
+        }
+
         slow_mpn_to_fft(Q, X->abuf, X->atrunc, X->a, X->an, X->bits, X->two_pow_tab);
         sd_fft_lctx_fft_trunc(Q, X->abuf, X->depth, X->atrunc, X->ztrunc);
+
         NMOD_RED2(m, X->cop >> (64 - X->depth), X->cop << X->depth, X->fctx->mod);
         m = nmod_inv(m, X->fctx->mod);
-        sd_fft_lctx_point_mul(Q, X->abuf, X->bbuf, m, X->depth);
+
+        if (X->squaring)
+            sd_fft_lctx_point_mul(Q, X->abuf, X->abuf, m, X->depth);
+        else
+            sd_fft_lctx_point_mul(Q, X->abuf, X->bbuf, m, X->depth);
+
         sd_fft_lctx_ifft_trunc(Q, X->abuf, X->depth, X->ztrunc);
         sd_fft_lctx_clear(Q, X->fctx);
     } while (X = X->next, X != NULL);
@@ -1304,6 +1356,7 @@ void mpn_ctx_mpn_mul(mpn_ctx_t R, ulong* z, ulong* a, ulong an, ulong* b, ulong 
     profile_entry P;
     ulong sz;
     void* worker_struct_buffer;
+    int squaring;
 
     mpn_ctx_best_profile(R, &P, an, bn);
 
@@ -1313,6 +1366,7 @@ void mpn_ctx_mpn_mul(mpn_ctx_t R, ulong* z, ulong* a, ulong an, ulong* b, ulong 
     sz = n_max(sz, sizeof(crt_worker_struct)*P.nthreads);
     worker_struct_buffer = flint_malloc(sz);
 
+    squaring = (a == b) && (an == bn);
     zn = an + bn;
     alen = n_cdiv(FLINT_BITS*an, P.bits);
     blen = n_cdiv(FLINT_BITS*bn, P.bits);
@@ -1393,6 +1447,7 @@ timeit_start(timer);
             X->a_stop_hard  = (i + 1 == nthreads) ? a_stop_hard : atrunc;
             X->b_start_hard = (i + 1 == nthreads) ? b_stop_easy : btrunc;
             X->b_stop_hard  = (i + 1 == nthreads) ? b_stop_hard : btrunc;
+            X->squaring = squaring;
         }
 
         for (slong i = P.nhandles; i > 0; i--)
@@ -1442,6 +1497,7 @@ timeit_start(timer);
             X->bbuf = bbuf + l*stride;
             X->btrunc = btrunc;
             X->next = (l + nthreads < P.np) ? X + nthreads : NULL;
+            X->squaring = squaring;
         }
 
         for (ulong i = n_min(P.nhandles, P.np - 1); i > 0; i--)
@@ -1490,6 +1546,7 @@ timeit_start(timer);
             X->btrunc = btrunc;
             X->two_pow_tab = R->slow_two_pow_tab[l];
             X->next = (l + nthreads < np) ? X + nthreads : NULL;
+            X->squaring = squaring;
         }
 
         for (ulong i = n_min(P.nhandles, P.np - 1); i > 0; i--)

--- a/src/fft_small/mpn_mul.c
+++ b/src/fft_small/mpn_mul.c
@@ -1043,15 +1043,15 @@ static void mpn_ctx_best_profile(
     ulong thread_limit = 8;
     ulong zn = an + bn;
 
-    if (zn < n_pow2(16-6))
+    if (zn < 2048)
         thread_limit = 1;
-    else if (zn < n_pow2(17-6))
+    else if (zn < 4096)
         thread_limit = 4;
-    else if (zn < n_pow2(18-6))
+    else if (zn < 8192)
         thread_limit = 5;
-    else if (zn < n_pow2(19-6))
+    else if (zn < 16384)
         thread_limit = 6;
-    else if (zn < n_pow2(20-6))
+    else if (zn < 32768)
         thread_limit = 7;
 
     P->nhandles = flint_request_threads(&P->handles, thread_limit);

--- a/src/fft_small/test/t-mul.c
+++ b/src/fft_small/test/t-mul.c
@@ -92,6 +92,20 @@ void test_mul(mpn_ctx_t R, ulong minsize, ulong maxsize, ulong nreps, flint_rand
             }
         }
 
+        mpn_ctx_mpn_mul(R, d, b, bn, b, bn);
+        mpn_sqr(c, b, bn);
+        for (ulong i = 0; i < 2 * bn; i++)
+        {
+            if (c[i] != d[i])
+            {
+                flint_printf("\nFAILED (squaring)\n");
+                flint_printf("bn = %wu\n", bn);
+                flint_printf("limb[%wu] = 0x%wx should be 0x%wx\n", i, d[i], c[i]);
+                fflush(stdout);
+                flint_abort();
+            }
+        }
+
         flint_set_num_threads(1 + n_randint(state, 10));
     }
 

--- a/src/mpn_extras/mul_fft_small.c
+++ b/src/mpn_extras/mul_fft_small.c
@@ -1,0 +1,91 @@
+/*
+    Copyright (C) 2023 Fredrik Johansson
+
+    This file is part of FLINT.
+
+    FLINT is free software: you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License (LGPL) as published
+    by the Free Software Foundation; either version 2.1 of the License, or
+    (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+*/
+
+#include "flint.h"
+#include "mpn_extras.h"
+
+#include "fft.h"
+
+/* FLINT's FFT can beat GMP below this threshold but apparently
+   not consistently. Something needs retuning? */
+#define FLINT_FFT_MUL_THRESHOLD 32000
+
+#define FLINT_FFT_SMALL_MUL_THRESHOLD 400
+
+#ifdef FLINT_HAVE_FFT_SMALL
+
+#include "fft_small.h"
+
+FLINT_TLS_PREFIX mpn_ctx_t default_mpn_ctx;
+FLINT_TLS_PREFIX int default_mpn_ctx_initialized = 0;
+
+void
+mpn_ctx_cleanup(void)
+{
+    if (default_mpn_ctx_initialized)
+    {
+        default_mpn_ctx_initialized = 0;
+        mpn_ctx_clear(default_mpn_ctx);
+    }
+}
+
+mp_limb_t flint_mpn_mul_large(mp_ptr r1, mp_srcptr i1, mp_size_t n1,
+                        mp_srcptr i2, mp_size_t n2)
+{
+    if (n2 < FLINT_FFT_SMALL_MUL_THRESHOLD)
+    {
+        if (n1 == n2)
+            if (i1 == i2)
+                mpn_sqr(r1, i1, n1);
+            else
+                mpn_mul_n(r1, i1, i2, n2);
+        else
+            mpn_mul(r1, i1, n1, i2, n2);
+    }
+    else
+    {
+        if (!default_mpn_ctx_initialized)
+        {
+            mpn_ctx_init(default_mpn_ctx, UWORD(0x0003f00000000001));
+            flint_register_cleanup_function(mpn_ctx_cleanup);
+            default_mpn_ctx_initialized = 1;
+        }
+
+        mpn_ctx_mpn_mul(default_mpn_ctx, r1, i1, n1, i2, n2);
+    }
+
+    return r1[n1 + n2 - 1];
+}
+
+#else
+
+mp_limb_t flint_mpn_mul_large(mp_ptr r1, mp_srcptr i1, mp_size_t n1,
+                        mp_srcptr i2, mp_size_t n2)
+{
+    if (n2 < FLINT_FFT_MUL_THRESHOLD)
+    {
+        if (n1 == n2)
+            if (i1 == i2)
+                mpn_sqr(r1, i1, n1);
+            else
+                mpn_mul_n(r1, i1, i2, n2);
+        else
+            mpn_mul(r1, i1, n1, i2, n2);
+    }
+    else
+    {
+        flint_mpn_mul_fft_main(r1, i1, n1, i2, n2);
+    }
+
+    return r1[n1 + n2 - 1];
+}
+
+#endif

--- a/src/mpn_extras/mul_fft_small.c
+++ b/src/mpn_extras/mul_fft_small.c
@@ -19,6 +19,7 @@
 #define FLINT_FFT_MUL_THRESHOLD 32000
 
 #define FLINT_FFT_SMALL_MUL_THRESHOLD 400
+#define FLINT_FFT_SMALL_SQR_THRESHOLD 800
 
 #ifdef FLINT_HAVE_FFT_SMALL
 
@@ -40,7 +41,7 @@ mpn_ctx_cleanup(void)
 mp_limb_t flint_mpn_mul_large(mp_ptr r1, mp_srcptr i1, mp_size_t n1,
                         mp_srcptr i2, mp_size_t n2)
 {
-    if (n2 < FLINT_FFT_SMALL_MUL_THRESHOLD)
+    if (n2 < FLINT_FFT_SMALL_MUL_THRESHOLD || (i1 == i2 && n1 == n2 && n2 < FLINT_FFT_SMALL_SQR_THRESHOLD))
     {
         if (n1 == n2)
             if (i1 == i2)


### PR DESCRIPTION
@tthsqe12 How does this look?

* I found a cutoff around 400 limbs vs ``mpn_mul`` on my machine (Zen 3). This probably needs adjusting for other machines.
* Probably needs better tuning for unbalanced operands and for multiple threads.
* Above a certain size we should probably build an mpn context on the fly instead of caching it. This will be a bit slower (10-20%?) but will avoid blowing the RAM for computations that barely fit in memory.
* Indeed, small_fft uses 2-3 times more memory than the SS fft, which in turn uses more memory than GMP; we'll eventually need a different strategy to handle huge multiplications.

Sample speedup ratios on the ``functions_benchmark`` example program.

```
const_pi, n digits
                      threads = 1             threads = 8   
           n       first      repeat       first      repeat
       10000       1.000                   2.000            
      100000       1.083                   1.111            
     1000000       1.361                   2.113            
    10000000       1.643                   1.496            
   100000000       1.804                   1.448            

const_euler, n digits
                      threads = 1             threads = 8   
           n       first      repeat       first      repeat
       10000       0.944                   1.545            
      100000       1.247                   2.312            
     1000000       1.669                   1.834            
    10000000       1.832                   1.769            

exp(x), n digits
                      threads = 1             threads = 8   
           n       first      repeat       first      repeat
       10000       1.000       1.048       0.500       1.318
      100000       1.111       1.520       1.200       1.624
     1000000       1.594       1.806       1.408       1.519
    10000000       1.990       1.980       1.538       1.592

log(x), n digits
                      threads = 1             threads = 8   
           n       first      repeat       first      repeat
       10000       1.000       1.029       1.000       1.429
      100000       1.292       1.542       1.452       2.470
     1000000       1.575       1.788       1.534       1.516
    10000000       1.965       1.981       1.548       1.629

sin(x), n digits
                      threads = 1             threads = 8   
           n       first      repeat       first      repeat
       10000       1.000       1.042       1.000       1.044
      100000       1.292       1.415       1.385       1.621
     1000000       1.622       1.757       1.572       1.711
    10000000       1.893       1.892       1.474       1.556

atan(x), n digits
                      threads = 1             threads = 8   
           n       first      repeat       first      repeat
       10000       1.000       0.992       1.000       1.008
      100000       1.202       1.335       1.078       1.774
     1000000       1.512       1.612       1.605       1.775
    10000000       1.906       1.943       1.475       1.566

erf(x), n digits
                      threads = 1             threads = 8   
           n       first      repeat       first      repeat
       10000       1.000       0.998       1.000       0.995
      100000       1.251       1.298       1.569       1.446
     1000000       1.700       1.723       2.261       2.254

gamma(x), n digits
                      threads = 1             threads = 8   
           n       first      repeat       first      repeat
       10000       0.991       1.002       0.959       0.994
      100000       1.514       1.547       1.846       2.236

zeta(x), n digits
                      threads = 1             threads = 8   
           n       first      repeat       first      repeat
       10000       1.079       0.993       0.649       0.757

eta(ix), n digits
                      threads = 1             threads = 8   
           n       first      repeat       first      repeat
       10000       0.714       1.000       1.000       1.000
      100000       1.450       1.817       2.407       2.156
     1000000       1.812       2.137       2.760       3.195

bernoulli(n)
                      threads = 1             threads = 8   
           n       first      repeat       first      repeat
       10000       1.000       1.008       1.000       1.389
      100000       1.060       1.038       1.209       0.994
     1000000       1.073       0.990       1.162       1.145

partitions(n^2)
                      threads = 1             threads = 8   
           n       first      repeat       first      repeat
       10000       0.647       0.995       1.000       1.021
      100000       1.164       1.214       0.977       2.118
     1000000       1.403       1.309       1.451       1.444
    10000000       1.536       1.520       1.441       1.490
```

* The reason most speedups are <2x is that we still use GMP for division and square root, which become massive bottlenecks. ``eta(ix)`` does the most plain multiplications and sees the biggest speedups in this benchmark.

Also, many high-level algorithms will want retuning.