### PR TITLE
Fix handling of non-finite input for arb/acb_poly_compose_series

### DIFF
--- a/src/acb_poly/compose_series.c
+++ b/src/acb_poly/compose_series.c
@@ -27,14 +27,14 @@ _acb_poly_compose_series(acb_ptr res, acb_srcptr poly1, slong len1,
          * poly2 are finite */
         slong k = 0;
 
-        while (acb_is_finite(poly1 + k) && acb_is_finite(poly2 + k))
+        while (((k >= len1) || acb_is_finite(poly1 + k)) && ((k >= len2) || acb_is_finite(poly2 + k)))
             k += 1;
 
         if (k > 0)
         {
             gr_ctx_t ctx;
             gr_ctx_init_complex_acb(ctx, prec);
-            GR_MUST_SUCCEED(_gr_poly_compose_series(res, poly1, k, poly2, k, FLINT_MIN(n, k), ctx));
+            GR_MUST_SUCCEED(_gr_poly_compose_series(res, poly1, FLINT_MIN(len1, k), poly2, FLINT_MIN(len2, k), FLINT_MIN(n, k), ctx));
             _acb_vec_indeterminate(res + k, n - k);
         }
         else

--- a/src/acb_poly/compose_series.c
+++ b/src/acb_poly/compose_series.c
@@ -23,7 +23,24 @@ _acb_poly_compose_series(acb_ptr res, acb_srcptr poly1, slong len1,
     }
     else if (!_acb_vec_is_finite(poly1, len1) || !_acb_vec_is_finite(poly2, len2))
     {
-        _acb_vec_indeterminate(res, n);
+        /* find k such that the first k coefficients of both poly1 and
+         * poly2 are finite */
+        slong k = 0;
+
+        while (acb_is_finite(poly1 + k) && acb_is_finite(poly2 + k))
+            k += 1;
+
+        if (k > 0)
+        {
+            gr_ctx_t ctx;
+            gr_ctx_init_complex_acb(ctx, prec);
+            GR_MUST_SUCCEED(_gr_poly_compose_series(res, poly1, k, poly2, k, FLINT_MIN(n, k), ctx));
+            _acb_vec_indeterminate(res + k, n - k);
+        }
+        else
+        {
+            _acb_vec_indeterminate(res, n);
+        }
     }
     else
     {

--- a/src/acb_poly/test/t-compose_series.c
+++ b/src/acb_poly/test/t-compose_series.c
@@ -87,6 +87,52 @@ int main(void)
             flint_abort();
         }
 
+        if (a->length > 0 && b->length > 0)
+        {
+            int any_finite;
+            slong i, k, l, m;
+
+            /* randomize coefficients to set to indeterminate value */
+            k = n_randint(state, a->length);
+            l = 1 + n_randint(state, b->length - 1);
+
+            acb_indeterminate(a->coeffs + k);
+            acb_indeterminate(b->coeffs + l);
+
+            acb_poly_compose_series(d, a, b, n, rbits3);
+
+            /* up to this all coefficients should be finite */
+            m = FLINT_MIN(FLINT_MIN(k, l), d->length);
+
+            /* check that coefficients after m are all non-finite */
+            any_finite = 0;
+            for (i = m; i < d->length; i++)
+                any_finite |= acb_is_finite(d->coeffs + i);
+
+            if (any_finite)
+            {
+                flint_printf("FAIL (non-finite 1)\n\n");
+                flint_abort();
+            }
+
+            /* check that coefficients up to m are all finite and
+               contain the expected result */
+            if (!_acb_vec_is_finite(d->coeffs, m))
+            {
+                flint_printf("FAIL (non-finite 2)\n\n");
+                flint_abort();
+            }
+
+            fmpq_poly_truncate(C, m);
+            acb_poly_truncate(d, m);
+
+            if (!acb_poly_contains_fmpq_poly(d, C))
+            {
+                flint_printf("FAIL (non-finite 3)\n\n");
+                flint_abort();
+            }
+        }
+
         fmpq_poly_clear(A);
         fmpq_poly_clear(B);
         fmpq_poly_clear(C);

--- a/src/acb_poly/test/t-compose_series.c
+++ b/src/acb_poly/test/t-compose_series.c
@@ -93,11 +93,19 @@ int main(void)
             slong i, k, l, m;
 
             /* randomize coefficients to set to indeterminate value */
-            k = n_randint(state, a->length);
-            l = 1 + n_randint(state, b->length - 1);
+            /* if the value is equal to the length we don't set an indeterminate value */
+            k = n_randint(state, a->length + 1);
+            l = 1 + n_randint(state, b->length);
 
-            acb_indeterminate(a->coeffs + k);
-            acb_indeterminate(b->coeffs + l);
+            if (k < a->length)
+              acb_indeterminate(a->coeffs + k);
+            else
+              k = n; // k doesn't affect number of finite coefficients
+
+            if (l < b->length)
+              acb_indeterminate(b->coeffs + l);
+            else
+              l = n; // l doesn't affect number of finite coefficients
 
             acb_poly_compose_series(d, a, b, n, rbits3);
 

--- a/src/arb_poly/compose_series.c
+++ b/src/arb_poly/compose_series.c
@@ -27,14 +27,14 @@ _arb_poly_compose_series(arb_ptr res, arb_srcptr poly1, slong len1,
          * poly2 are finite */
         slong k = 0;
 
-        while (arb_is_finite(poly1 + k) && arb_is_finite(poly2 + k))
+        while (((k >= len1) || arb_is_finite(poly1 + k)) && ((k >= len2) || arb_is_finite(poly2 + k)))
             k += 1;
 
         if (k > 0)
         {
             gr_ctx_t ctx;
             gr_ctx_init_real_arb(ctx, prec);
-            GR_MUST_SUCCEED(_gr_poly_compose_series(res, poly1, k, poly2, k, FLINT_MIN(n, k), ctx));
+            GR_MUST_SUCCEED(_gr_poly_compose_series(res, poly1, FLINT_MIN(len1, k), poly2, FLINT_MIN(len2, k), FLINT_MIN(n, k), ctx));
             _arb_vec_indeterminate(res + k, n - k);
         }
         else

--- a/src/arb_poly/compose_series.c
+++ b/src/arb_poly/compose_series.c
@@ -23,7 +23,24 @@ _arb_poly_compose_series(arb_ptr res, arb_srcptr poly1, slong len1,
     }
     else if (!_arb_vec_is_finite(poly1, len1) || !_arb_vec_is_finite(poly2, len2))
     {
-        _arb_vec_indeterminate(res, n);
+        /* find k such that the first k coefficients of both poly1 and
+         * poly2 are finite */
+        slong k = 0;
+
+        while (arb_is_finite(poly1 + k) && arb_is_finite(poly2 + k))
+            k += 1;
+
+        if (k > 0)
+        {
+            gr_ctx_t ctx;
+            gr_ctx_init_real_arb(ctx, prec);
+            GR_MUST_SUCCEED(_gr_poly_compose_series(res, poly1, k, poly2, k, FLINT_MIN(n, k), ctx));
+            _arb_vec_indeterminate(res + k, n - k);
+        }
+        else
+        {
+            _arb_vec_indeterminate(res, n);
+        }
     }
     else
     {

--- a/src/arb_poly/test/t-compose_series.c
+++ b/src/arb_poly/test/t-compose_series.c
@@ -93,11 +93,19 @@ int main(void)
             slong i, k, l, m;
 
             /* randomize coefficients to set to indeterminate value */
-            k = n_randint(state, a->length);
-            l = 1 + n_randint(state, b->length - 1);
+            /* if the value is equal to the length we don't set an indeterminate value */
+            k = n_randint(state, a->length + 1);
+            l = 1 + n_randint(state, b->length);
 
-            arb_indeterminate(a->coeffs + k);
-            arb_indeterminate(b->coeffs + l);
+            if (k < a->length)
+              arb_indeterminate(a->coeffs + k);
+            else
+              k = n; // k doesn't affect number of finite coefficients
+
+            if (l < b->length)
+              arb_indeterminate(b->coeffs + l);
+            else
+              l = n; // l doesn't affect number of finite coefficients
 
             arb_poly_compose_series(d, a, b, n, rbits3);
 

--- a/src/arb_poly/test/t-compose_series.c
+++ b/src/arb_poly/test/t-compose_series.c
@@ -87,6 +87,52 @@ int main(void)
             flint_abort();
         }
 
+        if (a->length > 0 && b->length > 0)
+        {
+            int any_finite;
+            slong i, k, l, m;
+
+            /* randomize coefficients to set to indeterminate value */
+            k = n_randint(state, a->length);
+            l = 1 + n_randint(state, b->length - 1);
+
+            arb_indeterminate(a->coeffs + k);
+            arb_indeterminate(b->coeffs + l);
+
+            arb_poly_compose_series(d, a, b, n, rbits3);
+
+            /* up to this all coefficients should be finite */
+            m = FLINT_MIN(FLINT_MIN(k, l), d->length);
+
+            /* check that coefficients after m are all non-finite */
+            any_finite = 0;
+            for (i = m; i < d->length; i++)
+                any_finite |= arb_is_finite(d->coeffs + i);
+
+            if (any_finite)
+            {
+                flint_printf("FAIL (non-finite 1)\n\n");
+                flint_abort();
+            }
+
+            /* check that coefficients up to m are all finite and
+               contain the expected result */
+            if (!_arb_vec_is_finite(d->coeffs, m))
+            {
+                flint_printf("FAIL (non-finite 2)\n\n");
+                flint_abort();
+            }
+
+            fmpq_poly_truncate(C, m);
+            arb_poly_truncate(d, m);
+
+            if (!arb_poly_contains_fmpq_poly(d, C))
+            {
+                flint_printf("FAIL (non-finite 3)\n\n");
+                flint_abort();
+            }
+        }
+
         fmpq_poly_clear(A);
         fmpq_poly_clear(B);
         fmpq_poly_clear(C);


### PR DESCRIPTION
If some higher coefficients in the input are non-finite it now computes finite values for the lower coefficients in the output instead of setting all coefficients in the output to non-finite values.

I added tests which I think should catch most mistakes I could have made.

This fixes #1372. 

Note that in the issue I say that this also affects `arb_poly_compose` and `acb_poly_compose`, this is not quite true. For those functions the constant term in the inner polynomial is in general non-zero and any non-finite coefficient in the outer polynomial thus gives a fully indeterminate result. The precise behavior for this before the change to use `gr_poly_compose` was dependent on which precise algorithm was used for computing the composition. For this reason I think it is fine to keep the current behavior of returning a fully indeterminate result for any non-finite input for these two functions.