### PR TITLE
Wip autotools

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -2,6 +2,6 @@
 
 rm -rf autom4te.cache
 
-autoreconf -i -s -v -Wall
+autoreconf -f -i -s -v -Wall
 
 rm -rf autom4te.cache

--- a/configure.ac
+++ b/configure.ac
@@ -32,6 +32,7 @@ AC_PREREQ(2.59)
 define(FLINT_VERSION,[3.0.0-dev])
 
 AC_INIT(FLINT, FLINT_VERSION, [https://github.com/flintlib/flint2/issues/], flint, [https://flintlib.org/])
+AC_CONFIG_AUX_DIR([config])
 AC_LANG(C)
 
 # Every major version of Flint (1.0, 1.1, 1.2, etc.) gets


### PR DESCRIPTION
The second commit from HEAD apparently solves [issue 1386](https://github.com/flintlib/flint2/issues/1386) by installing install-sh. The HEAD commit cleans things up by adding a subdirectory for downloaded autotools files as discussed there. They are independent of each other.