### PR TITLE
Add new function `gr_poly_nth_derivative`

### DIFF
--- a/doc/source/acb_poly.rst
+++ b/doc/source/acb_poly.rst
@@ -569,6 +569,15 @@ Differentiation
 
     Sets *res* to the derivative of *poly*.
 
+.. function:: void _acb_poly_nth_derivative(acb_ptr res, acb_srcptr poly, ulong n, slong len, slong prec)
+
+    Sets *{res, len - n}* to the nth derivative of *{poly, len}*. Does
+    nothing if *len <= n*. Allows aliasing of the input and output.
+
+.. function:: void acb_poly_nth_derivative(acb_poly_t res, const acb_poly_t poly, ulong n, slong prec)
+
+    Sets *res* to the nth derivative of *poly*.
+
 .. function:: void _acb_poly_integral(acb_ptr res, acb_srcptr poly, slong len, slong prec)
 
     Sets *{res, len}* to the integral of *{poly, len - 1}*.

--- a/doc/source/arb_poly.rst
+++ b/doc/source/arb_poly.rst
@@ -619,6 +619,15 @@ Differentiation
 
     Sets *res* to the derivative of *poly*.
 
+.. function:: void _arb_poly_nth_derivative(arb_ptr res, arb_srcptr poly, ulong n, slong len, slong prec)
+
+    Sets *{res, len - n}* to the nth derivative of *{poly, len}*. Does
+    nothing if *len <= n*. Allows aliasing of the input and output.
+
+.. function:: void arb_poly_nth_derivative(arb_poly_t res, const arb_poly_t poly, slong prec)
+
+    Sets *res* to the nth derivative of *poly*.
+
 .. function:: void _arb_poly_integral(arb_ptr res, arb_srcptr poly, slong len, slong prec)
 
     Sets *{res, len}* to the integral of *{poly, len - 1}*.

--- a/doc/source/gr_poly.rst
+++ b/doc/source/gr_poly.rst
@@ -391,6 +391,9 @@ Derivative and integral
 .. function:: int _gr_poly_derivative(gr_ptr res, gr_srcptr poly, slong len, gr_ctx_t ctx)
               int gr_poly_derivative(gr_poly_t res, const gr_poly_t poly, gr_ctx_t ctx)
 
+.. function:: int _gr_poly_nth_derivative(gr_ptr res, gr_srcptr poly, ulong n, slong len, gr_ctx_t ctx)
+              int gr_poly_nth_derivative(gr_poly_t res, const gr_poly_t poly, ulong n, gr_ctx_t ctx)
+
 .. function:: int _gr_poly_integral(gr_ptr res, gr_srcptr poly, slong len, gr_ctx_t ctx)
               int gr_poly_integral(gr_poly_t res, const gr_poly_t poly, gr_ctx_t ctx)
 

--- a/src/acb_poly.h
+++ b/src/acb_poly.h
@@ -153,6 +153,10 @@ void _acb_poly_derivative(acb_ptr res, acb_srcptr poly, slong len, slong prec);
 
 void acb_poly_derivative(acb_poly_t res, const acb_poly_t poly, slong prec);
 
+void _acb_poly_nth_derivative(acb_ptr res, acb_srcptr poly, ulong n, slong len, slong prec);
+
+void acb_poly_nth_derivative(acb_poly_t res, const acb_poly_t poly, ulong n, slong prec);
+
 void _acb_poly_integral(acb_ptr res, acb_srcptr poly, slong len, slong prec);
 
 void acb_poly_integral(acb_poly_t res, const acb_poly_t poly, slong prec);

--- a/src/acb_poly/nth_derivative.c
+++ b/src/acb_poly/nth_derivative.c
@@ -1,0 +1,49 @@
+/*
+    Copyright (C) 2023 Joel Dahne
+
+    This file is part of Arb.
+
+    Arb is free software: you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License (LGPL) as published
+    by the Free Software Foundation; either version 2.1 of the License, or
+    (at your option) any later version.  See <http://www.gnu.org/licenses/>.
+*/
+
+#include "acb_poly.h"
+#include "gr_poly.h"
+
+void
+_acb_poly_nth_derivative(acb_ptr res, acb_srcptr poly, ulong n, slong len, slong prec)
+{
+    gr_ctx_t ctx;
+    gr_ctx_init_complex_acb(ctx, prec);
+    if (_gr_poly_nth_derivative(res, poly, n, len, ctx) != GR_SUCCESS)
+        _acb_vec_indeterminate(res, n);
+}
+
+void
+acb_poly_nth_derivative(acb_poly_t res, const acb_poly_t poly, ulong n, slong prec)
+{
+    const slong len = poly->length;
+
+    if (len <= n)
+    {
+        acb_poly_zero(res);
+    }
+    else if (n == 0)
+    {
+        acb_poly_set(res, poly);
+    }
+    else if (n == 1)
+    {
+        acb_poly_fit_length(res, len - 1);
+        _acb_poly_derivative(res->coeffs, poly->coeffs, len, prec);
+        _acb_poly_set_length(res, len - 1);
+    }
+    else
+    {
+        acb_poly_fit_length(res, len - n);
+        _acb_poly_nth_derivative(res->coeffs, poly->coeffs, n, len, prec);
+        _acb_poly_set_length(res, len - n);
+    }
+}

