### PR TITLE
Fix some memory leaks in tests

### DIFF
--- a/src/acb_poly/test/t-inv_series.c
+++ b/src/acb_poly/test/t-inv_series.c
@@ -117,6 +117,7 @@ int main(void)
         acb_poly_clear(a);
         acb_poly_clear(b);
         acb_poly_clear(ab);
+        fmpq_poly_clear(id);
     }
 
     flint_randclear(state);

--- a/src/acb_poly/test/t-zeta_em_tail_bsplit.c
+++ b/src/acb_poly/test/t-zeta_em_tail_bsplit.c
@@ -63,6 +63,7 @@ int main(void)
 
         acb_clear(Na);
         acb_clear(s);
+        _acb_vec_clear(Nasx, len);
         _acb_vec_clear(z1, len);
         _acb_vec_clear(z2, len);
     }

--- a/src/aprcl/test/t-unity_zp_reduce_cyclotomic.c
+++ b/src/aprcl/test/t-unity_zp_reduce_cyclotomic.c
@@ -83,6 +83,7 @@ int main(void)
         unity_zp_clear(g);
     }
 
+    fmpz_mod_ctx_clear(ctx);
     FLINT_TEST_CLEANUP(state);
 
     flint_printf("PASS\n");

--- a/src/bernoulli/test/t-rev.c
+++ b/src/bernoulli/test/t-rev.c
@@ -89,6 +89,8 @@ int main(void)
         fmpz_clear(denom);
     }
 
+    nmod_poly_clear(A);
+
     flint_randclear(state);
     flint_cleanup();
     flint_printf("PASS\n");

--- a/src/fmpz/test/t-xgcd_canonical_bezout.c
+++ b/src/fmpz/test/t-xgcd_canonical_bezout.c
@@ -544,6 +544,7 @@ main(void)
         fmpz_clear(G);
     }
 
+    fmpz_clear(maxval);
     fmpz_clear(nd);
     fmpz_clear(na);
     fmpz_clear(nb);

--- a/src/fq_nmod/test/t-mul_si.c
+++ b/src/fq_nmod/test/t-mul_si.c
@@ -50,6 +50,8 @@ main(void)
             }
         }
 
+        fq_nmod_clear(rop, ctx);
+
         fq_nmod_ctx_clear(ctx);
         fmpz_clear(p);
         fmpz_clear(f);

--- a/src/fq_templates/test/t-sqrt.c
+++ b/src/fq_templates/test/t-sqrt.c
@@ -113,6 +113,7 @@ main(void)
             TEMPLATE(T, clear)(b, ctx);
             TEMPLATE(T, clear)(c, ctx);
             TEMPLATE(T, clear)(d, ctx);
+            TEMPLATE(T, clear)(x, ctx);
         }
 
         TEMPLATE(T, ctx_clear)(ctx);

--- a/src/gr_mat/test/t-inv.c
+++ b/src/gr_mat/test/t-inv.c
@@ -93,6 +93,7 @@ int main(void)
 
         gr_mat_clear(A, ctx);
         gr_mat_clear(B, ctx);
+        gr_mat_clear(AB, ctx);
 
         gr_ctx_clear(ctx);
     }


### PR DESCRIPTION
This fixes some memory leaks in tests which were relatively easy to track down. This is not really important by itself (and it doesn't affect user code), but it will allow focusing on the more interesting leaks.

Maybe in the future CI could check for leaks (though it may have a big resource cost).