### PR TITLE
Remove TMPDIR and use Win API on Windows

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -470,9 +470,7 @@ jobs:
       - name: "Configure"
         run: |
           ./bootstrap.sh
-          # We need to specify TMPDIR as we do not have write access to the
-          # CI's /tmp directory.
-          ./configure CC=${CC} CFLAGS="${CFLAGS}" TMPDIR="." ${EXTRA_OPTIONS}
+          ./configure CC=${CC} CFLAGS="${CFLAGS}" ${EXTRA_OPTIONS}
 
       - name: "Compile library"
         run: |

--- a/CMake/cmake_config.h.in
+++ b/CMake/cmake_config.h.in
@@ -18,8 +18,6 @@
 
 #cmakedefine01 FLINT_USES_FENV
 
-#define FLINT_TMPDIR "@FLINT_TMPDIR@"
-
 #ifdef _MSC_VER
 #define access _access
 #define strcasecmp _stricmp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -54,13 +54,6 @@ if(CMAKE_BUILD_TYPE STREQUAL Debug)
   set(FLINT_WANT_ASSERT ON)
 endif()
 
-# temporary directory
-if(NOT DEFINED TMPDIR)
-    set(FLINT_TMPDIR "/tmp" CACHE STRING "Path to a directory meant for temporary files for host system. Only relevant if host do not have read and write access to /tmp [default=/tmp].")
-else()
-    set(FLINT_TMPDIR "${TMPDIR}" CACHE STRING "Path to a directory meant for temporary files for host system. Only relevant if host do not have read and write access to /tmp [default=/tmp].")
-endif()
-
 # pthread configuration
 
 if(MSVC)

--- a/configure.ac
+++ b/configure.ac
@@ -475,15 +475,6 @@ AC_ARG_VAR(ABI, [Desired ABI])
 
 AC_ARG_VAR(LDCONFIG, [ldconfig tool])
 
-AC_ARG_VAR(TMPDIR, [Specify directory meant for temporary files for host system. Only relevant if host do not have read and write access to /tmp [default=/tmp].])
-
-if test -z "$TMPDIR";
-then
-    TMPDIR="/tmp"
-fi
-
-AC_DEFINE_UNQUOTED([FLINT_TMPDIR], ["$TMPDIR"], [Define to set the default directory for temporary files])
-
 ################################################################################
 # check programs and system
 ################################################################################

--- a/src/qsieve/factor.c
+++ b/src/qsieve/factor.c
@@ -489,9 +489,6 @@ cleanup:
     if (qs_inf->siqs != NULL && fclose((FILE *) qs_inf->siqs))
         flint_throw(FLINT_ERROR, "fclose fail\n");
     if (remove(qs_inf->fname)) {
-        perror("qsieve/factor.c: remove failed. perror says");
-        printf("qs_inf->fname is %s\n", qs_inf->fname);
-        printf("qs_inf->siqs != NULL is %d\n", qs_inf->siqs != NULL);
         flint_throw(FLINT_ERROR, "remove fail\n");
     }
     qsieve_clear(qs_inf);

--- a/src/qsieve/factor.c
+++ b/src/qsieve/factor.c
@@ -487,8 +487,12 @@ cleanup:
     flint_free(sieve);
     if (qs_inf->siqs != NULL && fclose((FILE *) qs_inf->siqs))
         flint_throw(FLINT_ERROR, "fclose fail\n");
-    if (remove(qs_inf->fname))
+    if (remove(qs_inf->fname)) {
+        perror("qsieve/factor.c: remove failed. perror says");
+        printf("qs_inf->fname is %s\n", qs_inf->fname);
+        printf("qs_inf->siqs != NULL is %d\n", qs_inf->siqs != NULL);
         flint_throw(FLINT_ERROR, "remove fail\n");
+    }
     qsieve_clear(qs_inf);
     qsieve_linalg_clear(qs_inf);
     qsieve_poly_clear(qs_inf);

