### PR TITLE
Tune fmpz_poly multiplication for fft_small

### DIFF
--- a/src/fmpq_poly/asin_series.c
+++ b/src/fmpq_poly/asin_series.c
@@ -21,8 +21,10 @@ _fmpq_poly_asin_series(fmpz * g, fmpz_t gden,
     fmpz * u;
     fmpz_t tden;
     fmpz_t uden;
+    slong h2len;
 
     hlen = FLINT_MIN(hlen, n);
+    h2len = FLINT_MIN(2 * hlen - 1, n);
 
     if (hlen == 1)
     {
@@ -37,11 +39,11 @@ _fmpq_poly_asin_series(fmpz * g, fmpz_t gden,
     fmpz_init(uden);
 
     /* asin(h(x)) = integral(h'(x)/sqrt(1-h(x)^2)) */
-    _fmpq_poly_mullow(u, uden, h, hden, hlen, h, hden, hlen, n);
-    _fmpq_poly_canonicalise(u, uden, n);
-    _fmpz_vec_neg(u, u, n);
+    _fmpq_poly_mullow(u, uden, h, hden, hlen, h, hden, hlen, h2len);
+    _fmpq_poly_canonicalise(u, uden, h2len);
+    _fmpz_vec_neg(u, u, h2len);
     fmpz_set(u, uden);  /* u += 1 */
-    _fmpq_poly_invsqrt_series(t, tden, u, uden, n, n);
+    _fmpq_poly_invsqrt_series(t, tden, u, uden, h2len, n);
     _fmpq_poly_derivative(u, uden, h, hden, hlen);
     _fmpq_poly_mullow(g, gden, t, tden, n, u, uden, hlen - 1, n);
     _fmpq_poly_canonicalise(g, gden, n - 1);

--- a/src/fmpq_poly/asinh_series.c
+++ b/src/fmpq_poly/asinh_series.c
@@ -21,8 +21,10 @@ _fmpq_poly_asinh_series(fmpz * g, fmpz_t gden,
     fmpz * u;
     fmpz_t tden;
     fmpz_t uden;
+    slong h2len;
 
     hlen = FLINT_MIN(hlen, n);
+    h2len = FLINT_MIN(2 * hlen - 1, n);
 
     if (hlen == 1)
     {
@@ -37,10 +39,10 @@ _fmpq_poly_asinh_series(fmpz * g, fmpz_t gden,
     fmpz_init(uden);
 
     /* asinh(h(x)) = integral(h'(x)/sqrt(1+h(x)^2)) */
-    _fmpq_poly_mullow(u, uden, h, hden, hlen, h, hden, hlen, n);
-    _fmpq_poly_canonicalise(u, uden, n);
+    _fmpq_poly_mullow(u, uden, h, hden, hlen, h, hden, hlen, h2len);
+    _fmpq_poly_canonicalise(u, uden, h2len);
     fmpz_set(u, uden);  /* u += 1 */
-    _fmpq_poly_invsqrt_series(t, tden, u, uden, n, n);
+    _fmpq_poly_invsqrt_series(t, tden, u, uden, h2len, n);
     _fmpq_poly_derivative(u, uden, h, hden, hlen);
     _fmpq_poly_mullow(g, gden, t, tden, n, u, uden, hlen - 1, n);
     _fmpq_poly_canonicalise(g, gden, n - 1);

--- a/src/fmpq_poly/atan_series.c
+++ b/src/fmpq_poly/atan_series.c
@@ -21,8 +21,10 @@ _fmpq_poly_atan_series(fmpz * g, fmpz_t gden,
     fmpz * u;
     fmpz_t tden;
     fmpz_t uden;
+    slong h2len;
 
     hlen = FLINT_MIN(hlen, n);
+    h2len = FLINT_MIN(2 * hlen - 1, n);
 
     if (hlen == 1)
     {
@@ -37,11 +39,11 @@ _fmpq_poly_atan_series(fmpz * g, fmpz_t gden,
     fmpz_init(uden);
 
     /* atan(h(x)) = integral(h'(x)/(1+h(x)^2)) */
-    _fmpq_poly_mullow(u, uden, h, hden, hlen, h, hden, hlen, n);
-    _fmpq_poly_canonicalise(u, uden, n);
+    _fmpq_poly_mullow(u, uden, h, hden, hlen, h, hden, hlen, h2len);
+    _fmpq_poly_canonicalise(u, uden, h2len);
     fmpz_set(u, uden);  /* u += 1 */
     _fmpq_poly_derivative(t, tden, h, hden, hlen);
-    _fmpq_poly_div_series(g, gden, t, tden, hlen - 1, u, uden, n, n);
+    _fmpq_poly_div_series(g, gden, t, tden, hlen - 1, u, uden, h2len, n);
     _fmpq_poly_canonicalise(g, gden, n - 1);
     _fmpq_poly_integral(g, gden, g, gden, n);
 

--- a/src/fmpq_poly/atanh_series.c
+++ b/src/fmpq_poly/atanh_series.c
@@ -21,8 +21,10 @@ _fmpq_poly_atanh_series(fmpz * g, fmpz_t gden,
     fmpz * u;
     fmpz_t tden;
     fmpz_t uden;
+    slong h2len;
 
     hlen = FLINT_MIN(hlen, n);
+    h2len = FLINT_MIN(2 * hlen - 1, n);
 
     if (hlen == 1)
     {
@@ -37,12 +39,12 @@ _fmpq_poly_atanh_series(fmpz * g, fmpz_t gden,
     fmpz_init(uden);
 
     /* atanh(h(x)) = integral(h'(x)/(1-h(x)^2)) */
-    _fmpq_poly_mullow(u, uden, h, hden, hlen, h, hden, hlen, n);
-    _fmpq_poly_canonicalise(u, uden, n);
-    _fmpz_vec_neg(u, u, n);
+    _fmpq_poly_mullow(u, uden, h, hden, hlen, h, hden, hlen, h2len);
+    _fmpq_poly_canonicalise(u, uden, h2len);
+    _fmpz_vec_neg(u, u, h2len);
     fmpz_set(u, uden);  /* u += 1 */
     _fmpq_poly_derivative(t, tden, h, hden, hlen);
-    _fmpq_poly_div_series(g, gden, t, tden, hlen - 1, u, uden, n, n);
+    _fmpq_poly_div_series(g, gden, t, tden, hlen - 1, u, uden, h2len, n);
     _fmpq_poly_canonicalise(g, gden, n - 1);
     _fmpq_poly_integral(g, gden, g, gden, n);
 

--- a/src/fmpz_poly.h
+++ b/src/fmpz_poly.h
@@ -381,6 +381,9 @@ void _fmpz_poly_mul_karatsuba(fmpz * res, const fmpz * poly1,
 void _fmpz_poly_mullow_karatsuba_n(fmpz * res, const fmpz * poly1,
                                                 const fmpz * poly2, slong n);
 
+void _fmpz_poly_mullow_karatsuba(fmpz * res, const fmpz * poly1, slong len1,
+                              const fmpz * poly2, slong len2, slong n);
+
 void fmpz_poly_mullow_karatsuba_n(fmpz_poly_t res,
                   const fmpz_poly_t poly1, const fmpz_poly_t poly2, slong n);
 
@@ -476,6 +479,8 @@ void _fmpz_poly_sqrlow_KS(fmpz * res, const fmpz * poly, slong len, slong n);
 void fmpz_poly_sqrlow_KS(fmpz_poly_t res, const fmpz_poly_t poly, slong n);
 
 void _fmpz_poly_sqrlow_karatsuba_n(fmpz * res, const fmpz * poly, slong n);
+
+void _fmpz_poly_sqrlow_karatsuba(fmpz * res, const fmpz * poly, slong len, slong n);
 
 void fmpz_poly_sqrlow_karatsuba_n(fmpz_poly_t res, const fmpz_poly_t poly, slong n);
 

--- a/src/fmpz_poly/div_preinv.c
+++ b/src/fmpz_poly/div_preinv.c
@@ -17,35 +17,38 @@ void
 _fmpz_poly_div_preinv(fmpz * Q, const fmpz * A, slong len1_in,
                                 const fmpz * B, const fmpz * B_inv, slong len2)
 {
-   slong len1 = len1_in;
-   slong n = len1 - len2 + 1;
-   fmpz * A_rev;
-   fmpz * a;
+    slong len1 = len1_in;
+    slong n = len1 - len2 + 1;
+    fmpz * A_rev;
+    fmpz * a;
 
-   if (n > len2)
-   {
-      a = _fmpz_vec_init(len1_in);
-      _fmpz_vec_set(a, A, len1_in);
+    if (n > len2)
+    {
+        a = _fmpz_vec_init(len1_in);
+        _fmpz_vec_set(a, A, len1_in);
 
-      do {
-         slong start = n - len2;
-         _fmpz_poly_divrem_preinv(Q + start, a + start, len1 - start,
+        do {
+            slong start = n - len2;
+            _fmpz_poly_divrem_preinv(Q + start, a + start, len1 - start,
                                                                B, B_inv, len2);
-         n -= len2;
-         len1 -= len2;
-      } while (n > len2);
-   } else
-      a = (fmpz *) A;
+            n -= len2;
+            len1 -= len2;
+        } while (n > len2);
+    }
+    else
+        a = (fmpz *) A;
 
-   A_rev = _fmpz_vec_init(len1);
+    A_rev = _fmpz_vec_init(len1);
 
-   _fmpz_poly_reverse(A_rev, a, len1, len1);
-   _fmpz_poly_mullow(Q, A_rev, len1, B_inv, len2, n);
-   _fmpz_poly_reverse(Q, Q, n, n);
+    _fmpz_poly_reverse(A_rev, a, len1, len1);
+    _fmpz_poly_mullow(Q, A_rev, len1, B_inv, len2, FLINT_MIN(len1 + len2 - 1, n));
+    if (len1 + len2 - 1 < n)
+        _fmpz_vec_zero(Q + len1 + len2 - 1, n - (len1 + len2 - 1));
+    _fmpz_poly_reverse(Q, Q, n, n);
+    _fmpz_vec_clear(A_rev, len1);
 
-   if (a != A)
-      _fmpz_vec_clear(a, len1_in);
-   _fmpz_vec_clear(A_rev, len1);
+    if (a != A)
+        _fmpz_vec_clear(a, len1_in);
 }
 
 void

--- a/src/fmpz_poly/divrem_preinv.c
+++ b/src/fmpz_poly/divrem_preinv.c
@@ -22,10 +22,13 @@ _fmpz_poly_divrem_preinv(fmpz * Q, fmpz * A, slong len1,
 
    _fmpz_poly_div_preinv(Q, A, len1, B, B_inv, len2);
 
-   if (len2 - 1 > n)
-      _fmpz_poly_mullow(P, B, len2 - 1, Q, n, len2 - 1);
-   else
-      _fmpz_poly_mullow(P, Q, n, B, len2 - 1, len2 - 1);
+   if (len2 - 1 > 0)
+   {
+       if (len2 - 1 > n)
+          _fmpz_poly_mullow(P, B, len2 - 1, Q, n, len2 - 1);
+       else
+          _fmpz_poly_mullow(P, Q, n, B, len2 - 1, len2 - 1);
+    }
 
    _fmpz_poly_sub(A, A, len2 - 1, P, len2 - 1);
 

--- a/src/gr_poly/div_series_newton.c
+++ b/src/gr_poly/div_series_newton.c
@@ -59,9 +59,9 @@ _gr_poly_div_series_newton(gr_ptr res, gr_srcptr B, slong Blen, gr_srcptr A, slo
         Anlen = FLINT_MIN(Alen, n);
         Wlen = FLINT_MIN(Anlen + m - 1, n);
         W2len = Wlen - m;
-
         status |= _gr_poly_mullow(W, A, Anlen, res, m, Wlen, ctx);
-        status |= _gr_poly_mullow(GR_ENTRY(res, m, sz), res, m, GR_ENTRY(W, m, sz), W2len, n - m, ctx);
+        if (W2len != 0)
+            status |= _gr_poly_mullow(GR_ENTRY(res, m, sz), res, m, GR_ENTRY(W, m, sz), W2len, n - m, ctx);
         status |= _gr_vec_neg(GR_ENTRY(res, m, sz), GR_ENTRY(res, m, sz), n - m, ctx);
     }
 
@@ -70,7 +70,6 @@ _gr_poly_div_series_newton(gr_ptr res, gr_srcptr B, slong Blen, gr_srcptr A, slo
 
     Anlen = FLINT_MIN(Alen, n);
     Wlen = FLINT_MIN(Anlen + m - 1, n);
-    W2len = Wlen - m;
 
     /* Karp-Markstein */
     status |= _gr_poly_mullow(T, res, m, B, Blen, m, ctx);

--- a/src/gr_poly/rsqrt_series_newton.c
+++ b/src/gr_poly/rsqrt_series_newton.c
@@ -51,7 +51,7 @@ _gr_poly_rsqrt_series_newton(gr_ptr g,
     if (len > n)
     {
         gr_ptr t, u;
-        slong tlen;
+        slong tlen, ulen;
 
         GR_TMP_INIT_VEC(t, 2 * len, ctx);
         u = GR_ENTRY(t, len, sz);
@@ -62,9 +62,11 @@ _gr_poly_rsqrt_series_newton(gr_ptr g,
             n = a[i];
 
             tlen = FLINT_MIN(2 * m - 1, n);
+            ulen = FLINT_MIN(n, m + tlen - 1);
+
             status |= _gr_poly_mullow(t, g, m, g, m, tlen, ctx);
-            status |= _gr_poly_mullow(u, g, m, t, tlen, n, ctx);
-            status |= _gr_poly_mullow(t, u, n, h, FLINT_MIN(hlen, n), n, ctx);   /* should be mulmid */
+            status |= _gr_poly_mullow(u, g, m, t, tlen, ulen, ctx);
+            status |= _gr_poly_mullow(t, u, ulen, h, FLINT_MIN(hlen, n), n, ctx);   /* should be mulmid */
             status |= _gr_vec_mul_scalar_2exp_si(GR_ENTRY(g, m, sz), GR_ENTRY(t, m, sz), n - m, -1, ctx);
             status |= _gr_vec_neg(GR_ENTRY(g, m, sz), GR_ENTRY(g, m, sz), n - m, ctx);
         }

--- a/src/gr_poly/sqrt_series_newton.c
+++ b/src/gr_poly/sqrt_series_newton.c
@@ -21,7 +21,7 @@ _gr_poly_sqrt_series_newton(gr_ptr g,
     slong a[FLINT_BITS];
     slong i, m, n, alloc;
     gr_ptr t, u, v;
-    slong tlen;
+    slong tlen, ulen;
 
     hlen = FLINT_MIN(hlen, len);
 
@@ -53,9 +53,11 @@ _gr_poly_sqrt_series_newton(gr_ptr g,
         n = a[i];
 
         tlen = FLINT_MIN(2 * m - 1, n);
+        ulen = FLINT_MIN(n, m + tlen - 1);
+
         status |= _gr_poly_mullow(t, g, m, g, m, tlen, ctx);
-        status |= _gr_poly_mullow(u, g, m, t, tlen, n, ctx);
-        status |= _gr_poly_mullow(t, u, n, h, FLINT_MIN(hlen, n), n, ctx);   /* should be mulmid */
+        status |= _gr_poly_mullow(u, g, m, t, tlen, ulen, ctx);
+        status |= _gr_poly_mullow(t, u, ulen, h, FLINT_MIN(hlen, n), n, ctx);   /* should be mulmid */
         status |= _gr_vec_mul_scalar_2exp_si(GR_ENTRY(g, m, sz), GR_ENTRY(t, m, sz), n - m, -1, ctx);
         status |= _gr_vec_neg(GR_ENTRY(g, m, sz), GR_ENTRY(g, m, sz), n - m, ctx);
     }

--- a/src/gr_poly/xgcd_euclidean.c
+++ b/src/gr_poly/xgcd_euclidean.c
@@ -120,6 +120,7 @@ _gr_poly_xgcd_euclidean(slong * lenG, gr_ptr G, gr_ptr S, gr_ptr T, gr_srcptr A,
             status |= _gr_vec_set(G, D, lenD, ctx);
             status |= _gr_vec_set(S, U, lenU, ctx);
 
+            if (status == GR_SUCCESS)
             {
                 lenQ = lenA + lenU - 1;
 


### PR DESCRIPTION
Now mul_KS almost always wins.

Speedups over old tuning (100 = 1.00x).

```
rows: n = 2, 4, 8, 16, ...
cols: bits = 100, 200, 400, 800, 1600, ...

1 thread:

 100  101  100  100   99  100  126  129  130  131  134  134  134  132  132  133  128  130  130 
 100  100  100  101  101  100  161  168  175  195  178  174  174  175  173  168  168  163 
 101  100  100  100  100  100  112  149  198  183  166  156  147  134  135  131  118 
 100  100  100  100  100  145  217  228  221  225  232  264  248  290  280   98 
 100   99  101  100  100  151  204  214  216  222  217  235  245  273  255 
 100  100  100  100  100  144  193  210  214  206  194  232  231  247 
 100  100  126  114  118  142  192  208  201  188  194  223  212 
  99  100  149  116  115  141  193  193  183  194  183  201 
 103   99  146  125  119  140  180  175  182  181  173 
 104   97  149  136  135  128  166  176  175  164 
 101   98  101  135  142  136  165  178  159 
 101   99  103   94  132  160  173  160 
 100   91  107   94  102  162  173 
 103   87  106   94  101   99 
 106   87  103   98  102 
 103   95  106  102 
 101   97  103 
 107   97 
 103 


8 threads:

 100  100  100  100   99  101  125  128  130  130  131  128  126  122  135  132  116  133  121 
 103  100  100  101  100  101  161  167  174  193  179  181  174  175  166  177  140  152 
 101  101  100  100  101  100  140  294  543  596  427  252  160   95   77   76   83 
 100  100  100  100  100  183  423  482  958  938  730  848  516  550  498   99 
 100  101  100  100  100  295  557  656 1011  683  563  494  386  437  498 
 100  100  100  100  101  385  621  744  946  729  424  400  400  516 
  99   99  153  205  300  424  677  681  723  464  305  337  423 
 101   97  262  249  262  352  452  333  291  183  177  226 
 100  102  310  243  223  286  262  209  196  195  202 
 100  122  361  316  274  193  149  137  134  137 
 104  105  101  255  152  116  114  111  123 
  96  103   85  112   98   99  100  109 
  68  116   96  105  105   72   99 
  65  114   89  104  104  101 
  90  114   87  102  106 
 118  116   90  105 
  94  109   89 
  97  111 
  93 
```

Cutoffs may need further tweaking for unbalanced or structured operands.
