### PR TITLE
quotes around path

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -12,7 +12,7 @@
 FLINT_DIR:=.
 SRC_DIR:=src
 BUILD_DIR:=build
-ABS_FLINT_DIR:=$(patsubst %/,%, $(dir $(abspath $(lastword $(MAKEFILE_LIST)))))
+ABS_FLINT_DIR:='$(patsubst %/,%, $(dir $(abspath $(lastword $(MAKEFILE_LIST)))))'
 ABS_SRC_DIR:=$(ABS_FLINT_DIR)/$(SRC_DIR)
 ABS_BUILD_DIR:=$(ABS_FLINT_DIR)/$(SRC_DIR)
 


### PR DESCRIPTION
before
```
$ make print-ABS_FLINT_DIR
ABS_FLINT_DIR=/I like spaces/flint2
```
after
```
$ make print-ABS_FLINT_DIR 
ABS_FLINT_DIR='/I like spaces/flint2'
```

without this, `make examples` fails