### PR TITLE
Fix memory leak in `fmpz_mod_poly_inv_series`

### DIFF
--- a/src/fmpz_mod_poly/inv_series.c
+++ b/src/fmpz_mod_poly/inv_series.c
@@ -46,6 +46,7 @@ void fmpz_mod_poly_inv_series(fmpz_mod_poly_t g, const fmpz_mod_poly_t h, slong 
         _fmpz_mod_poly_set_length(t, n);
         _fmpz_mod_poly_normalise(t);
         fmpz_mod_poly_swap(g, t, ctx);
+        fmpz_mod_poly_clear(t, ctx);
     }
     else
     {


### PR DESCRIPTION
Clear the old object, just like it is done in the other `inv_series.c` files.

- Fixes https://github.com/flintlib/flint2/issues/1419