### PR TITLE
Minor optimizations to zeta function for low precision

### DIFF
--- a/src/acb/rising_ui_get_mag.c
+++ b/src/acb/rising_ui_get_mag.c
@@ -30,7 +30,7 @@ acb_rising_get_mag2_right(mag_t bound, const arb_t a, const arb_t b, ulong n)
 
     for (k = 1; k < n; k++)
     {
-        mag_add_ui_2exp_si(u, u, 2 * k - 1, 0);
+        mag_add_ui(u, u, 2 * k - 1);
         mag_add(u, u, t);
         mag_mul(bound, bound, u);
     }

--- a/src/acb_poly/zeta_em_bound.c
+++ b/src/acb_poly/zeta_em_bound.c
@@ -29,9 +29,9 @@ bound_I(arb_ptr I, const arb_t A, const arb_t B, const arb_t C, slong len, slong
     arb_one(L);
 
     /* T = 1 / (A^Bm1 * Bm1) */
-    arb_inv(T, A, wp);
-    arb_pow(T, T, Bm1, wp);
-    arb_div(T, T, Bm1, wp);
+    arb_pow(T, A, Bm1, wp);
+    arb_mul(T, T, Bm1, wp);
+    arb_inv(T, T, wp);
 
     if (len > 1)
     {
@@ -47,11 +47,14 @@ bound_I(arb_ptr I, const arb_t A, const arb_t B, const arb_t C, slong len, slong
         {
             arb_mul_ui(L, L, k, wp);
             arb_add(L, L, Dk, wp);
-            arb_mul(Dk, Dk, D, wp);
+            if (k < len - 1)
+              arb_mul(Dk, Dk, D, wp);
         }
 
         arb_mul(I + k, L, T, wp);
-        arb_div(T, T, Bm1, wp);
+
+        if (k < len - 1)
+          arb_div(T, T, Bm1, wp);
     }
 
     arb_clear(D);


### PR DESCRIPTION
I make heavy use of the zeta function at low precision, say 30-60 bits. At so low precision the computation of the error bounds starts to be a big part of the computing time. When looking through the code I noticed some very minor optimizations. In my benchmark I see around 2% reduced computation time for the zeta function, not really ground breaking but not bad!