--- a/src/qsieve/factor.c
+++ b/src/qsieve/factor.c
@@ -220,7 +220,8 @@ void qsieve_factor(fmpz_factor_t factors, const fmpz_t n)
         flint_printf("Exception (qsieve_factor). GetTempPathA() failed.\n");
         flint_abort();
     }
-    if (GetTempFileNameA(temp_path, "siqs", /*uUnique*/ TRUE, qs_inf->fname) == 0)
+    /* uUnique = 0 means the we *do* want a unique filename (obviously!). */
+    if (GetTempFileNameA(temp_path, "siq", /*uUnique*/ 0, qs_inf->fname) == 0)
     {
         flint_printf("Exception (qsieve_factor). GetTempFileNameA() failed.\n");
         flint_abort();

--- a/src/qsieve/init.c
+++ b/src/qsieve/init.c
@@ -13,10 +13,8 @@
 #include "fmpz.h"
 #include "qsieve.h"
 
-#if (defined(__WIN32) && !defined(__CYGWIN__) && !defined(__MINGW32__) && !defined(__MINGW64__)) || defined(_MSC_VER)
-# ifndef MAX_PATH
-#  define MAX_PATH 260
-# endif
+#if (defined(__WIN32) && !defined(__CYGWIN__)) || defined(_MSC_VER)
+#include <windows.h>
 #endif
 
 void qsieve_init(qs_t qs_inf, const fmpz_t n)
@@ -24,10 +22,10 @@ void qsieve_init(qs_t qs_inf, const fmpz_t n)
     size_t fname_alloc_size;
     slong i;
 
-#if (defined(__WIN32) && !defined(__CYGWIN__) && !defined(__MINGW32__) && !defined(__MINGW64__)) || defined(_MSC_VER)
+#if (defined(__WIN32) && !defined(__CYGWIN__)) || defined(_MSC_VER)
     fname_alloc_size = MAX_PATH;
 #else
-    fname_alloc_size = sizeof(FLINT_TMPDIR "/siqsXXXXXX");
+    fname_alloc_size = 20;
 #endif
     qs_inf->fname = (char *) flint_malloc(fname_alloc_size); /* space for filename */
 

--- a/src/qsieve/large_prime_variant.c
+++ b/src/qsieve/large_prime_variant.c
@@ -503,7 +503,11 @@ int qsieve_process_relation(qs_t qs_inf)
     relation_t * rlist;
     int done = 0;
 
+    if (qs_inf->siqs != NULL && fclose((FILE *) qs_inf->siqs))
+        flint_throw(FLINT_ERROR, "fclose fail\n");
     qs_inf->siqs = (FLINT_FILE *) fopen(qs_inf->fname, "r");
+    if (qs_inf->siqs == NULL)
+        flint_throw(FLINT_ERROR, "fopen fail\n");
 
 #if QS_DEBUG & 64
     printf("Getting relations\n");
@@ -528,7 +532,9 @@ int qsieve_process_relation(qs_t qs_inf)
         }
     }
 
-    fclose((FILE *) qs_inf->siqs);
+    if(fclose((FILE *) qs_inf->siqs))
+        flint_throw(FLINT_ERROR, "fclose fail\n");
+    qs_inf->siqs = NULL;
 
 #if QS_DEBUG & 64
     printf("Removing duplicates\n");
@@ -581,7 +587,11 @@ int qsieve_process_relation(qs_t qs_inf)
     {
        qs_inf->edges -= 100;
        done = 0;
+       if (qs_inf->siqs != NULL && fclose((FILE *) qs_inf->siqs))
+           flint_throw(FLINT_ERROR, "fclose fail\n");
        qs_inf->siqs = (FLINT_FILE *) fopen(qs_inf->fname, "a");
+       if (qs_inf->siqs == NULL)
+           flint_throw(FLINT_ERROR, "fopen fail\n");
     } else
     {
        done = 1;


### PR DESCRIPTION
See https://github.com/flintlib/flint2/issues/1206#issuecomment-1666558134

I am hoping that this will expose a CI failure on MinGW because there is a MinGW bug that currently does not show up in CI.

I have not yet tested it locally with MinGW (it takes a long time to test that with the Windows machine that I have available).