--- a/src/arb_poly.h
+++ b/src/arb_poly.h
@@ -432,6 +432,10 @@ void _arb_poly_derivative(arb_ptr res, arb_srcptr poly, slong len, slong prec);
 
 void arb_poly_derivative(arb_poly_t res, const arb_poly_t poly, slong prec);
 
+void _arb_poly_nth_derivative(arb_ptr res, arb_srcptr poly, ulong n, slong len, slong prec);
+
+void arb_poly_nth_derivative(arb_poly_t res, const arb_poly_t poly, ulong n, slong prec);
+
 void _arb_poly_integral(arb_ptr res, arb_srcptr poly, slong len, slong prec);
 
 void arb_poly_integral(arb_poly_t res, const arb_poly_t poly, slong prec);

--- a/src/arb_poly/nth_derivative.c
+++ b/src/arb_poly/nth_derivative.c
@@ -1,0 +1,49 @@
+/*
+    Copyright (C) 2023 Joel Dahne
+
+    This file is part of Arb.
+
+    Arb is free software: you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License (LGPL) as published
+    by the Free Software Foundation; either version 2.1 of the License, or
+    (at your option) any later version.  See <http://www.gnu.org/licenses/>.
+*/
+
+#include "arb_poly.h"
+#include "gr_poly.h"
+
+void
+_arb_poly_nth_derivative(arb_ptr res, arb_srcptr poly, ulong n, slong len, slong prec)
+{
+    gr_ctx_t ctx;
+    gr_ctx_init_real_arb(ctx, prec);
+    if (_gr_poly_nth_derivative(res, poly, n, len, ctx) != GR_SUCCESS)
+        _arb_vec_indeterminate(res, n);
+}
+
+void
+arb_poly_nth_derivative(arb_poly_t res, const arb_poly_t poly, ulong n, slong prec)
+{
+    const slong len = poly->length;
+
+    if (len <= n)
+    {
+        arb_poly_zero(res);
+    }
+    else if (n == 0)
+    {
+        arb_poly_set(res, poly);
+    }
+    else if (n == 1)
+    {
+        arb_poly_fit_length(res, len - 1);
+        _arb_poly_derivative(res->coeffs, poly->coeffs, len, prec);
+        _arb_poly_set_length(res, len - 1);
+    }
+    else
+    {
+        arb_poly_fit_length(res, len - n);
+        _arb_poly_nth_derivative(res->coeffs, poly->coeffs, n, len, prec);
+        _arb_poly_set_length(res, len - n);
+    }
+}

--- a/src/gr_poly.h
+++ b/src/gr_poly.h
@@ -285,6 +285,9 @@ WARN_UNUSED_RESULT int gr_poly_compose_series(gr_poly_t res, const gr_poly_t pol
 WARN_UNUSED_RESULT int _gr_poly_derivative(gr_ptr res, gr_srcptr poly, slong len, gr_ctx_t ctx);
 WARN_UNUSED_RESULT int gr_poly_derivative(gr_poly_t res, const gr_poly_t poly, gr_ctx_t ctx);
 
+WARN_UNUSED_RESULT int _gr_poly_nth_derivative(gr_ptr res, gr_srcptr poly, ulong n, slong len, gr_ctx_t ctx);
+WARN_UNUSED_RESULT int gr_poly_nth_derivative(gr_poly_t res, const gr_poly_t poly, ulong n, gr_ctx_t ctx);
+
 WARN_UNUSED_RESULT int _gr_poly_integral(gr_ptr res, gr_srcptr poly, slong len, gr_ctx_t ctx);
 WARN_UNUSED_RESULT int gr_poly_integral(gr_poly_t res, const gr_poly_t poly, gr_ctx_t ctx);
 

--- a/src/gr_poly/nth_derivative.c
+++ b/src/gr_poly/nth_derivative.c
@@ -1,0 +1,75 @@
+/*
+    Copyright (C) 2023 Joel Dahne
+
+    This file is part of FLINT.
+
+    FLINT is free software: you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License (LGPL) as published
+    by the Free Software Foundation; either version 2.1 of the License, or
+    (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+*/
+
+#include "fmpz.h"
+#include "gr_poly.h"
+
+int
+_gr_poly_nth_derivative(gr_ptr res, gr_srcptr poly, ulong n, slong len, gr_ctx_t ctx)
+{
+    gr_method_binary_op_fmpz mul_fmpz = GR_BINARY_OP_FMPZ(ctx, MUL_FMPZ);
+    fmpz_t c;
+    slong i;
+    slong sz = ctx->sizeof_elem;
+    int status = GR_SUCCESS;
+
+    /* todo: optimize for small n so that c fits in ulong */
+    /* todo: optimize for large n and finite characteristic or precision */
+
+    fmpz_init(c);
+
+    fmpz_fac_ui(c, n);
+    status |= mul_fmpz(GR_ENTRY(res, 0, sz), GR_ENTRY(poly, n, sz), c, ctx);
+    for (i = n + 1; i < len; i ++)
+    {
+        fmpz_divexact_ui(c, c, i - n);
+        fmpz_mul_ui(c, c, i);
+        status |= mul_fmpz(GR_ENTRY(res, i - n, sz), GR_ENTRY(poly, i, sz), c, ctx);
+    }
+
+    fmpz_clear(c);
+
+    return status;
+}
+
+int
+gr_poly_nth_derivative(gr_poly_t res, const gr_poly_t poly, ulong n, gr_ctx_t ctx)
+{
+    int status;
+    const slong len = poly->length;
+
+    if (len <= n)
+    {
+        status = gr_poly_zero(res, ctx);
+    }
+    else if (n == 0)
+    {
+        status = gr_poly_set(res, poly, ctx);
+    }
+    else if (n == 1)
+    {
+        gr_poly_fit_length(res, len - 1, ctx);
+        status = _gr_poly_derivative(res->coeffs, poly->coeffs, len, ctx);
+        _gr_poly_set_length(res, len - 1, ctx);
+        /* todo: only call in nonzero characteristic */
+        _gr_poly_normalise(res, ctx);
+    }
+    else
+    {
+        gr_poly_fit_length(res, len - n, ctx);
+        status = _gr_poly_nth_derivative(res->coeffs, poly->coeffs, n, len, ctx);
+        _gr_poly_set_length(res, len - n, ctx);
+        /* todo: only call in nonzero characteristic */
+        _gr_poly_normalise(res, ctx);
+    }
+
+    return status;
+}

--- a/src/gr_poly/test/t-nth_derivative.c
+++ b/src/gr_poly/test/t-nth_derivative.c
@@ -1,0 +1,79 @@
+/*
+    Copyright (C) 2023 Joel Dahne
+
+    This file is part of FLINT.
+
+    FLINT is free software: you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License (LGPL) as published
+    by the Free Software Foundation; either version 2.1 of the License, or
+    (at your option) any later version.  See <https://www.gnu.org/licenses/>.
+*/
+
+#include "flint.h"
+#include "gr_poly.h"
+#include "ulong_extras.h"
+
+int
+main(void)
+{
+    slong iter;
+    flint_rand_t state;
+
+    flint_printf("nth_derivative....");
+    fflush(stdout);
+
+    flint_randinit(state);
+
+    for (iter = 0; iter < 1000; iter++)
+    {
+        int status;
+        ulong nth;
+        slong j;
+        gr_ctx_t ctx;
+        gr_poly_t a, b;
+
+        gr_ctx_init_random(ctx, state);
+
+        gr_poly_init(a, ctx);
+        gr_poly_init(b, ctx);
+
+        status = GR_SUCCESS;
+
+        status |= gr_poly_randtest(a, state, n_randint(state, 30), ctx);
+        status |= gr_poly_randtest(b, state, n_randint(state, 30), ctx);
+
+        nth = n_randint(state, 30);
+
+        if (n_randint(state, 2)) {
+            status |= gr_poly_nth_derivative(b, a, nth, ctx);
+        }
+        else
+        {
+            status |= gr_poly_set(b, a, ctx);
+            status |= gr_poly_nth_derivative(b, b, nth, ctx);
+        }
+
+        /* Compute derivative iteratively */
+        for (j = 0; j < nth; j ++)
+            status |= gr_poly_derivative(a, a, ctx);
+
+        if (status == GR_SUCCESS && gr_poly_equal(a, b, ctx) == T_FALSE)
+        {
+            flint_printf("FAIL:\n");
+            flint_printf("a = "); gr_poly_print(a, ctx); flint_printf("\n");
+            flint_printf("b = "); gr_poly_print(b, ctx); flint_printf("\n");
+            flint_abort();
+        }
+
+        gr_poly_clear(a, ctx);
+        gr_poly_clear(b, ctx);
+
+        gr_ctx_clear(ctx);
+    }
+
+
+    flint_randclear(state);
+    flint_cleanup();
+    flint_printf("PASS\n");
+    return 0;
+}


### PR DESCRIPTION
It has been on my wish list for a while to have a method for computing higher order derivatives of polynomials, specifically for `arb_poly` and `acb_poly` in my case. Recently I noticed that `fmpz_poly` and `fmpq_poly` do have such methods. I have also been keeping track of the progress with the `gr` methods and have wanted to look closer at it. I thought I could combine both of these goals by trying to implement a `gr_poly_nth_derivative` function.

The implementation, as well as the tests, is basically a combination of the one for `fmpz_poly_nth_derivative` and `gr_poly_derivative`. If this looks reasonable, and is a function you want to add, I could implement `gr_poly_nth_integral` as well. I could also create simple wrappers for `arb_poly` and `acb_poly`, that would be useful for me.

For specific rings it would be possible to create better implementations than the generic one, the one for `fmpq_poly` is one example. I think this is to be handled by allowing for overloading the function though?